### PR TITLE
chore(build): expand justfile recipes and add AGENTS.md/CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 **Run `just build` before opening any PR.** It must pass cleanly.
 
 ```
-just build   # lint-fix -> typecheck -> build -> tests -> coverage (autofixes lint)
+just build   # full autofix + build + coverage + Python checks/tests
 ```
 
 If `just build` is red, do not open a PR. Fix failing tests or coverage gaps first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# cheese-flow — Agent Instructions
+
+## Build Gate
+
+**Run `just build` before opening any PR.** It must pass cleanly.
+
+```
+just build   # lint-fix -> typecheck -> build -> tests -> coverage (autofixes lint)
+```
+
+If `just build` is red, do not open a PR. Fix failing tests or coverage gaps first.
+Lint and format errors are auto-fixed by `just build` — re-run after if files changed.
+
+## Recipes
+
+```bash
+just install     # Install all dependencies (npm + uv)
+just build       # Full pipeline with autofix — use this before every PR
+just build-ci    # Full pipeline no autofix — CI uses this
+just test        # Run vitest (passthrough: just test -t pattern)
+just test-py     # Run pytest (passthrough: just test-py -k pattern)
+just clean       # Remove build artifacts and caches
+```
+
+For anything else, call the underlying tool directly (`npx tsx src/index.ts ...`, `npm run <script>`, `uv run ...`).
+
+## Project Overview
+
+cheese-flow is opinionated scaffolding for portable agents and skills that compile into harness-specific markdown bundles (Claude Code, Codex, Cursor, Copilot CLI).
+
+- **Entry points**: `cheese` CLI (`src/index.ts`), milknado Python TUI (`python/`)
+- **Architecture**: Sliced Bread — vertical slices under `src/lib/` and `src/adapters/`
+- **Templates**: Eta-rendered `agents/*.md.eta` and `skills/*/SKILL.md`
+- **Tests**: `tests/` (vitest, coverage thresholds in `vitest.config.ts`) and `tests/python/` (pytest)
+
+## Code Style
+
+- TypeScript (Node 22+), formatted with Biome (`biome.json`)
+- Python 3.11+, formatted with ruff (line length 100)
+- Max function: 40 lines, max file: 300 lines, max params: 4
+- camelCase functions (TS) / snake_case (Python), PascalCase classes, SCREAMING_SNAKE_CASE constants, kebab-case files
+
+## Engineering Principles
+
+1. Trust nothing from external sources (validate at boundaries — Zod for TS object safety)
+2. Fail fast and loud — no silent failures
+3. Separate business logic from infrastructure
+4. YAGNI — only what's needed now
+5. Name things after business concepts, not technical abstractions
+6. Minimize state mutation
+
+## No Migration Code
+
+This project is pre-release. Do not add migration backfills, deprecation shims, or compatibility layers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# cheese-flow
+
+See [AGENTS.md](AGENTS.md) for full development instructions.
+
+**Run `just build` before opening any PR.**

--- a/justfile
+++ b/justfile
@@ -1,7 +1,18 @@
 set shell := ["bash", "-c", "set -euo pipefail; if r=$(rtk rewrite \"$0\" 2>/dev/null); then eval \"$r\"; else eval \"$0\"; fi"]
+set dotenv-load := true
 
+# Show all available recipes
+default:
+    @just --list
+
+# Install all dependencies (npm + uv)
+install:
+    npm install
+    uv sync
+
+# Full build with autofix: format -> lint -> typecheck -> build -> tests (for devs before PRs)
 build:
-    rm -rf dist coverage .claude .codex
+    rm -rf dist coverage .claude .codex .cursor .copilot
     npm install
     npm run format
     npm run lint:fix
@@ -11,9 +22,11 @@ build:
     uv run --group dev ruff format
     uv run --group dev ruff check --fix
     uv run --group dev pytest
+    @echo "Build passed - ready for PR"
 
+# Full build no autofix: format check -> lint check -> typecheck -> build -> tests (for CI)
 build-ci:
-    rm -rf dist coverage .claude .codex
+    rm -rf dist coverage .claude .codex .cursor .copilot
     npm ci
     npm run format:check
     npm run lint:check
@@ -23,6 +36,19 @@ build-ci:
     uv run --group dev ruff format --check
     uv run --group dev ruff check
     uv run --group dev pytest
+    @echo "CI build passed"
 
-test-py:
-    uv run --group dev pytest
+# Run the TypeScript test suite (passes args through to vitest)
+test *args:
+    npm run test -- {{args}}
+
+# Run the Python test suite (passes args through to pytest)
+test-py *args:
+    uv run --group dev pytest {{args}}
+
+# Clean build artifacts and caches
+clean:
+    rm -rf dist coverage .claude .codex .cursor .copilot
+    rm -rf .pytest_cache .ruff_cache htmlcov .coverage node_modules/.cache
+    find . -type d -name __pycache__ -prune -exec rm -rf {} +
+    find . -type f -name "*.pyc" -delete

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 set shell := ["bash", "-c", "set -euo pipefail; if r=$(rtk rewrite \"$0\" 2>/dev/null); then eval \"$r\"; else eval \"$0\"; fi"]
-set dotenv-load := true
+set dotenv-load := false
 
 # Show all available recipes
 default:
@@ -8,7 +8,7 @@ default:
 # Install all dependencies (npm + uv)
 install:
     npm install
-    uv sync
+    uv sync --group dev
 
 # Full build with autofix: format -> lint -> typecheck -> build -> tests (for devs before PRs)
 build:


### PR DESCRIPTION
## Summary
- Expand `justfile` with `install`, `clean`, default `--list`, pass-through `test`/`test-py` recipes, and cleanup of `.cursor`/`.copilot` artifacts.
- Add `AGENTS.md` documenting the `just build` PR gate, recipes, code style, and engineering principles.
- Add a thin `CLAUDE.md` that points at `AGENTS.md`.

## Test plan
- [x] `just build` passes locally (lint, typecheck, vitest w/ coverage, ruff, pytest)