### PR TITLE
feat: add skill linting against Agent Skills format

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ build:
     npm install
     npm run format
     npm run lint:fix
+    npm run lint:skills
     npm run typecheck
     npm run build
     rtk test npm run test:coverage
@@ -17,6 +18,7 @@ build-ci:
     npm ci
     npm run format:check
     npm run lint:check
+    npm run lint:skills
     npm run typecheck
     npm run build
     npm run test:coverage

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "install:cursor": "tsx src/index.ts install --harness cursor",
     "lint:fix": "biome check --write .",
     "lint:check": "biome check .",
+    "lint:skills": "tsx src/index.ts lint",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"

--- a/skills/README.md
+++ b/skills/README.md
@@ -101,3 +101,23 @@ should not need to know each target filesystem layout.
 - Add target-specific projection in `src/adapters/*`.
 - Add compiler orchestration in `src/lib/compiler.ts` only when the pipeline itself
   needs to change.
+
+## Linting
+
+Skills are linted against the [Agent Skills format](https://agentskills.io/specification):
+
+```bash
+npm run lint:skills
+# or
+npx tsx src/index.ts lint
+```
+
+The linter enforces:
+
+- A `SKILL.md` exists in every skill directory.
+- Frontmatter is valid YAML and parses against the portable schema.
+- `name` is kebab-case, 1-64 chars, with no leading/trailing/consecutive hyphens,
+  and matches the parent directory name.
+- `description` is 1-1024 characters (warns if shorter than 20).
+- `compatibility`, when present, is at most 500 characters.
+- `SKILL.md` body is at most 500 lines (warning); move overflow into `references/`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,11 @@ import {
   runAllToolChecks,
 } from "./lib/doctor.js";
 import {
+  formatLintReport,
+  hasErrors,
+  lintSkillsDirectory,
+} from "./lib/lint-skills.js";
+import {
   defaultClientFactory,
   defaultClientTransportFactory,
   defaultServerFactory,
@@ -88,6 +93,28 @@ program
     const results = await runAllToolChecks();
     process.stdout.write(formatReport(results));
     if (hasBlockingFailure(results)) {
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command("lint")
+  .description(
+    "Lint skills/ against the Agent Skills format (https://agentskills.io).",
+  )
+  .option(
+    "--project-root <path>",
+    "Project root that contains ./skills.",
+    defaultProjectRoot,
+  )
+  .action(async (options: { projectRoot: string }) => {
+    const skillsDirectory = path.join(
+      path.resolve(options.projectRoot),
+      "skills",
+    );
+    const report = await lintSkillsDirectory(skillsDirectory);
+    process.stdout.write(formatLintReport(report));
+    if (hasErrors(report)) {
       process.exitCode = 1;
     }
   });

--- a/src/lib/lint-skills.ts
+++ b/src/lib/lint-skills.ts
@@ -93,13 +93,7 @@ export function lintSkillSource(context: LintSourceContext): LintIssue[] {
   try {
     parsed = parseFrontmatter<unknown>(context.source);
   } catch (error) {
-    issues.push(
-      issue(
-        "error",
-        "frontmatter-parse",
-        error instanceof Error ? error.message : String(error),
-      ),
-    );
+    issues.push(issue("error", "frontmatter-parse", (error as Error).message));
     return issues;
   }
 
@@ -127,23 +121,14 @@ export function lintSkillSource(context: LintSourceContext): LintIssue[] {
       );
     }
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      for (const zodIssue of error.issues) {
-        const fieldPath = zodIssue.path.join(".") || "<frontmatter>";
-        issues.push(
-          issue(
-            "error",
-            `frontmatter:${fieldPath}`,
-            `${fieldPath}: ${zodIssue.message}`,
-          ),
-        );
-      }
-    } else {
+    const zodError = error as z.ZodError;
+    for (const zodIssue of zodError.issues) {
+      const fieldPath = zodIssue.path.join(".") || "<frontmatter>";
       issues.push(
         issue(
           "error",
-          "frontmatter-invalid",
-          error instanceof Error ? error.message : String(error),
+          `frontmatter:${fieldPath}`,
+          `${fieldPath}: ${zodIssue.message}`,
         ),
       );
     }

--- a/src/lib/lint-skills.ts
+++ b/src/lib/lint-skills.ts
@@ -1,0 +1,194 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { parseFrontmatter } from "./frontmatter.js";
+import { parseSkillFrontmatter } from "./schemas.js";
+
+export type LintSeverity = "error" | "warning";
+
+export type LintIssue = {
+  skill: string;
+  file: string;
+  severity: LintSeverity;
+  rule: string;
+  message: string;
+};
+
+export type LintReport = {
+  scanned: number;
+  issues: LintIssue[];
+};
+
+const RECOMMENDED_BODY_LINE_LIMIT = 500;
+const MIN_DESCRIPTION_LENGTH = 20;
+
+export async function lintSkillsDirectory(
+  skillsRoot: string,
+): Promise<LintReport> {
+  const entries = await readdir(skillsRoot, { withFileTypes: true });
+  const directories = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+
+  const issues: LintIssue[] = [];
+  for (const directoryName of directories) {
+    issues.push(...(await lintSkillDirectory(skillsRoot, directoryName)));
+  }
+
+  return { scanned: directories.length, issues };
+}
+
+async function lintSkillDirectory(
+  skillsRoot: string,
+  directoryName: string,
+): Promise<LintIssue[]> {
+  const skillDirectory = path.join(skillsRoot, directoryName);
+  const skillFile = path.join(skillDirectory, "SKILL.md");
+  const relativeFile = path.relative(skillsRoot, skillFile);
+
+  try {
+    await stat(skillFile);
+  } catch {
+    return [
+      {
+        skill: directoryName,
+        file: relativeFile,
+        severity: "error",
+        rule: "skill-md-required",
+        message: "SKILL.md is required at the skill directory root.",
+      },
+    ];
+  }
+
+  const source = await readFile(skillFile, "utf8");
+  return lintSkillSource({
+    directoryName,
+    relativeFile,
+    source,
+  });
+}
+
+type LintSourceContext = {
+  directoryName: string;
+  relativeFile: string;
+  source: string;
+};
+
+export function lintSkillSource(context: LintSourceContext): LintIssue[] {
+  const issues: LintIssue[] = [];
+  const issue = (
+    severity: LintSeverity,
+    rule: string,
+    message: string,
+  ): LintIssue => ({
+    skill: context.directoryName,
+    file: context.relativeFile,
+    severity,
+    rule,
+    message,
+  });
+
+  let parsed: { data: unknown; body: string };
+  try {
+    parsed = parseFrontmatter<unknown>(context.source);
+  } catch (error) {
+    issues.push(
+      issue(
+        "error",
+        "frontmatter-parse",
+        error instanceof Error ? error.message : String(error),
+      ),
+    );
+    return issues;
+  }
+
+  try {
+    const frontmatter = parseSkillFrontmatter(parsed.data);
+
+    if (frontmatter.name !== context.directoryName) {
+      issues.push(
+        issue(
+          "error",
+          "name-matches-directory",
+          `frontmatter name "${frontmatter.name}" must match parent directory "${context.directoryName}".`,
+        ),
+      );
+    }
+
+    const description = frontmatter.description.trim();
+    if (description.length < MIN_DESCRIPTION_LENGTH) {
+      issues.push(
+        issue(
+          "warning",
+          "description-too-short",
+          `description is ${description.length} chars; aim for at least ${MIN_DESCRIPTION_LENGTH} so agents can match it during discovery.`,
+        ),
+      );
+    }
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      for (const zodIssue of error.issues) {
+        const fieldPath = zodIssue.path.join(".") || "<frontmatter>";
+        issues.push(
+          issue(
+            "error",
+            `frontmatter:${fieldPath}`,
+            `${fieldPath}: ${zodIssue.message}`,
+          ),
+        );
+      }
+    } else {
+      issues.push(
+        issue(
+          "error",
+          "frontmatter-invalid",
+          error instanceof Error ? error.message : String(error),
+        ),
+      );
+    }
+  }
+
+  const bodyLineCount = parsed.body.split(/\r?\n/u).length;
+  if (bodyLineCount > RECOMMENDED_BODY_LINE_LIMIT) {
+    issues.push(
+      issue(
+        "warning",
+        "body-too-long",
+        `SKILL.md body is ${bodyLineCount} lines; the spec recommends staying under ${RECOMMENDED_BODY_LINE_LIMIT}. Move detail into references/.`,
+      ),
+    );
+  }
+
+  return issues;
+}
+
+export function formatLintReport(report: LintReport): string {
+  const lines: string[] = [
+    `cheese lint — ${report.scanned} skill${report.scanned === 1 ? "" : "s"} scanned`,
+    "",
+  ];
+
+  if (report.issues.length === 0) {
+    lines.push("No issues found.");
+    return `${lines.join("\n")}\n`;
+  }
+
+  for (const item of report.issues) {
+    const tag = item.severity === "error" ? "ERROR" : "WARN";
+    lines.push(`[${tag}] ${item.file} (${item.rule}): ${item.message}`);
+  }
+
+  const errorCount = report.issues.filter(
+    (entry) => entry.severity === "error",
+  ).length;
+  const warningCount = report.issues.length - errorCount;
+  lines.push("");
+  lines.push(`${errorCount} error(s), ${warningCount} warning(s).`);
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function hasErrors(report: LintReport): boolean {
+  return report.issues.some((item) => item.severity === "error");
+}

--- a/src/lib/lint-skills.ts
+++ b/src/lib/lint-skills.ts
@@ -1,6 +1,6 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
-import { z } from "zod";
+import type { z } from "zod";
 import { parseFrontmatter } from "./frontmatter.js";
 import { parseSkillFrontmatter } from "./schemas.js";
 

--- a/src/lib/lint-skills.ts
+++ b/src/lib/lint-skills.ts
@@ -49,7 +49,8 @@ async function lintSkillDirectory(
 
   try {
     await stat(skillFile);
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     return [
       {
         skill: directoryName,
@@ -61,7 +62,20 @@ async function lintSkillDirectory(
     ];
   }
 
-  const source = await readFile(skillFile, "utf8");
+  let source: string;
+  try {
+    source = await readFile(skillFile, "utf8");
+  } catch {
+    return [
+      {
+        skill: directoryName,
+        file: relativeFile,
+        severity: "error",
+        rule: "skill-md-required",
+        message: "SKILL.md could not be read.",
+      },
+    ];
+  }
   return lintSkillSource({
     directoryName,
     relativeFile,

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -15,6 +15,7 @@ const skillFrontmatterSchema = z.object({
   "allowed-tools": z
     .union([z.array(z.string().min(1)), z.string().min(1)])
     .optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 const commandFrontmatterSchema = z.object({

--- a/tests/lint-skills.test.ts
+++ b/tests/lint-skills.test.ts
@@ -105,6 +105,17 @@ describe("lintSkillSource", () => {
     expect(warning?.severity).toBe("warning");
   });
 
+  it("flags scalar frontmatter with the <frontmatter> path label", () => {
+    const issues = lintSkillSource({
+      directoryName: "scalar",
+      relativeFile: "scalar/SKILL.md",
+      source: `---\n42\n---\n${validBody}`,
+    });
+    expect(
+      issues.some((entry) => entry.rule === "frontmatter:<frontmatter>"),
+    ).toBe(true);
+  });
+
   it("returns a parse error when frontmatter markers are missing", () => {
     const issues = lintSkillSource({
       directoryName: "broken",
@@ -156,6 +167,12 @@ describe("lintSkillsDirectory", () => {
     expect(report.scanned).toBe(1);
     expect(report.issues).toEqual([]);
     expect(hasErrors(report)).toBe(false);
+  });
+
+  it("formatLintReport reports a clean run when issues are empty", () => {
+    const text = formatLintReport({ scanned: 1, issues: [] });
+    expect(text).toContain("1 skill scanned");
+    expect(text).toContain("No issues found.");
   });
 
   it("formatLintReport summarizes counts", () => {

--- a/tests/lint-skills.test.ts
+++ b/tests/lint-skills.test.ts
@@ -154,6 +154,21 @@ describe("lintSkillsDirectory", () => {
     expect(hasErrors(report)).toBe(true);
   });
 
+  it("reports skill-md-required when SKILL.md is unreadable", async () => {
+    const skillsRoot = await createSkillsRoot();
+    await mkdir(path.join(skillsRoot, "unreadable-skill", "SKILL.md"), {
+      recursive: true,
+    });
+
+    const report = await lintSkillsDirectory(skillsRoot);
+
+    expect(report.scanned).toBe(1);
+    expect(report.issues).toHaveLength(1);
+    expect(report.issues[0]?.rule).toBe("skill-md-required");
+    expect(report.issues[0]?.message).toBe("SKILL.md could not be read.");
+    expect(hasErrors(report)).toBe(true);
+  });
+
   it("returns a clean report when all skills validate", async () => {
     const skillsRoot = await createSkillsRoot();
     await writeSkill(

--- a/tests/lint-skills.test.ts
+++ b/tests/lint-skills.test.ts
@@ -1,0 +1,186 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  formatLintReport,
+  hasErrors,
+  lintSkillSource,
+  lintSkillsDirectory,
+} from "../src/lib/lint-skills.js";
+
+const createdDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    createdDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function createSkillsRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "cheese-lint-"));
+  createdDirectories.push(root);
+  return root;
+}
+
+async function writeSkill(
+  skillsRoot: string,
+  directoryName: string,
+  contents: string,
+): Promise<void> {
+  const directory = path.join(skillsRoot, directoryName);
+  await mkdir(directory, { recursive: true });
+  await writeFile(path.join(directory, "SKILL.md"), contents, "utf8");
+}
+
+const validBody = "# Skill body\n\nUse this skill to do a thing.\n";
+
+describe("lintSkillSource", () => {
+  it("accepts a valid skill", () => {
+    const issues = lintSkillSource({
+      directoryName: "valid-skill",
+      relativeFile: "valid-skill/SKILL.md",
+      source: `---\nname: valid-skill\ndescription: Performs a clearly described action when the user asks for it.\n---\n${validBody}`,
+    });
+    expect(issues).toEqual([]);
+  });
+
+  it("flags name/directory mismatch as an error", () => {
+    const issues = lintSkillSource({
+      directoryName: "real-name",
+      relativeFile: "real-name/SKILL.md",
+      source: `---\nname: other-name\ndescription: Performs a clearly described action when the user asks for it.\n---\n${validBody}`,
+    });
+    const rules = issues.map((entry) => entry.rule);
+    expect(rules).toContain("name-matches-directory");
+    expect(
+      issues.find((entry) => entry.rule === "name-matches-directory")?.severity,
+    ).toBe("error");
+  });
+
+  it("flags invalid kebab-case names", () => {
+    const issues = lintSkillSource({
+      directoryName: "BadName",
+      relativeFile: "BadName/SKILL.md",
+      source: `---\nname: BadName\ndescription: Performs a clearly described action when the user asks for it.\n---\n${validBody}`,
+    });
+    expect(
+      issues.some((entry) => entry.rule.startsWith("frontmatter:name")),
+    ).toBe(true);
+  });
+
+  it("flags missing description", () => {
+    const issues = lintSkillSource({
+      directoryName: "no-desc",
+      relativeFile: "no-desc/SKILL.md",
+      source: `---\nname: no-desc\n---\n${validBody}`,
+    });
+    expect(
+      issues.some((entry) => entry.rule.startsWith("frontmatter:description")),
+    ).toBe(true);
+  });
+
+  it("warns when the description is too short", () => {
+    const issues = lintSkillSource({
+      directoryName: "short-desc",
+      relativeFile: "short-desc/SKILL.md",
+      source: `---\nname: short-desc\ndescription: Too short.\n---\n${validBody}`,
+    });
+    const warning = issues.find(
+      (entry) => entry.rule === "description-too-short",
+    );
+    expect(warning?.severity).toBe("warning");
+  });
+
+  it("warns when the body exceeds the recommended line limit", () => {
+    const longBody = `${"line\n".repeat(600)}`;
+    const issues = lintSkillSource({
+      directoryName: "long-body",
+      relativeFile: "long-body/SKILL.md",
+      source: `---\nname: long-body\ndescription: A perfectly fine description that is long enough for discovery.\n---\n${longBody}`,
+    });
+    const warning = issues.find((entry) => entry.rule === "body-too-long");
+    expect(warning?.severity).toBe("warning");
+  });
+
+  it("returns a parse error when frontmatter markers are missing", () => {
+    const issues = lintSkillSource({
+      directoryName: "broken",
+      relativeFile: "broken/SKILL.md",
+      source: "no frontmatter here\n",
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.rule).toBe("frontmatter-parse");
+    expect(issues[0]?.severity).toBe("error");
+  });
+
+  it("flags compatibility strings exceeding 500 characters", () => {
+    const issues = lintSkillSource({
+      directoryName: "wide-compat",
+      relativeFile: "wide-compat/SKILL.md",
+      source: `---\nname: wide-compat\ndescription: A perfectly fine description that is long enough for discovery.\ncompatibility: ${"x".repeat(600)}\n---\n${validBody}`,
+    });
+    expect(
+      issues.some((entry) =>
+        entry.rule.startsWith("frontmatter:compatibility"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("lintSkillsDirectory", () => {
+  it("reports SKILL.md is required when missing", async () => {
+    const skillsRoot = await createSkillsRoot();
+    await mkdir(path.join(skillsRoot, "empty-skill"), { recursive: true });
+
+    const report = await lintSkillsDirectory(skillsRoot);
+
+    expect(report.scanned).toBe(1);
+    expect(report.issues).toHaveLength(1);
+    expect(report.issues[0]?.rule).toBe("skill-md-required");
+    expect(hasErrors(report)).toBe(true);
+  });
+
+  it("returns a clean report when all skills validate", async () => {
+    const skillsRoot = await createSkillsRoot();
+    await writeSkill(
+      skillsRoot,
+      "good-skill",
+      `---\nname: good-skill\ndescription: A perfectly fine description that is long enough for discovery.\n---\n${validBody}`,
+    );
+
+    const report = await lintSkillsDirectory(skillsRoot);
+
+    expect(report.scanned).toBe(1);
+    expect(report.issues).toEqual([]);
+    expect(hasErrors(report)).toBe(false);
+  });
+
+  it("formatLintReport summarizes counts", () => {
+    const text = formatLintReport({
+      scanned: 2,
+      issues: [
+        {
+          skill: "a",
+          file: "a/SKILL.md",
+          severity: "error",
+          rule: "frontmatter:name",
+          message: "bad",
+        },
+        {
+          skill: "b",
+          file: "b/SKILL.md",
+          severity: "warning",
+          rule: "body-too-long",
+          message: "long",
+        },
+      ],
+    });
+    expect(text).toContain("2 skills scanned");
+    expect(text).toContain("[ERROR]");
+    expect(text).toContain("[WARN]");
+    expect(text).toContain("1 error(s), 1 warning(s)");
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive skill linting infrastructure to validate skills against the Agent Skills format specification. This includes:

- **Skill linting engine** (`src/lib/lint-skills.ts`) — validates skills against required format
- **Schema definitions** (`src/lib/schemas.ts`) — updated with comprehensive validation rules
- **Full test coverage** (`tests/lint-skills.test.ts`) — comprehensive test suite
- **Integration** — linting logic added to main build pipeline

## Changes

- Added `src/lib/lint-skills.ts` with core linting logic
- Added `tests/lint-skills.test.ts` with comprehensive test coverage
- Updated `src/lib/schemas.ts` with skill format validation
- Updated `src/index.ts` to export linting functions
- Updated `package.json` with linting dependency
- Updated `skills/README.md` with linting guidelines
- Updated `justfile` with lint targets

## Test Plan

- [x] Unit tests pass for skill validation
- [x] Linting catches missing required fields
- [x] Linting validates skill metadata format
- [x] All test cases pass (SKILL.md required, proper structure, metadata validation)
