### PR TITLE
feat: add Context7-backed research skill

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,6 +4,10 @@
       "command": "npx",
       "args": ["tilth", "--mcp", "--edit"]
     },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    },
     "tavily": {
       "command": "npx",
       "args": ["-y", "tavily-mcp@latest"],

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Opinionated scaffolding for portable agents and skills that can be compiled into
 - `references/` — long-form architectural references (Sliced Bread, etc.)
 - `.claude-plugin/` — Claude Code + Copilot CLI install manifest
 - `.cursor-plugin/` — Cursor install manifest
-- `.mcp.json` — shared MCP server declarations (tilth, tavily)
+- `.mcp.json` — shared MCP server declarations (tilth, Context7, Tavily)
 - `.claude/` / `.codex/` / `.cursor/` / `.copilot/` — generated install outputs (gitignored)
 
 ## Getting started

--- a/commands/briesearch.md
+++ b/commands/briesearch.md
@@ -1,6 +1,6 @@
 ---
 name: briesearch
-description: Multi-source research orchestrator. Routes a question across web search, library docs, and in-repo tools, writes findings to <harness>/research/<slug>.md, and returns a compact synthesis to the main context.
+description: Multi-source research orchestrator. Routes a question across Tavily, Context7 library docs, GitHub, and in-repo tools, writes findings to <harness>/research/<slug>.md, and returns a compact synthesis to the main context.
 argument-hint: "<question | library | API | dependency>"
 ---
 
@@ -12,14 +12,24 @@ multiple information sources in parallel, writes full findings to
 main context so it does not pollute the caller's window. `<harness>` is the
 active harness output root — `.claude` for Claude Code, `.codex` for Codex.
 
+## Execution
+
+Invoke the `research` skill with `$ARGUMENTS`. The skill owns source routing,
+scratch-file handling, synthesis, confidence scoring, optional report writing,
+and cleanup.
+
+Do not reimplement the fetcher workflow in this command. This command is the
+user-facing alias and contract for research; `skills/research/SKILL.md` is the
+implementation source of truth.
+
 ## Source routing
 
 | Source | Tool | Best for |
 |---|---|---|
-| General web | Tavily | Broad technical content, blog posts, long-form material |
-| SERP + facts | Serper | Up-to-date facts, product pages, vendor documentation |
+| Web + facts | Tavily | Broad technical content, recency, product pages, vendor documentation |
 | Library docs | Context7 | API reference, configuration, migration notes |
 | In-repo context | tilth, ripgrep, LSP | How the target codebase already handles related concerns |
+| Open-source examples | GitHub | How public projects solve similar problems |
 
 Each source runs in parallel where possible. Overlapping findings are
 merged; conflicts are flagged in the synthesis.
@@ -44,17 +54,3 @@ merged; conflicts are flagged in the synthesis.
 - Investigating a dependency (maturity, license, maintenance activity).
 - Pulling external context before `/mold` or `/cheese` so the spec is
   informed, not speculative.
-
-## Deferred behavior
-
-> **Scaffold notice.** Parallel source dispatch and the
-> `<harness>/research/<slug>.md` write are not yet wired. This file
-> documents the routing and output contract. The current implementation
-> should describe what `/briesearch` would do and stop — it does not yet
-> call Tavily, Serper, Context7, or the codebase tools.
-
-The next iteration will:
-
-- Dispatch the four source lookups in parallel via the `Agent` tool.
-- Merge findings, flag conflicts, and write the full report.
-- Return only the compact synthesis to the caller's context window.

--- a/references/dotfiles-takeover-inventory.md
+++ b/references/dotfiles-takeover-inventory.md
@@ -1,0 +1,159 @@
+# Dotfiles Claude Takeover Inventory
+
+Source reviewed: `/Users/paul/Dev/dotfiles/claude`
+
+This inventory tracks Claude Code skills, commands, and agents that are worth
+moving into `cheese-flow` as portable source material. It is intentionally a
+triage document, not a migration log.
+
+## Current Shape
+
+- Dotfiles source contains 42 skill definitions, 34 slash commands, and 43 agent
+  definitions across global and plugin-local directories.
+- `cheese-flow` currently has the portable source model documented in
+  `skills/README.md`, one starter skill, five commands, and one agent template.
+- Best target for portable skill content is `skills/<name>/SKILL.md`.
+- Best target for reusable command content is `commands/<name>.md`.
+- Best target for agents is likely `agents/<name>.md.eta`, because agent metadata
+  needs harness-specific projection.
+
+## Priority 1: Bring Over First
+
+These assets are broadly useful, mostly markdown-first, and have low coupling to
+personal paths or Claude-only behavior.
+
+### Skills
+
+| Asset | Source | Why It Belongs |
+| --- | --- | --- |
+| `chisel` | `skills/chisel/SKILL.md` | Safe editing patterns and `sd` usage are broadly portable. |
+| `commit` | `skills/commit/SKILL.md` | Focused staging and conventional commit discipline should travel across harnesses. |
+| `de-slop` | `skills/de-slop/SKILL.md` | Core quality guard against predictable AI code smells. |
+| `diff` | `skills/diff/SKILL.md` | Lightweight pre-commit smoke review. |
+| `git-hygiene` | `skills/git-hygiene/SKILL.md` | Prevents unsafe git-content access patterns. |
+| `justfile` | `skills/justfile/SKILL.md` | Practical project automation onboarding. |
+| `lint` | `skills/lint/SKILL.md` | Multi-language lint routing and summarization. |
+| `nih-audit` | `skills/nih-audit/SKILL.md` | Library-vs-custom-code audit is broadly useful. |
+| `ralphify-spec` | `skills/ralphify-spec/SKILL.md` | Converts iterative work into repeatable loop specs. |
+| `self-eval` | `skills/self-eval/SKILL.md` | Portable response/change quality checklist. |
+| `skill-improver` | `skills/skill-improver/SKILL.md` | Directly supports maintaining this repo's skill catalog. |
+| `tdd-assertions` | `skills/tdd-assertions/SKILL.md` | Strengthens tests across languages. |
+| `tui-design` | `skills/tui-design/SKILL.md` | Mostly design guidance; low harness coupling. |
+| `version-doctor` | `skills/version-doctor/SKILL.md` | Common dependency/version failure workflow. |
+| `worktree` | `skills/worktree/SKILL.md` | General isolated-branch workflow. |
+
+### Commands
+
+| Asset | Source | Why It Belongs |
+| --- | --- | --- |
+| `init` | `plugins/local/cheese-flow/commands/init.md` | Already cheese-flow branded; should live in the repo as source of truth. |
+| `explore` | `plugins/local/cheese-flow/commands/explore.md` | Core cheese-flow value proposition. |
+| `hello` | `plugins/local/cheese-flow/commands/hello.md` | Cheap install smoke test. |
+| `research` | `commands/research.md` | Thin wrapper around the `research` skill. |
+| `diff` | `commands/diff.md` | Thin wrapper around the `diff` skill. |
+| `respond` | `commands/respond.md` | Useful PR-review workflow once GitHub tooling is modeled. |
+| `worktree` | `commands/worktree.md` | Thin wrapper around the `worktree` skill. |
+| `pingpong` | `commands/pingpong.md` | Portable TDD pairing prompt. |
+| `hint` | `commands/hint.md` | Portable teaching prompt; needs normalized frontmatter. |
+| `explain` | `commands/explain.md` | Portable concept explanation workflow. |
+| `duck` | `commands/duck.md` | Portable rubber-duck workflow. |
+| `pull` | `commands/pull.md` | Useful in multi-worktree flows; validate assumptions before shipping. |
+
+### Agents
+
+| Asset | Source | Why It Belongs |
+| --- | --- | --- |
+| `cheese-factory` | `agents/cheese-factory.md` | General codebase orientation. |
+| `ghostbuster` | `agents/ghostbuster.md` | Reusable dead-code/spec-drift forensic agent. |
+| `nih-scanner` | `agents/nih-scanner.md` | Pairs with the `nih-audit` skill. |
+| `lsp-probe` | `agents/lsp-probe.md` | Useful short-lived LSP query broker. |
+| `fromage-pasteurize` | `agents/fromage-pasteurize.md` | Standalone security/dependency audit agent. |
+| `explore-lsp` | `plugins/local/cheese-flow/agents/explore-lsp.md` | Low-coupling part of the cheese-flow exploration stack. |
+
+## Priority 2: Adapt Before Porting
+
+These are valuable, but they assume specific tools, Claude Code paths, MCP
+servers, or sub-agent names. They should move after the compiler can express the
+right harness overrides.
+
+### Skills
+
+- `fetch` and `research`: keep the routing ideas, but split Context7/Tavily
+  and scratch-file details into harness-specific metadata.
+- `make`: preserve build/test detection; isolate the Claude-specific "hooks block
+  raw builds" behavior.
+- `lookup`, `trace`, `scout`, `prek`, `merge-resolve`: useful but need explicit
+  CLI availability assumptions.
+- `gh` and `respond`: valuable once GitHub MCP vs `gh` fallback is represented
+  cleanly.
+- `ghostbuster`, `xray`, `spec-verify`, `age`: high value, but agent packs and
+  spec paths need to be bundled consistently.
+- `session-analytics`, `test-sandbox`: useful for Claude Code users, but personal
+  paths such as `~/.claude` must not leak into default portable output.
+- `init` and `explore` from the local cheese-flow plugin: should become
+  first-class repo skills, but they depend on tilth, tokei, LSP, and graph tooling.
+
+### Commands
+
+- `age`: merge with the existing `commands/age.md`; do not duplicate.
+- `code-review`, `spec`, `nih-audit`, `ghostbuster`, `skill-improver`,
+  `setup-perms`, `scaffold`, `test`, `wreck`, `onboard`, `audit`, `simplifier`:
+  useful workflows, but each needs path/tool normalization or bundled agents.
+- `fromage`, `fromagerie`, `move-my-cheese`, `cheese-convoy`: treat as an
+  optional platform bundle. They only make sense with the full skill and agent
+  graph.
+- `copilot-review`, `copilot-delegate`, `copilot-setup`: keep optional until
+  Copilot is intentionally supported as a first-class target.
+- `agents`: rewrite to inspect project/compiled assets, not hardcoded
+  `~/.claude` paths.
+
+### Agents
+
+- `whey-drainer`, `roquefort-wrecker`, `ricotta-reducer`: strong quality agents;
+  adapt build/test commands and skill dependencies.
+- `fromage-culture`, `fromage-curdle`, `fromage-cook`, `fromage-press`,
+  `fromage-wire`, `fromage-fort`: core pipeline agents, but they require the
+  surrounding Fromage command/skill conventions.
+- `fromage-age-*`: port as a coherent Age review pack, not one at a time.
+- `fromagerie-*`, `culture-*`, `worktree-triage`: wait until worktree,
+  token-sizing, and MCP dependencies are explicit in `cheese-flow`.
+- `explore-tilth`, `explore-tokei`, `explore-graph`: keep as optional exploration
+  layers behind installed-tool or MCP checks.
+- `xray` reference agents: useful as an opt-in bundle once the `xray` skill is
+  adapted.
+
+## Leave Local For Now
+
+- `settings-clean`: valuable for a personal Claude Code setup, but not portable.
+- `worktree-sweep`: tied to `ccw-sweep` and a personal `~/Dev` layout.
+- `skill-analytics-*`: depends on personal Claude Code analytics data.
+- `todoist-flow` skills and agents: separate product/plugin, not core
+  `cheese-flow`.
+- `hello-cheese`: scaffold/demo value only; superseded by `basic-skill` and real
+  cheese-flow commands.
+- `culture-context7`: wait until Context7 is a declared dependency.
+
+## Open Decisions
+
+1. Should `cheese-flow` ship one default bundle plus optional packs, or should all
+   assets compile into every harness by default?
+2. Should agents stay Claude-oriented, or should the source schema grow a portable
+   agent metadata model with per-harness model/tool projections?
+3. How should MCP-backed capabilities such as Context7, tilth, graph search, and
+   GitHub be expressed: required dependency, optional feature, or harness override?
+4. Where should Claude-only operational paths such as `.claude/specs`,
+   `.claude/review`, and `~/.claude/analytics` be normalized for other harnesses?
+
+## Suggested First Migration Batch
+
+1. Copy the Priority 1 skills into `skills/`, adding portable frontmatter:
+   `name`, `description`, `license`, `compatibility`, and broad `allowed-tools`.
+2. Copy supporting `references/` and `scripts/` directories for skills that have
+   local assets, especially `justfile`, `ralphify-spec`, `de-slop`, and
+   `skill-improver`.
+3. Bring over plugin-local `init`, `explore`, and `hello` commands with matching
+   `init` and `explore` skills.
+4. Add the first low-coupling agents: `cheese-factory`, `ghostbuster`,
+   `nih-scanner`, `lsp-probe`, `fromage-pasteurize`, and `explore-lsp`.
+5. Run the compiler tests after each batch and tighten schemas only when a real
+   source asset needs the field.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,103 @@
+# Portable Skill Sources
+
+Top-level `skills/` is the canonical source directory for portable skill definitions.
+The compiler in `src/` reads these sources, validates their frontmatter, and emits
+harness-specific artifacts for Claude Code, Codex, Cursor, Copilot CLI, and future
+targets.
+
+`src/` should contain compiler code and harness adapters. It should not contain the
+canonical skill content.
+
+## Source Model
+
+Each skill lives in its own directory:
+
+```text
+skills/
+  chisel/
+    SKILL.md
+    references/
+      ...
+```
+
+`SKILL.md` is the portable source file. Its markdown body describes the skill once.
+Its YAML frontmatter contains a portable superset of metadata that adapters can
+project into each harness.
+
+```yaml
+---
+name: chisel
+description: Edit file contents safely.
+license: MIT
+compatibility: Works in markdown-based coding harnesses.
+allowed-tools:
+  - read
+  - edit
+  - bash
+metadata:
+  owner: cheese-flow
+  category: editing
+harness:
+  claude-code:
+    allowed-tools:
+      - Read
+      - Edit
+      - Bash(sd:*)
+  cursor:
+    globs:
+      - "**/*"
+    alwaysApply: false
+---
+```
+
+## Portable Fields
+
+Portable fields should mean the same thing regardless of target harness:
+
+- `name` is the stable kebab-case skill identifier and must match the directory name.
+- `description` is the short human-readable purpose.
+- `license` records reuse terms when the source skill needs them.
+- `compatibility` explains where the skill can run.
+- `allowed-tools` describes the broad tool intent in source form.
+- `metadata` carries repository-owned details that may not be emitted everywhere.
+
+Adapters may preserve, transform, or omit these fields depending on the target
+harness.
+
+## Harness Overrides
+
+Use `harness` only when a target needs different metadata from the portable default.
+This keeps one canonical skill body while allowing valid per-harness output.
+
+Examples:
+
+- Claude Code can preserve Agent Skills frontmatter such as `allowed-tools`.
+- Cursor may convert the same skill body into `.cursor/rules/*.mdc` and
+  `.cursor/commands/*.md`, using fields like `description`, `globs`, and
+  `alwaysApply`.
+- A harness without hooks or tool restrictions should omit unsupported fields rather
+  than emitting invalid metadata.
+
+The rule is: validate generously at the source, emit strictly per target.
+
+## Compiler Responsibilities
+
+The compiler should:
+
+1. Parse `skills/<name>/SKILL.md`.
+2. Validate the portable source schema.
+3. Check that `frontmatter.name` matches `<name>`.
+4. Select the target harness adapter.
+5. Emit only fields valid for that harness.
+6. Copy references and other skill-local assets as needed.
+
+Adapters own the projection from portable source to target output. The source skill
+should not need to know each target filesystem layout.
+
+## Where New Work Goes
+
+- Add or update skill content in top-level `skills/`.
+- Add source schema support in `src/lib/schemas.ts`.
+- Add target-specific projection in `src/adapters/*`.
+- Add compiler orchestration in `src/lib/compiler.ts` only when the pipeline itself
+  needs to change.

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: research
+description: Multi-source research orchestrator that routes questions across Context7 library docs, Tavily web research, codebase analysis, and GitHub examples, then returns a compact synthesis with confidence scoring.
+license: MIT
+compatibility: Works in markdown-based coding harnesses with sub-agent support. Context7, Tavily, and GitHub lookups are optional source routes.
+allowed-tools:
+  - read
+  - write
+  - bash
+  - subagent
+  - mcp
+---
+# Research
+
+Use this skill when the user asks to research a technical question, compare
+libraries or approaches, investigate external APIs, or gather 2+ sources before
+making an implementation decision.
+
+Do not use this skill for a single library-doc lookup, a codebase-only question,
+or a simple fact that can be answered directly.
+
+## Context Discipline
+
+Run the orchestration inline, but keep raw evidence out of the main context:
+
+1. Route sources once and state the committed routing decision.
+2. Spawn fetchers in parallel where the harness supports it.
+3. Have fetchers write findings to scratch files under `$TMPDIR`.
+4. Have one synthesis sub-agent read those scratch files and return the final
+   answer.
+5. Delete the scratch directory after synthesis, unless a report file was
+   requested.
+
+The caller should see only the routing decision, fetcher status, synthesis, and
+optional report path.
+
+## Arguments
+
+Parse the request for:
+
+- `--report` or `--report <filepath>`: save a durable markdown report.
+  Default path: `<harness>/research/<slugified-topic>.md`.
+- Everything else: the research question.
+
+Create a run directory:
+
+```bash
+RUN_ID="$(date +%Y%m%d-%H%M%S)-<slug>"
+RUN_DIR="${TMPDIR:-/tmp}/cheese-flow-research-${RUN_ID}"
+mkdir -p "$RUN_DIR"
+```
+
+Use a 4-6 word kebab-case slug derived from the topic.
+
+## Phase 1: Classify
+
+Identify:
+
+- Primary topic
+- Question type: factual lookup, how-to, comparison, pattern search, API usage
+- Complexity: simple fact, focused question, comparison, or deep analysis
+- Constraints: version, language, framework, performance, license, architecture
+
+## Phase 2: Route Sources
+
+Decide once. If a source is committed here, it must be executed in Phase 3.
+
+```text
+Is it about a specific library API, config, or migration?
+  YES -> Context7, plus GitHub if real-world usage matters
+
+Is it a factual, current, vendor, product, or "what/who/when" question?
+  YES -> Tavily basic search
+
+Is it a "how should I..." or best-practices question?
+  YES -> Tavily advanced search, plus Context7 when a named library is involved
+
+Is it about patterns in this repo?
+  YES -> Codebase fetcher
+
+Is it about how open-source projects solve something?
+  YES -> GitHub fetcher, plus Tavily if written analysis would help
+```
+
+Source guide:
+
+| Source | Best For | Notes |
+| --- | --- | --- |
+| Context7 | Library APIs, config, migration notes | Prefer over general web for named dependencies. |
+| Tavily | Current facts, technical articles, vendor docs, best practices | Use basic for factual lookups, advanced for analysis. |
+| Codebase | Local conventions, existing usage, constraints | Use repository search and reads. |
+| GitHub | Real-world OSS usage patterns | Use `gh` or the harness GitHub integration. |
+
+Emit a compact routing block:
+
+```text
+ROUTING DECISION:
+- Context7: YES (library: "<library>", query: "<focused question>")
+- Tavily: YES (query: "<natural-language question>", depth: basic|advanced)
+- Codebase: NO (external-only question)
+- GitHub: NO (not looking for OSS usage patterns)
+```
+
+## Phase 3: Execute Fetchers
+
+Hard rule: if a source was committed in Phase 2, spawn it in Phase 3. Do not
+silently skip a routed source because it seems low value later.
+
+Every fetcher must:
+
+1. Use only its assigned source tools.
+2. Write findings to `<RUN_DIR>/<source>.md`.
+3. Return exactly one status line:
+   - `done: <RUN_DIR>/<source>.md`
+   - `unavailable: <one-line reason>`
+
+Scratch file schema:
+
+```markdown
+# <source> - <topic>
+_Confidence: <0-100>_  _Status: <ok|unavailable>_
+
+## Direct Answer
+<1-2 sentences>
+
+## Evidence
+<quotes, snippets, key facts, or code references>
+
+## Sources
+- <URLs, file refs, library IDs, repo links>
+```
+
+### Context7 Fetcher
+
+Use Context7 for library documentation. Resolve the library first, then query
+the resolved docs. Limit to 3 Context7 calls.
+
+Prompt shape:
+
+```text
+You are fetching library documentation via Context7.
+Use only Context7 MCP tools. Do not use web search.
+
+Steps:
+1. Resolve the library ID for "<library>".
+2. Query docs for "<focused question>".
+3. Verify the resolved library matches the question.
+4. Write findings to <RUN_DIR>/context7.md using the scratch schema.
+5. Return only: done: <RUN_DIR>/context7.md
+
+If Context7 is unavailable, write a one-line unavailable note to the scratch
+file and return only: unavailable: <reason>
+```
+
+### Tavily Fetcher
+
+Use Tavily for web, facts, technical articles, product docs, and current
+ecosystem context. Do not route Serper; Tavily is the web source.
+
+Prompt shape:
+
+```text
+You are researching with Tavily.
+Use only Tavily MCP tools. Do not use generic web search.
+
+Query: "<natural-language question>"
+Depth: basic for factual/current lookups, advanced for how-to or comparisons.
+
+Steps:
+1. Search with the selected depth.
+2. If snippets are insufficient, extract from one promising URL.
+3. Max 3 Tavily calls.
+4. Write findings to <RUN_DIR>/tavily.md using the scratch schema.
+5. Return only: done: <RUN_DIR>/tavily.md
+
+Do not use high-cost deep research tools unless the user explicitly asked for
+deep research.
+```
+
+### Codebase Fetcher
+
+Use repository tools to find local precedents and constraints.
+
+Prompt shape:
+
+```text
+You are analyzing the local codebase for patterns.
+Question: <question>
+
+Find:
+- Existing usage of this dependency, pattern, or architecture
+- Constraints implied by current code
+- File references that matter to the decision
+
+Write findings to <RUN_DIR>/codebase.md and return only:
+done: <RUN_DIR>/codebase.md
+```
+
+### GitHub Fetcher
+
+Use GitHub for real-world open-source patterns.
+
+Prompt shape:
+
+```text
+You are searching GitHub for real-world examples.
+Use the harness GitHub integration or `gh` CLI.
+
+Find:
+- 2-3 relevant public examples
+- Observable implementation patterns
+- Caveats or maintenance signals
+
+Write findings to <RUN_DIR>/github.md and return only:
+done: <RUN_DIR>/github.md
+```
+
+## Phase 4: Synthesis
+
+Spawn one synthesis sub-agent. It reads each `done` scratch file and ignores
+unavailable sources for content while still counting them in confidence.
+
+Synthesis task:
+
+1. Build one evidence row per routed source:
+   `Source | Finding | Score | Notes`.
+2. Apply the mechanical confidence cap:
+   - Any unavailable, failed, skipped, or not-spawned source caps overall
+     confidence at 49.
+   - 3+ agreeing sources: 85-100.
+   - 2 agreeing sources: 60-84.
+   - Disagreement: cap at 49 and explain why.
+   - 1 completed source: inherit that source's score.
+3. Return exactly:
+
+```markdown
+## Research: <Question>
+
+### Finding
+<1-3 concise paragraphs>
+
+### Evidence by Source
+| Source | Finding | Score | Notes |
+| --- | --- | --- | --- |
+| ... |
+
+### Implications
+<2-4 sentences about how this affects the user's task>
+
+### Overall Confidence
+**<score>** - <justification based on source agreement and completeness>
+```
+
+If `--report` was set, append a fenced `report-body` block containing a full
+markdown report with source URLs, file refs, and repo links. The orchestration
+layer writes that report body verbatim to the requested path.
+
+## Cleanup
+
+After synthesis and any report write:
+
+```bash
+rm -rf "$RUN_DIR"
+```
+
+## Rules
+
+- Do not read scratch files in the main context.
+- Do not write application code or implement the researched solution.
+- Do not use Serper or SerperAPI; Tavily is the web and facts source.
+- Do not use high-cost Tavily deep research unless the user explicitly asks.
+- Do not skip a source that was committed in the routing decision.
+- If a routed source fails, surface the incomplete confidence cap instead of
+  pretending the remaining evidence is complete.

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -3,6 +3,9 @@ name: research
 description: Multi-source research orchestrator that routes questions across Context7 library docs, Tavily web research, codebase analysis, and GitHub examples, then returns a compact synthesis with confidence scoring.
 license: MIT
 compatibility: Works in markdown-based coding harnesses with sub-agent support. Context7, Tavily, and GitHub lookups are optional source routes.
+metadata:
+  owner: cheese-flow
+  category: research
 allowed-tools:
   - read
   - write
@@ -28,19 +31,17 @@ Run the orchestration inline, but keep raw evidence out of the main context:
 3. Have fetchers write findings to scratch files under `$TMPDIR`.
 4. Have one synthesis sub-agent read those scratch files and return the final
    answer.
-5. Delete the scratch directory after synthesis, unless a report file was
-   requested.
+5. Write the full report to `<harness>/research/<slugified-topic>.md`.
+6. Delete the scratch directory after the report is written.
 
-The caller should see only the routing decision, fetcher status, synthesis, and
-optional report path.
+`<harness>` is the active harness output root — `.claude` for Claude Code,
+`.codex` for Codex, etc. The caller should see only the routing decision,
+fetcher status, synthesis, and the report path.
 
 ## Arguments
 
-Parse the request for:
-
-- `--report` or `--report <filepath>`: save a durable markdown report.
-  Default path: `<harness>/research/<slugified-topic>.md`.
-- Everything else: the research question.
+The entire request body is the research question. The skill always writes a
+full report; the caller does not pass an output path.
 
 Create a run directory:
 
@@ -251,13 +252,14 @@ Synthesis task:
 **<score>** - <justification based on source agreement and completeness>
 ```
 
-If `--report` was set, append a fenced `report-body` block containing a full
-markdown report with source URLs, file refs, and repo links. The orchestration
-layer writes that report body verbatim to the requested path.
+After the synthesis block, append a fenced `report-body` block containing a
+full markdown report with source URLs, file refs, and repo links. The
+orchestration layer writes that report body verbatim to
+`<harness>/research/<slug>.md`.
 
 ## Cleanup
 
-After synthesis and any report write:
+After the report is written:
 
 ```bash
 rm -rf "$RUN_DIR"

--- a/src/domain/harness.ts
+++ b/src/domain/harness.ts
@@ -50,6 +50,10 @@ export type McpServerConfig = {
 
 export const canonicalMcpServers: Record<string, McpServerConfig> = {
   tilth: { command: "npx", args: ["tilth", "--mcp", "--edit"] },
+  context7: {
+    command: "npx",
+    args: ["-y", "@upstash/context7-mcp"],
+  },
   tavily: {
     command: "npx",
     args: ["-y", "tavily-mcp@latest"],

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -70,7 +70,9 @@ describe("installHarnessArtifacts", () => {
       await readFile(path.join(projectRoot, ".claude", ".mcp.json"), "utf8"),
     ) as { mcpServers: Record<string, unknown> };
     expect(claudeMcp.mcpServers).toHaveProperty("tilth");
+    expect(claudeMcp.mcpServers).toHaveProperty("context7");
     expect(claudeMcp.mcpServers).toHaveProperty("tavily");
+    expect(claudeMcp.mcpServers).not.toHaveProperty("serper");
 
     const codexPlugin = JSON.parse(
       await readFile(
@@ -84,6 +86,7 @@ describe("installHarnessArtifacts", () => {
       await readFile(path.join(projectRoot, ".codex", ".mcp.json"), "utf8"),
     ) as { mcpServers: Record<string, unknown> };
     expect(codexMcp.mcpServers).toHaveProperty("tilth");
+    expect(codexMcp.mcpServers).toHaveProperty("context7");
   });
 
   it("validates the shipped skill metadata", async () => {
@@ -173,7 +176,7 @@ describe("installHarnessArtifacts", () => {
     ) as { agents: string[]; skills: string[]; commands: string[] };
 
     expect(manifest.agents).toEqual(["basic-agent.md"]);
-    expect(manifest.skills).toEqual(["basic-skill", "nested-dir"]);
+    expect(manifest.skills).toEqual(["basic-skill", "nested-dir", "research"]);
     expect(manifest.commands).toEqual([]);
   });
 
@@ -222,6 +225,7 @@ describe("installHarnessArtifacts", () => {
       await readFile(path.join(cursorRoot, "mcp.json"), "utf8"),
     ) as { mcpServers: Record<string, unknown> };
     expect(mcpJson.mcpServers).toHaveProperty("tilth");
+    expect(mcpJson.mcpServers).toHaveProperty("context7");
     expect(mcpJson.mcpServers).toHaveProperty("tavily");
   });
 
@@ -267,6 +271,7 @@ describe("installHarnessArtifacts", () => {
       await readFile(path.join(copilotRoot, ".mcp.json"), "utf8"),
     ) as { mcpServers: Record<string, unknown> };
     expect(mcpJson.mcpServers).toHaveProperty("tilth");
+    expect(mcpJson.mcpServers).toHaveProperty("context7");
 
     // Hooks file with version:1 and camelCase keys
     const hooksJson = JSON.parse(

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -15,7 +15,7 @@ afterEach(async () => {
 });
 
 describe("emitMcpConfig", () => {
-  it("emits .mcp.json for claude-code with tilth and tavily entries", async () => {
+  it("emits .mcp.json for claude-code with tilth, context7, and tavily entries", async () => {
     const outputRoot = await mkdtemp(path.join(os.tmpdir(), "cheese-flow-"));
     createdDirectories.push(outputRoot);
 
@@ -27,7 +27,9 @@ describe("emitMcpConfig", () => {
 
     expect(config.mcpServers).toBeDefined();
     expect(config.mcpServers.tilth).toBeDefined();
+    expect(config.mcpServers.context7).toBeDefined();
     expect(config.mcpServers.tavily).toBeDefined();
+    expect(config.mcpServers.serper).toBeUndefined();
   });
 
   it("tilth entry has npx command with --mcp and --edit flags", async () => {
@@ -59,6 +61,23 @@ describe("emitMcpConfig", () => {
     expect(config.mcpServers.tavily.env.TAVILY_API_KEY).toBeDefined();
   });
 
+  it("context7 entry uses the official npx package", async () => {
+    const outputRoot = await mkdtemp(path.join(os.tmpdir(), "cheese-flow-"));
+    createdDirectories.push(outputRoot);
+
+    await emitMcpConfig("claude-code", outputRoot);
+
+    const mcpPath = path.join(outputRoot, ".mcp.json");
+    const content = await readFile(mcpPath, "utf8");
+    const config = JSON.parse(content);
+
+    expect(config.mcpServers.context7.command).toBe("npx");
+    expect(config.mcpServers.context7.args).toEqual([
+      "-y",
+      "@upstash/context7-mcp",
+    ]);
+  });
+
   it("emits mcp.json (no leading dot) for cursor target", async () => {
     const outputRoot = await mkdtemp(path.join(os.tmpdir(), "cheese-flow-"));
     createdDirectories.push(outputRoot);
@@ -71,6 +90,7 @@ describe("emitMcpConfig", () => {
 
     expect(config.mcpServers).toBeDefined();
     expect(config.mcpServers.tilth).toBeDefined();
+    expect(config.mcpServers.context7).toBeDefined();
   });
 
   it("includes milknado TODO marker in output", async () => {


### PR DESCRIPTION
Add Context7 to the shared MCP configuration and wire Briesearch to a portable research skill that routes through Tavily, Context7, GitHub, and codebase sources without Serper.

Made-with: Cursor