### PR TITLE
feat: add cheese doctor command and bundle tilth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,12 @@
       "dependencies": {
         "commander": "^14.0.3",
         "eta": "^4.5.1",
+        "tilth": "^0.6.3",
         "yaml": "^2.8.3",
         "zod": "^4.3.6"
       },
       "bin": {
-        "cheese-flow": "dist/index.js"
+        "cheese": "dist/index.js"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.12",
@@ -2020,6 +2021,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tilth": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/tilth/-/tilth-0.6.3.tgz",
+      "integrity": "sha512-m3dF0tmdrC1WQf22JF45B/2kTHUw/sPaxocu6c2QyLox9EmnxyPg/XeYEO9E8wL29V76ghzQpp+zIWN6ohYb0w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "tilth": "run.js"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "private": true,
   "bin": {
-    "cheese-flow": "./dist/index.js"
+    "cheese": "./dist/index.js"
   },
   "files": [
     "dist",
@@ -49,6 +49,7 @@
   "dependencies": {
     "commander": "^14.0.3",
     "eta": "^4.5.1",
+    "tilth": "^0.6.3",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Command, InvalidArgumentError } from "commander";
 import { installHarnessArtifacts } from "./lib/compiler.js";
+import {
+  formatReport,
+  hasBlockingFailure,
+  runAllToolChecks,
+} from "./lib/doctor.js";
 import { type HarnessName, harnessDefinitions } from "./lib/harnesses.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -24,7 +29,7 @@ function parseHarness(value: string): HarnessName {
 const program = new Command();
 
 program
-  .name("cheese-flow")
+  .name("cheese")
   .description(
     "Compile portable agents and Agent Skills into harness-specific markdown bundles.",
   )
@@ -64,6 +69,19 @@ program
 
     for (const output of outputs) {
       process.stdout.write(`Compiled harness bundle: ${output}\n`);
+    }
+  });
+
+program
+  .command("doctor")
+  .description(
+    "Verify required, recommended, and suggested CLI tools are installed.",
+  )
+  .action(async () => {
+    const results = await runAllToolChecks();
+    process.stdout.write(formatReport(results));
+    if (hasBlockingFailure(results)) {
+      process.exitCode = 1;
     }
   });
 

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -1,0 +1,105 @@
+import { spawn } from "node:child_process";
+
+export type ToolTier = "required" | "recommended" | "suggested";
+
+export type ToolCheck = {
+  name: string;
+  tier: ToolTier;
+  purpose: string;
+  installHint: string;
+};
+
+export type ToolResult = ToolCheck & {
+  ok: boolean;
+  version?: string;
+  error?: string;
+};
+
+export const toolChecks: ToolCheck[] = [
+  {
+    name: "tilth",
+    tier: "required",
+    purpose: "Tree-sitter code intelligence used by exploration skills.",
+    installHint:
+      "Bundled with cheese-flow. If missing, install globally: npm install -g cheese-flow",
+  },
+  {
+    name: "mergiraf",
+    tier: "recommended",
+    purpose: "Syntax-aware merge driver for resolving conflicts cleanly.",
+    installHint: "brew install mergiraf  (or: cargo install mergiraf)",
+  },
+  {
+    name: "rtk",
+    tier: "suggested",
+    purpose: "Token-optimized CLI proxy for Claude Code sessions.",
+    installHint: "cargo install rtk-cli",
+  },
+];
+
+export async function runToolCheck(check: ToolCheck): Promise<ToolResult> {
+  return new Promise<ToolResult>((resolve) => {
+    const child = spawn(check.name, ["--version"], { stdio: "pipe" });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (error: Error) => {
+      resolve({ ...check, ok: false, error: error.message });
+    });
+    child.on("close", (code: number | null) => {
+      if (code === 0) {
+        const version = (stdout || stderr).trim().split("\n")[0] ?? "";
+        resolve(
+          version.length > 0
+            ? { ...check, ok: true, version }
+            : { ...check, ok: true },
+        );
+      } else {
+        resolve({
+          ...check,
+          ok: false,
+          error: `exited with code ${code ?? "unknown"}`,
+        });
+      }
+    });
+  });
+}
+
+export async function runAllToolChecks(): Promise<ToolResult[]> {
+  return Promise.all(toolChecks.map(runToolCheck));
+}
+
+const tierLabels: Record<ToolTier, string> = {
+  required: "REQUIRED",
+  recommended: "RECOMMENDED",
+  suggested: "SUGGESTED",
+};
+
+export function formatReport(results: ToolResult[]): string {
+  const lines: string[] = ["cheese doctor — tool dependency check", ""];
+
+  for (const result of results) {
+    const status = result.ok ? "ok" : "missing";
+    const tag = tierLabels[result.tier];
+    lines.push(`[${tag}] ${result.name}: ${status}`);
+    lines.push(`  ${result.purpose}`);
+    if (result.ok && result.version) {
+      lines.push(`  found: ${result.version}`);
+    } else {
+      lines.push(`  install: ${result.installHint}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+export function hasBlockingFailure(results: ToolResult[]): boolean {
+  return results.some((result) => result.tier === "required" && !result.ok);
+}

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -1,6 +1,26 @@
 import { spawn } from "node:child_process";
+import { delimiter, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 export type ToolTier = "required" | "recommended" | "suggested";
+
+const bundledBinDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "node_modules",
+  ".bin",
+);
+
+function spawnEnv(): NodeJS.ProcessEnv {
+  const existingPath = process.env.PATH ?? "";
+  return {
+    ...process.env,
+    PATH: existingPath
+      ? `${bundledBinDir}${delimiter}${existingPath}`
+      : bundledBinDir,
+  };
+}
 
 export type ToolCheck = {
   name: string;
@@ -39,7 +59,10 @@ export const toolChecks: ToolCheck[] = [
 
 export async function runToolCheck(check: ToolCheck): Promise<ToolResult> {
   return new Promise<ToolResult>((resolve) => {
-    const child = spawn(check.name, ["--version"], { stdio: "pipe" });
+    const child = spawn(check.name, ["--version"], {
+      stdio: "pipe",
+      env: spawnEnv(),
+    });
     let stdout = "";
     let stderr = "";
 

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -91,6 +91,8 @@ export function formatReport(results: ToolResult[]): string {
     lines.push(`  ${result.purpose}`);
     if (result.ok && result.version) {
       lines.push(`  found: ${result.version}`);
+    } else if (result.ok) {
+      lines.push(`  found`);
     } else {
       lines.push(`  install: ${result.installHint}`);
     }


### PR DESCRIPTION
## Summary
- Rename CLI bin from `cheese-flow` to `cheese` (clean break, no alias)
- Bundle `tilth` as a runtime dependency so its platform binary is fetched via postinstall
- Add `cheese doctor` subcommand with tiered tool checks: REQUIRED (tilth), RECOMMENDED (mergiraf), SUGGESTED (rtk) — exits non-zero only when a required tool is missing

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes (9/9)
- [ ] `cheese doctor` renders all three tiers and reports installed versions