### PR TITLE
feat(build): integrate ruff for Python format and lint-fix

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,6 +8,8 @@ build:
     npm run typecheck
     npm run build
     rtk test npm run test:coverage
+    uv run --group dev ruff format
+    uv run --group dev ruff check --fix
     uv run --group dev pytest
 
 build-ci:
@@ -18,6 +20,8 @@ build-ci:
     npm run typecheck
     npm run build
     npm run test:coverage
+    uv run --group dev ruff format --check
+    uv run --group dev ruff check
     uv run --group dev pytest
 
 test-py:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 [dependency-groups]
 dev = [
   "pytest==9.0.3",
+  "ruff==0.14.5",
 ]
 
 [build-system]
@@ -26,3 +27,11 @@ package = false
 testpaths = ["tests/python"]
 pythonpath = ["python"]
 addopts = "-q"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+extend-exclude = ["dist", ".claude", ".codex"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]

--- a/python/mcp_server.py
+++ b/python/mcp_server.py
@@ -8,7 +8,6 @@ avoids a fresh ``uv run`` cold-start.
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
-
 from milknado import solve_blend_plan
 
 mcp = FastMCP("cheese-flow")

--- a/skills/merge-resolve/scripts/batch-resolve.py
+++ b/skills/merge-resolve/scripts/batch-resolve.py
@@ -16,8 +16,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from git_utils import (
-    get_conflicted_files,
     extract_stages,
+    get_conflicted_files,
     is_mergiraf_supported,
     run_git,
 )
@@ -61,8 +61,15 @@ def resolve_file(path: str, dry_run: bool = True, verbose: bool = False) -> dict
         Path(theirs_path).write_text(theirs)
 
         cmd = [
-            "mergiraf", "merge", base_path, ours_path, theirs_path,
-            "-o", merged_path, "-p", path,
+            "mergiraf",
+            "merge",
+            base_path,
+            ours_path,
+            theirs_path,
+            "-o",
+            merged_path,
+            "-p",
+            path,
         ]
 
         if verbose:
@@ -147,8 +154,12 @@ def format_verbose(results: list, dry_run: bool) -> str:
 
 def main():
     parser = argparse.ArgumentParser(description="Batch resolve conflicts using mergiraf.")
-    parser.add_argument("--apply", action="store_true", help="Apply resolutions (default is dry-run).")
-    parser.add_argument("--verbose", action="store_true", help="Markdown-formatted output and mergiraf debug logs.")
+    parser.add_argument(
+        "--apply", action="store_true", help="Apply resolutions (default is dry-run)."
+    )
+    parser.add_argument(
+        "--verbose", action="store_true", help="Markdown-formatted output and mergiraf debug logs."
+    )
     parser.add_argument("files", nargs="*", help="Specific files (default: all conflicted files).")
 
     args = parser.parse_args()

--- a/skills/merge-resolve/scripts/conflict-pick.py
+++ b/skills/merge-resolve/scripts/conflict-pick.py
@@ -8,7 +8,6 @@ import argparse
 import re
 import sys
 from pathlib import Path
-from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
 
@@ -20,17 +19,17 @@ def _resolve_conflict_block(
     ours_lines: list[str],
     theirs_lines: list[str],
     strategy: str,
-    grep_pattern: Optional[str],
+    grep_pattern: str | None,
 ) -> list[str]:
     if grep_pattern and not re.search(grep_pattern, "\n".join(conflict_text)):
         return conflict_text
     return ours_lines if strategy == "ours" else theirs_lines
 
 
-def resolve_hunks(content: str, strategy: str, grep_pattern: Optional[str] = None) -> str:
+def resolve_hunks(content: str, strategy: str, grep_pattern: str | None = None) -> str:
     result: list[str] = []
     in_conflict = False
-    current_section: Optional[str] = None
+    current_section: str | None = None
     ours_lines: list[str] = []
     theirs_lines: list[str] = []
     conflict_text: list[str] = []
@@ -52,9 +51,11 @@ def resolve_hunks(content: str, strategy: str, grep_pattern: Optional[str] = Non
         elif line.startswith("======="):
             current_section = "theirs"
         elif line.startswith(">>>>>>>"):
-            result.extend(_resolve_conflict_block(
-                conflict_text, ours_lines, theirs_lines, strategy, grep_pattern
-            ))
+            result.extend(
+                _resolve_conflict_block(
+                    conflict_text, ours_lines, theirs_lines, strategy, grep_pattern
+                )
+            )
             in_conflict = False
             current_section = None
         elif current_section == "ours":
@@ -73,9 +74,13 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Pick ours or theirs for conflict hunks")
     parser.add_argument("file", help="File to resolve")
     parser.add_argument("--ours", action="store_true", help="Take our changes for matching hunks")
-    parser.add_argument("--theirs", action="store_true", help="Take their changes for matching hunks")
+    parser.add_argument(
+        "--theirs", action="store_true", help="Take their changes for matching hunks"
+    )
     parser.add_argument("--grep", metavar="PATTERN", help="Only resolve hunks matching this regex")
-    parser.add_argument("--dry-run", action="store_true", help="Print resolved content without writing")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print resolved content without writing"
+    )
     return parser.parse_args()
 
 

--- a/skills/merge-resolve/scripts/conflict-summary.py
+++ b/skills/merge-resolve/scripts/conflict-summary.py
@@ -15,10 +15,10 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from git_utils import (
     get_conflicted_files,
+    get_file_extension,
+    get_surrounding_context,
     is_mergiraf_supported,
     parse_conflict_hunks,
-    get_surrounding_context,
-    get_file_extension,
 )
 
 _OURS_CAP = 5
@@ -113,7 +113,8 @@ def format_terse_output(summaries: list) -> str:
             continue
         mergiraf = "y" if s["mergiraf_supported"] else "n"
         lines.append(
-            f"{s['path']} hunks={s['hunk_count']} ext={s['extension']} mergiraf={mergiraf} rec={s['recommendation']}"
+            f"{s['path']} hunks={s['hunk_count']} ext={s['extension']} "
+            f"mergiraf={mergiraf} rec={s['recommendation']}"
         )
         for hunk in s["hunks"]:
             lines.extend(_render_hunk_terse(hunk))
@@ -164,7 +165,8 @@ def format_verbose_output(summaries: list) -> str:
         status = "supported" if summary["mergiraf_supported"] else "not supported"
         lines.append(f"## {summary['path']}")
         lines.append(
-            f"Extension: .{summary['extension']} | Mergiraf: {status} | Hunks: {summary['hunk_count']}"
+            f"Extension: .{summary['extension']} | Mergiraf: {status} | "
+            f"Hunks: {summary['hunk_count']}"
         )
         lines.append("")
 
@@ -190,9 +192,7 @@ def main():
     parser.add_argument(
         "--context", type=int, default=3, help="Lines of context to show (default: 3)."
     )
-    parser.add_argument(
-        "files", nargs="*", help="Specific files (default: all conflicted files)."
-    )
+    parser.add_argument("files", nargs="*", help="Specific files (default: all conflicted files).")
 
     args = parser.parse_args()
 

--- a/skills/merge-resolve/scripts/git_utils.py
+++ b/skills/merge-resolve/scripts/git_utils.py
@@ -3,10 +3,9 @@
 
 import subprocess
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 
-def run_git(args: List[str], capture_output: bool = True) -> subprocess.CompletedProcess:
+def run_git(args: list[str], capture_output: bool = True) -> subprocess.CompletedProcess:
     return subprocess.run(
         ["git"] + args,
         capture_output=capture_output,
@@ -14,7 +13,7 @@ def run_git(args: List[str], capture_output: bool = True) -> subprocess.Complete
     )
 
 
-def get_conflicted_files() -> List[str]:
+def get_conflicted_files() -> list[str]:
     result = run_git(["diff", "--name-only", "--diff-filter=U"])
     if result.returncode != 0:
         return []
@@ -29,7 +28,7 @@ def has_conflict_markers(path: str) -> bool:
         return False
 
 
-def extract_stages(path: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+def extract_stages(path: str) -> tuple[str | None, str | None, str | None]:
     """Returns (base, ours, theirs) from git stage slots; None for any unavailable stage."""
     base = ours = theirs = None
 
@@ -59,14 +58,32 @@ def is_mergiraf_supported(path: str) -> bool:
     ext = get_file_extension(path)
     # Languages supported by mergiraf (Tree-sitter based)
     supported_extensions = {
-        "rs", "go", "py", "ts", "tsx", "js", "jsx", "java", "scala",
-        "c", "cc", "cpp", "cxx", "h", "hpp", "hxx",
-        "rb", "php", "cs", "swift", "md"
+        "rs",
+        "go",
+        "py",
+        "ts",
+        "tsx",
+        "js",
+        "jsx",
+        "java",
+        "scala",
+        "c",
+        "cc",
+        "cpp",
+        "cxx",
+        "h",
+        "hpp",
+        "hxx",
+        "rb",
+        "php",
+        "cs",
+        "swift",
+        "md",
     }
     return ext.lower() in supported_extensions
 
 
-def parse_conflict_hunks(content: str) -> List[dict]:
+def parse_conflict_hunks(content: str) -> list[dict]:
     """Handles both diff3 (with ||||||| base) and standard (without base) conflict markers."""
     lines = content.split("\n")
     hunks = []
@@ -101,8 +118,9 @@ def parse_conflict_hunks(content: str) -> List[dict]:
     return hunks
 
 
-def get_surrounding_context(content: str, start_line: int, end_line: int,
-                            context_lines: int = 3) -> Tuple[List[str], List[str]]:
+def get_surrounding_context(
+    content: str, start_line: int, end_line: int, context_lines: int = 3
+) -> tuple[list[str], list[str]]:
     lines = content.split("\n")
 
     # Before context (avoiding conflict markers)
@@ -111,19 +129,19 @@ def get_surrounding_context(content: str, start_line: int, end_line: int,
     for i in range(before_start, start_line - 1):
         line = lines[i]
         if not any(marker in line for marker in ["<<<<<<", "======", ">>>>>>", "||||||"]):
-            before.append(f"{i+1}: {line}")
+            before.append(f"{i + 1}: {line}")
 
     after_end = min(len(lines), end_line + context_lines)
     after = []
     for i in range(end_line, after_end):
         line = lines[i]
         if not any(marker in line for marker in ["<<<<<<", "======", ">>>>>>", "||||||"]):
-            after.append(f"{i+1}: {line}")
+            after.append(f"{i + 1}: {line}")
 
     return before, after
 
 
-def detect_lockfile_type(path: str) -> Optional[str]:
+def detect_lockfile_type(path: str) -> str | None:
     filename = Path(path).name.lower()
 
     lockfile_map = {

--- a/skills/merge-resolve/scripts/lockfile-resolve.py
+++ b/skills/merge-resolve/scripts/lockfile-resolve.py
@@ -13,11 +13,10 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from git_utils import (
-    get_conflicted_files,
     detect_lockfile_type,
+    get_conflicted_files,
     run_git,
 )
-
 
 # Map lockfile types to regeneration commands and manifest files
 LOCKFILE_CONFIG = {
@@ -79,24 +78,26 @@ def resolve_lockfile(
         "resolved": False,
         "message": "",
     }
-    
+
     lockfile_type = detect_lockfile_type(lockfile_path)
     if not lockfile_type:
         result["message"] = "Unknown lockfile type"
         return result
-    
+
     config = LOCKFILE_CONFIG.get(lockfile_type)
     if not config:
         result["message"] = f"No config for lockfile type: {lockfile_type}"
         return result
-    
+
     manifest_path = Path(lockfile_path).parent / config["manifest"]
     if not manifest_path.exists():
         result["message"] = f"Manifest not found: {manifest_path}"
         return result
 
     if "<<<<<<<" in manifest_path.read_text():
-        result["message"] = f"Manifest {manifest_path} has conflict markers — resolve it before regenerating"
+        result["message"] = (
+            f"Manifest {manifest_path} has conflict markers — resolve it before regenerating"
+        )
         return result
 
     if dry_run:
@@ -134,7 +135,9 @@ def resolve_lockfile(
         if go_mod.exists():
             add_mod_result = run_git(["add", str(go_mod)])
             if add_mod_result.returncode != 0:
-                result["message"] = f"regenerated but staging go.mod failed: {add_mod_result.stderr.strip()}"
+                result["message"] = (
+                    f"regenerated but staging go.mod failed: {add_mod_result.stderr.strip()}"
+                )
                 return result
 
     result["resolved"] = True

--- a/tests/python/test_batch_resolve.py
+++ b/tests/python/test_batch_resolve.py
@@ -13,8 +13,12 @@ from types import ModuleType
 from unittest.mock import patch
 
 
-def make_completed(stdout: str = "", returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
-    return subprocess.CompletedProcess(args=["x"], returncode=returncode, stdout=stdout, stderr=stderr)
+def make_completed(
+    stdout: str = "", returncode: int = 0, stderr: str = ""
+) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=["x"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
 
 
 def _merged_path(cmd: list[str]) -> str:
@@ -41,9 +45,11 @@ class TestResolveFile:
             Path(_merged_path(cmd)).write_text("clean-merged-output\n")
             return make_completed()
 
-        with patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")), \
-             patch.object(batch_resolve.subprocess, "run", side_effect=fake_run), \
-             patch.object(batch_resolve, "run_git") as git_mock:
+        with (
+            patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")),
+            patch.object(batch_resolve.subprocess, "run", side_effect=fake_run),
+            patch.object(batch_resolve, "run_git") as git_mock,
+        ):
             result = batch_resolve.resolve_file("foo.py", dry_run=True)
         assert result["resolved"] is True
         assert result["message"] == "would resolve cleanly"
@@ -57,9 +63,11 @@ class TestResolveFile:
             Path(_merged_path(cmd)).write_text("merged-content\n")
             return make_completed()
 
-        with patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")), \
-             patch.object(batch_resolve.subprocess, "run", side_effect=fake_run), \
-             patch.object(batch_resolve, "run_git", return_value=make_completed()):
+        with (
+            patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")),
+            patch.object(batch_resolve.subprocess, "run", side_effect=fake_run),
+            patch.object(batch_resolve, "run_git", return_value=make_completed()),
+        ):
             result = batch_resolve.resolve_file(str(target), dry_run=False)
 
         assert result["resolved"] is True
@@ -74,9 +82,13 @@ class TestResolveFile:
             Path(_merged_path(cmd)).write_text("merged\n")
             return make_completed()
 
-        with patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")), \
-             patch.object(batch_resolve.subprocess, "run", side_effect=fake_run), \
-             patch.object(batch_resolve, "run_git", return_value=make_completed(returncode=1, stderr="locked")):
+        with (
+            patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")),
+            patch.object(batch_resolve.subprocess, "run", side_effect=fake_run),
+            patch.object(
+                batch_resolve, "run_git", return_value=make_completed(returncode=1, stderr="locked")
+            ),
+        ):
             result = batch_resolve.resolve_file(str(target), dry_run=False)
         assert result["resolved"] is False
         assert "staging failed" in result["message"]
@@ -86,15 +98,23 @@ class TestResolveFile:
             Path(_merged_path(cmd)).write_text("<<<<<<< x\nA\n=======\nB\n>>>>>>> y\n")
             return make_completed()
 
-        with patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")), \
-             patch.object(batch_resolve.subprocess, "run", side_effect=fake_run):
+        with (
+            patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")),
+            patch.object(batch_resolve.subprocess, "run", side_effect=fake_run),
+        ):
             result = batch_resolve.resolve_file("foo.py", dry_run=True)
         assert result["resolved"] is False
         assert "conflicts remain" in result["message"]
 
     def test_mergiraf_command_failure(self, batch_resolve: ModuleType) -> None:
-        with patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")), \
-             patch.object(batch_resolve.subprocess, "run", return_value=make_completed(returncode=2, stderr="boom")):
+        with (
+            patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")),
+            patch.object(
+                batch_resolve.subprocess,
+                "run",
+                return_value=make_completed(returncode=2, stderr="boom"),
+            ),
+        ):
             result = batch_resolve.resolve_file("foo.py", dry_run=True)
         assert result["resolved"] is False
         assert "mergiraf failed" in result["message"]
@@ -108,8 +128,10 @@ class TestResolveFile:
             Path(_merged_path(cmd)).write_text("a\n<<<<<<< ours\nx\n=======\ny\n>>>>>>> theirs\n")
             return make_completed(returncode=1)
 
-        with patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")), \
-             patch.object(batch_resolve.subprocess, "run", side_effect=fake_run):
+        with (
+            patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")),
+            patch.object(batch_resolve.subprocess, "run", side_effect=fake_run),
+        ):
             result = batch_resolve.resolve_file("foo.py", dry_run=True)
         assert result["resolved"] is False
         assert "conflicts remain" in result["message"]
@@ -119,7 +141,12 @@ class TestResolveFile:
 class TestFormatters:
     def test_terse_includes_status_and_summary(self, batch_resolve: ModuleType) -> None:
         results = [
-            {"path": "a.py", "resolved": True, "supported": True, "message": "would resolve cleanly"},
+            {
+                "path": "a.py",
+                "resolved": True,
+                "supported": True,
+                "message": "would resolve cleanly",
+            },
             {"path": "b.py", "resolved": False, "supported": True, "message": "conflicts remain"},
         ]
         out = batch_resolve.format_terse(results, dry_run=True)

--- a/tests/python/test_conflict_pick.py
+++ b/tests/python/test_conflict_pick.py
@@ -28,11 +28,7 @@ class TestResolveHunks:
         assert "A" not in result
 
     def test_resolves_multiple_hunks(self, conflict_pick: ModuleType) -> None:
-        content = (
-            _conflict(["A1"], ["B1"])
-            + "\nmiddle\n"
-            + _conflict(["A2"], ["B2"])
-        )
+        content = _conflict(["A1"], ["B1"]) + "\nmiddle\n" + _conflict(["A2"], ["B2"])
         result = conflict_pick.resolve_hunks(content, strategy="ours")
         assert "A1" in result and "A2" in result
         assert "B1" not in result and "B2" not in result
@@ -76,4 +72,6 @@ class TestResolveHunks:
     def test_no_conflicts_returns_input_unchanged(self, conflict_pick: ModuleType) -> None:
         content = "line1\nline2\nline3\n"
         # resolve_hunks splits and rejoins, so trailing newline normalization is OK.
-        assert conflict_pick.resolve_hunks(content, strategy="ours").rstrip("\n") == content.rstrip("\n")
+        assert conflict_pick.resolve_hunks(content, strategy="ours").rstrip("\n") == content.rstrip(
+            "\n"
+        )

--- a/tests/python/test_conflict_summary.py
+++ b/tests/python/test_conflict_summary.py
@@ -10,14 +10,7 @@ import json
 from pathlib import Path
 from types import ModuleType
 
-
-CONFLICT = (
-    "<<<<<<< HEAD\n"
-    "ours-line\n"
-    "=======\n"
-    "theirs-line\n"
-    ">>>>>>> branch\n"
-)
+CONFLICT = "<<<<<<< HEAD\nours-line\n=======\ntheirs-line\n>>>>>>> branch\n"
 
 
 class TestSummarizeFile:
@@ -73,7 +66,9 @@ class TestFormatTerseOutput:
         first_line = out.splitlines()[0]
         assert first_line == "# legend: +ours |base -theirs"
 
-    def test_recommendation_uses_no_dry_run_flag(self, conflict_summary: ModuleType, tmp_path: Path) -> None:
+    def test_recommendation_uses_no_dry_run_flag(
+        self, conflict_summary: ModuleType, tmp_path: Path
+    ) -> None:
         # Regression: --dry-run flag was removed; recommendation must not mention it.
         f = tmp_path / "foo.py"
         f.write_text(CONFLICT)

--- a/tests/python/test_git_utils.py
+++ b/tests/python/test_git_utils.py
@@ -10,7 +10,9 @@ from unittest.mock import patch
 import pytest
 
 
-def make_completed(stdout: str = "", returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
+def make_completed(
+    stdout: str = "", returncode: int = 0, stderr: str = ""
+) -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(
         args=["git"], returncode=returncode, stdout=stdout, stderr=stderr
     )
@@ -71,15 +73,7 @@ class TestParseConflictHunks:
         assert git_utils.parse_conflict_hunks("just some\nplain text\n") == []
 
     def test_single_standard_hunk(self, git_utils: ModuleType) -> None:
-        content = (
-            "before\n"
-            "<<<<<<< HEAD\n"
-            "ours-line\n"
-            "=======\n"
-            "theirs-line\n"
-            ">>>>>>> branch\n"
-            "after\n"
-        )
+        content = "before\n<<<<<<< HEAD\nours-line\n=======\ntheirs-line\n>>>>>>> branch\nafter\n"
         hunks = git_utils.parse_conflict_hunks(content)
         assert len(hunks) == 1
         assert hunks[0]["ours"] == ["ours-line"]
@@ -89,15 +83,7 @@ class TestParseConflictHunks:
         assert hunks[0]["end_line"] == 6
 
     def test_diff3_hunk_captures_base(self, git_utils: ModuleType) -> None:
-        content = (
-            "<<<<<<< HEAD\n"
-            "ours\n"
-            "||||||| merged\n"
-            "base\n"
-            "=======\n"
-            "theirs\n"
-            ">>>>>>> other\n"
-        )
+        content = "<<<<<<< HEAD\nours\n||||||| merged\nbase\n=======\ntheirs\n>>>>>>> other\n"
         hunks = git_utils.parse_conflict_hunks(content)
         assert hunks[0]["base"] == ["base"]
         assert hunks[0]["ours"] == ["ours"]
@@ -118,29 +104,35 @@ class TestParseConflictHunks:
 class TestGetSurroundingContext:
     def test_returns_lines_before_and_after(self, git_utils: ModuleType) -> None:
         content = "\n".join(f"line{i}" for i in range(1, 11))
-        before, after = git_utils.get_surrounding_context(content, start_line=5, end_line=6, context_lines=2)
+        before, after = git_utils.get_surrounding_context(
+            content, start_line=5, end_line=6, context_lines=2
+        )
         assert before == ["3: line3", "4: line4"]
         assert after == ["7: line7", "8: line8"]
 
     def test_skips_conflict_marker_lines(self, git_utils: ModuleType) -> None:
         content = "a\nb\n<<<<<<< HEAD\nc\n=======\nd\n>>>>>>> x\ne\nf\n"
-        before, after = git_utils.get_surrounding_context(content, start_line=3, end_line=7, context_lines=2)
+        before, after = git_utils.get_surrounding_context(
+            content, start_line=3, end_line=7, context_lines=2
+        )
         assert all("<<<<<<" not in line and "======" not in line for line in before + after)
 
     def test_handles_start_at_top(self, git_utils: ModuleType) -> None:
         content = "a\nb\n"
-        before, _after = git_utils.get_surrounding_context(content, start_line=1, end_line=2, context_lines=3)
+        before, _after = git_utils.get_surrounding_context(
+            content, start_line=1, end_line=2, context_lines=3
+        )
         assert before == []
 
 
 class TestRunGit:
     def test_invokes_git_with_args(self, git_utils: ModuleType) -> None:
-        with patch.object(git_utils.subprocess, "run", return_value=make_completed(stdout="ok")) as run_mock:
+        with patch.object(
+            git_utils.subprocess, "run", return_value=make_completed(stdout="ok")
+        ) as run_mock:
             result = git_utils.run_git(["status"])
         assert result.stdout == "ok"
-        run_mock.assert_called_once_with(
-            ["git", "status"], capture_output=True, text=True
-        )
+        run_mock.assert_called_once_with(["git", "status"], capture_output=True, text=True)
 
 
 class TestGetConflictedFiles:

--- a/tests/python/test_lockfile_resolve.py
+++ b/tests/python/test_lockfile_resolve.py
@@ -13,7 +13,9 @@ from types import ModuleType
 from unittest.mock import patch
 
 
-def make_completed(stdout: str = "", returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
+def make_completed(
+    stdout: str = "", returncode: int = 0, stderr: str = ""
+) -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(
         args=["x"], returncode=returncode, stdout=stdout, stderr=stderr
     )
@@ -49,8 +51,10 @@ class TestResolveLockfile:
         self, lockfile_resolve: ModuleType, tmp_path: Path
     ) -> None:
         write_clean_manifest(tmp_path)
-        with patch.object(lockfile_resolve.subprocess, "run") as run_mock, \
-             patch.object(lockfile_resolve, "run_git") as git_mock:
+        with (
+            patch.object(lockfile_resolve.subprocess, "run") as run_mock,
+            patch.object(lockfile_resolve, "run_git") as git_mock,
+        ):
             result = lockfile_resolve.resolve_lockfile(str(tmp_path / "Cargo.lock"), dry_run=True)
         assert result["resolved"] is True
         assert "would take" in result["message"]
@@ -64,8 +68,12 @@ class TestResolveLockfile:
         lockfile = tmp_path / "Cargo.lock"
         lockfile.write_text("<<<<<<< HEAD\nold\n=======\nnew\n>>>>>>> x\n")
 
-        with patch.object(lockfile_resolve, "run_git") as git_mock, \
-             patch.object(lockfile_resolve.subprocess, "run", return_value=make_completed()) as run_mock:
+        with (
+            patch.object(lockfile_resolve, "run_git") as git_mock,
+            patch.object(
+                lockfile_resolve.subprocess, "run", return_value=make_completed()
+            ) as run_mock,
+        ):
             git_mock.side_effect = [
                 make_completed(stdout="theirs-content\n"),  # git show :3:
                 make_completed(),  # git add
@@ -79,9 +87,7 @@ class TestResolveLockfile:
         assert run_mock.call_args.args[0] == ["cargo", "generate-lockfile"]
         assert git_mock.call_args_list[-1].args[0] == ["add", str(lockfile)]
 
-    def test_git_show_failure(
-        self, lockfile_resolve: ModuleType, tmp_path: Path
-    ) -> None:
+    def test_git_show_failure(self, lockfile_resolve: ModuleType, tmp_path: Path) -> None:
         write_clean_manifest(tmp_path)
         lockfile = tmp_path / "Cargo.lock"
         lockfile.write_text("doesnt matter")
@@ -97,8 +103,14 @@ class TestResolveLockfile:
         lockfile = tmp_path / "Cargo.lock"
         lockfile.write_text("ignored")
 
-        with patch.object(lockfile_resolve, "run_git", return_value=make_completed(stdout="ok")), \
-             patch.object(lockfile_resolve.subprocess, "run", return_value=make_completed(returncode=1, stderr="boom")):
+        with (
+            patch.object(lockfile_resolve, "run_git", return_value=make_completed(stdout="ok")),
+            patch.object(
+                lockfile_resolve.subprocess,
+                "run",
+                return_value=make_completed(returncode=1, stderr="boom"),
+            ),
+        ):
             result = lockfile_resolve.resolve_lockfile(str(lockfile), strategy="theirs")
 
         assert result["resolved"] is False
@@ -111,8 +123,10 @@ class TestResolveLockfile:
         lockfile = tmp_path / "Cargo.lock"
         lockfile.write_text("untouched")
 
-        with patch.object(lockfile_resolve, "run_git") as git_mock, \
-             patch.object(lockfile_resolve.subprocess, "run", return_value=make_completed()):
+        with (
+            patch.object(lockfile_resolve, "run_git") as git_mock,
+            patch.object(lockfile_resolve.subprocess, "run", return_value=make_completed()),
+        ):
             git_mock.return_value = make_completed()
             result = lockfile_resolve.resolve_lockfile(str(lockfile), strategy="regen")
 
@@ -126,8 +140,10 @@ class TestResolveLockfile:
         lockfile = tmp_path / "go.sum"
         lockfile.write_text("ignored")
 
-        with patch.object(lockfile_resolve, "run_git") as git_mock, \
-             patch.object(lockfile_resolve.subprocess, "run", return_value=make_completed()):
+        with (
+            patch.object(lockfile_resolve, "run_git") as git_mock,
+            patch.object(lockfile_resolve.subprocess, "run", return_value=make_completed()),
+        ):
             git_mock.side_effect = [
                 make_completed(stdout="theirs"),  # git show
                 make_completed(),  # git add lockfile
@@ -145,8 +161,10 @@ class TestResolveLockfile:
         lockfile = tmp_path / "Cargo.lock"
         lockfile.write_text("ignored")
 
-        with patch.object(lockfile_resolve, "run_git") as git_mock, \
-             patch.object(lockfile_resolve.subprocess, "run", return_value=make_completed()):
+        with (
+            patch.object(lockfile_resolve, "run_git") as git_mock,
+            patch.object(lockfile_resolve.subprocess, "run", return_value=make_completed()),
+        ):
             git_mock.side_effect = [
                 make_completed(stdout="theirs"),
                 make_completed(returncode=1, stderr="lock"),

--- a/uv.lock
+++ b/uv.lock
@@ -142,6 +142,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -152,7 +153,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = "==9.0.3" }]
+dev = [
+    { name = "pytest", specifier = "==9.0.3" },
+    { name = "ruff", specifier = "==0.14.5" },
+]
 
 [[package]]
 name = "click"
@@ -952,6 +956,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/fa/fbb67a5780ae0f704876cb8ac92d6d76da41da4dc72b7ed3565ab18f2f52/ruff-0.14.5.tar.gz", hash = "sha256:8d3b48d7d8aad423d3137af7ab6c8b1e38e4de104800f0d596990f6ada1a9fc1", size = 5615944, upload-time = "2025-11-13T19:58:51.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/31/c07e9c535248d10836a94e4f4e8c5a31a1beed6f169b31405b227872d4f4/ruff-0.14.5-py3-none-linux_armv6l.whl", hash = "sha256:f3b8248123b586de44a8018bcc9fefe31d23dda57a34e6f0e1e53bd51fd63594", size = 13171630, upload-time = "2025-11-13T19:57:54.894Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/5c/283c62516dca697cd604c2796d1487396b7a436b2f0ecc3fd412aca470e0/ruff-0.14.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f7a75236570318c7a30edd7f5491945f0169de738d945ca8784500b517163a72", size = 13413925, upload-time = "2025-11-13T19:57:59.181Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f3/aa319f4afc22cb6fcba2b9cdfc0f03bbf747e59ab7a8c5e90173857a1361/ruff-0.14.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6d146132d1ee115f8802356a2dc9a634dbf58184c51bff21f313e8cd1c74899a", size = 12574040, upload-time = "2025-11-13T19:58:02.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/7f/cb5845fcc7c7e88ed57f58670189fc2ff517fe2134c3821e77e29fd3b0c8/ruff-0.14.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2380596653dcd20b057794d55681571a257a42327da8894b93bbd6111aa801f", size = 13009755, upload-time = "2025-11-13T19:58:05.172Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d2/bcbedbb6bcb9253085981730687ddc0cc7b2e18e8dc13cf4453de905d7a0/ruff-0.14.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2d1fa985a42b1f075a098fa1ab9d472b712bdb17ad87a8ec86e45e7fa6273e68", size = 12937641, upload-time = "2025-11-13T19:58:08.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/58/e25de28a572bdd60ffc6bb71fc7fd25a94ec6a076942e372437649cbb02a/ruff-0.14.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88f0770d42b7fa02bbefddde15d235ca3aa24e2f0137388cc15b2dcbb1f7c7a7", size = 13610854, upload-time = "2025-11-13T19:58:11.419Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/24/43bb3fd23ecee9861970978ea1a7a63e12a204d319248a7e8af539984280/ruff-0.14.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:3676cb02b9061fee7294661071c4709fa21419ea9176087cb77e64410926eb78", size = 15061088, upload-time = "2025-11-13T19:58:14.551Z" },
+    { url = "https://files.pythonhosted.org/packages/23/44/a022f288d61c2f8c8645b24c364b719aee293ffc7d633a2ca4d116b9c716/ruff-0.14.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b595bedf6bc9cab647c4a173a61acf4f1ac5f2b545203ba82f30fcb10b0318fb", size = 14734717, upload-time = "2025-11-13T19:58:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/58/81/5c6ba44de7e44c91f68073e0658109d8373b0590940efe5bd7753a2585a3/ruff-0.14.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f55382725ad0bdb2e8ee2babcbbfb16f124f5a59496a2f6a46f1d9d99d93e6e2", size = 14028812, upload-time = "2025-11-13T19:58:20.533Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ef/41a8b60f8462cb320f68615b00299ebb12660097c952c600c762078420f8/ruff-0.14.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7497d19dce23976bdaca24345ae131a1d38dcfe1b0850ad8e9e6e4fa321a6e19", size = 13825656, upload-time = "2025-11-13T19:58:23.345Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/00/207e5de737fdb59b39eb1fac806904fe05681981b46d6a6db9468501062e/ruff-0.14.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:410e781f1122d6be4f446981dd479470af86537fb0b8857f27a6e872f65a38e4", size = 13959922, upload-time = "2025-11-13T19:58:26.537Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/7e/fa1f5c2776db4be405040293618846a2dece5c70b050874c2d1f10f24776/ruff-0.14.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c01be527ef4c91a6d55e53b337bfe2c0f82af024cc1a33c44792d6844e2331e1", size = 12932501, upload-time = "2025-11-13T19:58:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d8/d86bf784d693a764b59479a6bbdc9515ae42c340a5dc5ab1dabef847bfaa/ruff-0.14.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f66e9bb762e68d66e48550b59c74314168ebb46199886c5c5aa0b0fbcc81b151", size = 12927319, upload-time = "2025-11-13T19:58:32.923Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/de/ee0b304d450ae007ce0cb3e455fe24fbcaaedae4ebaad6c23831c6663651/ruff-0.14.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d93be8f1fa01022337f1f8f3bcaa7ffee2d0b03f00922c45c2207954f351f465", size = 13206209, upload-time = "2025-11-13T19:58:35.952Z" },
+    { url = "https://files.pythonhosted.org/packages/33/aa/193ca7e3a92d74f17d9d5771a765965d2cf42c86e6f0fd95b13969115723/ruff-0.14.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c135d4b681f7401fe0e7312017e41aba9b3160861105726b76cfa14bc25aa367", size = 13953709, upload-time = "2025-11-13T19:58:39.002Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f1/7119e42aa1d3bf036ffc9478885c2e248812b7de9abea4eae89163d2929d/ruff-0.14.5-py3-none-win32.whl", hash = "sha256:c83642e6fccfb6dea8b785eb9f456800dcd6a63f362238af5fc0c83d027dd08b", size = 12925808, upload-time = "2025-11-13T19:58:42.779Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/9d/7c0a255d21e0912114784e4a96bf62af0618e2190cae468cd82b13625ad2/ruff-0.14.5-py3-none-win_amd64.whl", hash = "sha256:9d55d7af7166f143c94eae1db3312f9ea8f95a4defef1979ed516dbb38c27621", size = 14331546, upload-time = "2025-11-13T19:58:45.691Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/69756670caedcf3b9be597a6e12276a6cf6197076eb62aad0c608f8efce0/ruff-0.14.5-py3-none-win_arm64.whl", hash = "sha256:4b700459d4649e2594b31f20a9de33bc7c19976d4746d8d0798ad959621d64a4", size = 13433331, upload-time = "2025-11-13T19:58:48.434Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Added ruff 0.14.5 to Python dev dependencies with rule set E/F/I/UP/B/SIM (100-char line length, py311 target).
Updated `just build` to auto-format and auto-fix Python code, mirroring TypeScript behavior via biome.
CI build uses check-only mode (no fixes) to catch style issues early.
Applied formatting pass across all Python files to establish consistent baseline.
All 88 Python tests pass.

🧀 Generated with cheese-flow