### PR TITLE
fix: handle signal in milknado close handler

### DIFF
--- a/src/lib/milknado.ts
+++ b/src/lib/milknado.ts
@@ -14,9 +14,14 @@ type OutputReader = {
 export type SpawnedProcess = {
   stdout: OutputReader;
   stderr: OutputReader;
-  on(event: "close", listener: (code: number | null) => void): unknown;
+  on(
+    event: "close",
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): unknown;
   on(event: "error", listener: (error: unknown) => void): unknown;
 };
+
+const userCancelSignals = new Set<NodeJS.Signals>(["SIGINT", "SIGTERM"]);
 
 export type SpawnFn = (
   file: string,
@@ -105,18 +110,22 @@ async function waitForExit(child: SpawnedProcess): Promise<void> {
       });
     });
 
-    child.on("close", (code: number | null) => {
+    child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
       settle(() => {
         if (code === 0) {
           resolve();
           return;
         }
 
-        reject(
-          new Error(
-            `milknado backend failed via uv with exit code ${code ?? "unknown"}.`,
-          ),
-        );
+        if (signal && userCancelSignals.has(signal)) {
+          reject(new Error(`milknado run cancelled by ${signal}.`));
+          return;
+        }
+
+        const detail = signal
+          ? `signal ${signal}`
+          : `exit code ${code ?? "unknown"}`;
+        reject(new Error(`milknado backend failed via uv with ${detail}.`));
       });
     });
   });

--- a/tests/milknado.test.ts
+++ b/tests/milknado.test.ts
@@ -133,10 +133,52 @@ describe("milknado helpers", () => {
       spawnFn: vi.fn<SpawnFn>().mockReturnValue(child),
     });
 
-    child.emit("close", null);
+    child.emit("close", null, null);
 
     await expect(runPromise).rejects.toThrow(
       /milknado backend failed via uv with exit code unknown\./u,
+    );
+  });
+
+  it("reports the terminating signal when the process is killed", async () => {
+    const child = createMockChildProcess();
+    const runPromise = runMilknadoCommand({
+      projectRoot: path.resolve(path.sep, "tmp", "cheese-flow"),
+      spawnFn: vi.fn<SpawnFn>().mockReturnValue(child),
+    });
+
+    child.emit("close", null, "SIGKILL");
+
+    await expect(runPromise).rejects.toThrow(
+      /milknado backend failed via uv with signal SIGKILL\./u,
+    );
+  });
+
+  it("treats SIGINT as a user-cancelled run", async () => {
+    const child = createMockChildProcess();
+    const runPromise = runMilknadoCommand({
+      projectRoot: path.resolve(path.sep, "tmp", "cheese-flow"),
+      spawnFn: vi.fn<SpawnFn>().mockReturnValue(child),
+    });
+
+    child.emit("close", null, "SIGINT");
+
+    await expect(runPromise).rejects.toThrow(
+      /milknado run cancelled by SIGINT\./u,
+    );
+  });
+
+  it("treats SIGTERM as a user-cancelled run", async () => {
+    const child = createMockChildProcess();
+    const runPromise = runMilknadoCommand({
+      projectRoot: path.resolve(path.sep, "tmp", "cheese-flow"),
+      spawnFn: vi.fn<SpawnFn>().mockReturnValue(child),
+    });
+
+    child.emit("close", null, "SIGTERM");
+
+    await expect(runPromise).rejects.toThrow(
+      /milknado run cancelled by SIGTERM\./u,
     );
   });
 


### PR DESCRIPTION
## Summary
- Widen `SpawnedProcess.on('close')` listener type to `(code, signal)` matching Node's actual signature.
- Treat `SIGINT`/`SIGTERM` as user-cancelled runs (`milknado run cancelled by <signal>.`); report other signals as `failed via uv with signal <name>.` instead of losing the signal.
- Null code + null signal still reports `exit code unknown` (unchanged).

## Test plan
- [x] Added SIGKILL / SIGINT / SIGTERM coverage in `tests/milknado.test.ts` (12/12 passing)
- [x] Lint + build clean