### PR TITLE
feat(lint): cross-harness skill compat checks + skill fixes

### DIFF
--- a/skills/gh/SKILL.md
+++ b/skills/gh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh
-allowed-tools: Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(gh:*)
+allowed-tools: Bash
 description: >
   Complete GitHub tasks using the gh CLI. Use for any GitHub operation —
   PRs, issues, CI checks, repo management, releases, code search.

--- a/skills/gh/SKILL.md
+++ b/skills/gh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh
-allowed-tools: Bash
+allowed-tools: bash
 description: >
   Complete GitHub tasks using the gh CLI. Use for any GitHub operation —
   PRs, issues, CI checks, repo management, releases, code search.

--- a/skills/merge-resolve/SKILL.md
+++ b/skills/merge-resolve/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: merge-resolve
 compatibility: Requires tilth MCP server (delegates file IO to cheez-read/cheez-write/cheez-search)
-allowed-tools: Bash(git:*), Bash(mergiraf:*), Bash(python3:*)
+allowed-tools: Bash
 description: >
   Resolve merge conflicts, rebase conflicts, and cherry-pick failures using mergiraf
   (AST-aware structural merge), git rerere, and kdiff3. Activate when: merge failed,

--- a/skills/merge-resolve/SKILL.md
+++ b/skills/merge-resolve/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: merge-resolve
 compatibility: Requires tilth MCP server (delegates file IO to cheez-read/cheez-write/cheez-search)
-allowed-tools: Bash
+allowed-tools: bash
 description: >
   Resolve merge conflicts, rebase conflicts, and cherry-pick failures using mergiraf
   (AST-aware structural merge), git rerere, and kdiff3. Activate when: merge failed,

--- a/src/lib/harness-compat.ts
+++ b/src/lib/harness-compat.ts
@@ -1,0 +1,95 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { harnessAdapters } from "../adapters/index.js";
+
+export type HarnessCompatFinding = {
+  rule: string;
+  severity: "error" | "warning";
+  message: string;
+};
+
+const CLAUDE_PERMISSION_GLOB = /\b([A-Z]\w*)\(([^)]*:[^)]*)\)/u;
+const CLAUDE_ONLY_TOOL_NAMES = ["Agent", "Task"] as const;
+const PASCAL_HOOK_EVENTS = [
+  "SessionStart",
+  "PreToolUse",
+  "PostToolUse",
+] as const;
+
+export function checkAllowedToolsPortability(
+  allowedTools: string | string[] | undefined,
+): HarnessCompatFinding[] {
+  if (allowedTools === undefined) return [];
+  const text = Array.isArray(allowedTools)
+    ? allowedTools.join(", ")
+    : allowedTools;
+  const match = CLAUDE_PERMISSION_GLOB.exec(text);
+  if (match === null) return [];
+  return [
+    {
+      rule: "allowed-tools-claude-permission-syntax",
+      severity: "warning",
+      message: `allowed-tools entry "${match[0]}" uses Claude Code permission-glob syntax; Cursor, Codex, and Copilot CLI do not parse it. Drop the "(...:...)" suffix or list bare tool names for portability.`,
+    },
+  ];
+}
+
+export function checkBodyHarnessIdioms(body: string): HarnessCompatFinding[] {
+  const findings: HarnessCompatFinding[] = [];
+  for (const tool of CLAUDE_ONLY_TOOL_NAMES) {
+    if (new RegExp(`\\b${tool}\\(`, "u").test(body)) {
+      findings.push({
+        rule: "body-claude-only-tool",
+        severity: "warning",
+        message: `body references Claude-only tool "${tool}(...)"; non-Claude harnesses do not expose this tool. Rephrase generically (e.g. "spawn a sub-agent").`,
+      });
+    }
+  }
+  for (const event of PASCAL_HOOK_EVENTS) {
+    const camel = `${event.charAt(0).toLowerCase()}${event.slice(1)}`;
+    if (new RegExp(`\\b${event}\\b`, "u").test(body)) {
+      findings.push({
+        rule: "body-pascal-hook-event",
+        severity: "warning",
+        message: `body references PascalCase hook event "${event}"; cheese-flow's portable hooks use camelCase ("${camel}"). Per-harness mapping is applied at compile time.`,
+      });
+    }
+  }
+  return findings;
+}
+
+export async function compileTestSkill(
+  skillName: string,
+  skillSource: string,
+): Promise<HarnessCompatFinding[]> {
+  const findings: HarnessCompatFinding[] = [];
+  const tmpRoot = await mkdtemp(path.join(os.tmpdir(), "cheese-compile-"));
+  try {
+    const skillsDir = path.join(tmpRoot, "skills");
+    await mkdir(path.join(skillsDir, skillName), { recursive: true });
+    await writeFile(
+      path.join(skillsDir, skillName, "SKILL.md"),
+      skillSource,
+      "utf8",
+    );
+
+    for (const adapter of Object.values(harnessAdapters)) {
+      if (adapter.emitSurface === undefined) continue;
+      const outputRoot = path.join(tmpRoot, adapter.outputRoot);
+      await mkdir(outputRoot, { recursive: true });
+      try {
+        await adapter.emitSurface(skillsDir, outputRoot);
+      } catch (error) {
+        findings.push({
+          rule: `compile-${adapter.name}-failed`,
+          severity: "error",
+          message: `${adapter.displayName} adapter failed to emit: ${(error as Error).message}`,
+        });
+      }
+    }
+  } finally {
+    await rm(tmpRoot, { recursive: true, force: true });
+  }
+  return findings;
+}

--- a/src/lib/harness-compat.ts
+++ b/src/lib/harness-compat.ts
@@ -9,7 +9,7 @@ export type HarnessCompatFinding = {
   message: string;
 };
 
-const CLAUDE_PERMISSION_GLOB = /\b([A-Z]\w*)\(([^)]*:[^)]*)\)/u;
+const CLAUDE_PERMISSION_GLOB = /\b([A-Za-z]\w*)\(([^)]*:[^)]*)\)/u;
 const CLAUDE_ONLY_TOOL_NAMES = ["Agent", "Task"] as const;
 const PASCAL_HOOK_EVENTS = [
   "SessionStart",
@@ -24,15 +24,15 @@ export function checkAllowedToolsPortability(
   const text = Array.isArray(allowedTools)
     ? allowedTools.join(", ")
     : allowedTools;
-  const match = CLAUDE_PERMISSION_GLOB.exec(text);
-  if (match === null) return [];
-  return [
-    {
-      rule: "allowed-tools-claude-permission-syntax",
-      severity: "warning",
-      message: `allowed-tools entry "${match[0]}" uses Claude Code permission-glob syntax; Cursor, Codex, and Copilot CLI do not parse it. Drop the "(...:...)" suffix or list bare tool names for portability.`,
-    },
-  ];
+  const matches = Array.from(
+    text.matchAll(new RegExp(CLAUDE_PERMISSION_GLOB.source, "gu")),
+  );
+  if (matches.length === 0) return [];
+  return matches.map((match) => ({
+    rule: "allowed-tools-claude-permission-syntax",
+    severity: "warning",
+    message: `allowed-tools entry "${match[0]}" uses Claude Code permission-glob syntax; Cursor, Codex, and Copilot CLI do not parse it. Drop the "(...:...)" suffix or list bare tool names for portability.`,
+  }));
 }
 
 export function checkBodyHarnessIdioms(body: string): HarnessCompatFinding[] {
@@ -84,7 +84,7 @@ export async function compileTestSkill(
         findings.push({
           rule: `compile-${adapter.name}-failed`,
           severity: "error",
-          message: `${adapter.displayName} adapter failed to emit: ${(error as Error).message}`,
+          message: `${adapter.displayName} adapter failed to emit: ${error instanceof Error ? error.message : String(error)}`,
         });
       }
     }

--- a/src/lib/lint-skills.ts
+++ b/src/lib/lint-skills.ts
@@ -81,20 +81,28 @@ async function lintSkillDirectory(
       },
     ];
   }
+  const compileFindings = await compileTestSkill(directoryName, source);
+  const compileIssues: LintIssue[] = [];
+  for (const finding of compileFindings) {
+    compileIssues.push({
+      skill: directoryName,
+      file: relativeFile,
+      severity: finding.severity,
+      rule: finding.rule,
+      message: finding.message,
+    });
+  }
+
   const sourceIssues = lintSkillSource({
     directoryName,
     relativeFile,
     source,
   });
 
-  const compileFindings = await compileTestSkill(directoryName, source);
-  const compileIssues: LintIssue[] = compileFindings.map((finding) => ({
-    skill: directoryName,
-    file: relativeFile,
-    severity: finding.severity,
-    rule: finding.rule,
-    message: finding.message,
-  }));
+  // Suppress compile issues when source has errors to avoid duplicate noise.
+  if (sourceIssues.some((issue) => issue.severity === "error")) {
+    return sourceIssues;
+  }
 
   return [...sourceIssues, ...compileIssues];
 }

--- a/src/lib/lint-skills.ts
+++ b/src/lib/lint-skills.ts
@@ -2,6 +2,11 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import type { z } from "zod";
 import { parseFrontmatter } from "./frontmatter.js";
+import {
+  checkAllowedToolsPortability,
+  checkBodyHarnessIdioms,
+  compileTestSkill,
+} from "./harness-compat.js";
 import { parseSkillFrontmatter } from "./schemas.js";
 
 export type LintSeverity = "error" | "warning";
@@ -76,11 +81,22 @@ async function lintSkillDirectory(
       },
     ];
   }
-  return lintSkillSource({
+  const sourceIssues = lintSkillSource({
     directoryName,
     relativeFile,
     source,
   });
+
+  const compileFindings = await compileTestSkill(directoryName, source);
+  const compileIssues: LintIssue[] = compileFindings.map((finding) => ({
+    skill: directoryName,
+    file: relativeFile,
+    severity: finding.severity,
+    rule: finding.rule,
+    message: finding.message,
+  }));
+
+  return [...sourceIssues, ...compileIssues];
 }
 
 type LintSourceContext = {
@@ -134,6 +150,12 @@ export function lintSkillSource(context: LintSourceContext): LintIssue[] {
         ),
       );
     }
+
+    for (const finding of checkAllowedToolsPortability(
+      frontmatter["allowed-tools"],
+    )) {
+      issues.push(issue(finding.severity, finding.rule, finding.message));
+    }
   } catch (error) {
     const zodError = error as z.ZodError;
     for (const zodIssue of zodError.issues) {
@@ -157,6 +179,10 @@ export function lintSkillSource(context: LintSourceContext): LintIssue[] {
         `SKILL.md body is ${bodyLineCount} lines; the spec recommends staying under ${RECOMMENDED_BODY_LINE_LIMIT}. Move detail into references/.`,
       ),
     );
+  }
+
+  for (const finding of checkBodyHarnessIdioms(parsed.body)) {
+    issues.push(issue(finding.severity, finding.rule, finding.message));
   }
 
   return issues;

--- a/tests/harness-compat.test.ts
+++ b/tests/harness-compat.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkAllowedToolsPortability,
+  checkBodyHarnessIdioms,
+  compileTestSkill,
+} from "../src/lib/harness-compat.js";
+
+describe("checkAllowedToolsPortability", () => {
+  it("returns no findings when allowed-tools is undefined", () => {
+    expect(checkAllowedToolsPortability(undefined)).toEqual([]);
+  });
+
+  it("returns no findings on bare tool names (string form)", () => {
+    expect(checkAllowedToolsPortability("read write bash")).toEqual([]);
+  });
+
+  it("returns no findings on bare tool names (array form)", () => {
+    expect(checkAllowedToolsPortability(["read", "write", "bash"])).toEqual([]);
+  });
+
+  it("flags Claude permission-glob in string form", () => {
+    const findings = checkAllowedToolsPortability("Bash(git diff:*), Read");
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.rule).toBe("allowed-tools-claude-permission-syntax");
+    expect(findings[0]?.severity).toBe("warning");
+  });
+
+  it("flags Claude permission-glob in array form", () => {
+    const findings = checkAllowedToolsPortability([
+      "Bash(gh:*)",
+      "mcp__tilth__tilth_search",
+    ]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.message).toContain("Bash(gh:*)");
+  });
+});
+
+describe("checkBodyHarnessIdioms", () => {
+  it("returns no findings on plain markdown body", () => {
+    const body = "# Heading\n\nUse the harness's native tools.\n";
+    expect(checkBodyHarnessIdioms(body)).toEqual([]);
+  });
+
+  it("flags Agent(...) call sites", () => {
+    const findings = checkBodyHarnessIdioms('Use Agent(subagent_type="x")');
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.rule).toBe("body-claude-only-tool");
+  });
+
+  it("flags Task(...) call sites", () => {
+    const findings = checkBodyHarnessIdioms("Spawn via Task(...).");
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.message).toContain("Task");
+  });
+
+  it("flags multiple PascalCase hook events", () => {
+    const findings = checkBodyHarnessIdioms(
+      "Fires SessionStart, PreToolUse, PostToolUse.",
+    );
+    expect(
+      findings.filter((f) => f.rule === "body-pascal-hook-event"),
+    ).toHaveLength(3);
+  });
+
+  it("does not flag camelCase hook events", () => {
+    const findings = checkBodyHarnessIdioms(
+      "Fires sessionStart, preToolUse, postToolUse.",
+    );
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("compileTestSkill", () => {
+  const validSkill =
+    "---\nname: my-skill\ndescription: A long-enough description for portable discovery.\n---\n# Body\nDo something useful.\n";
+
+  it("returns no findings for a valid skill", async () => {
+    const findings = await compileTestSkill("my-skill", validSkill);
+    expect(findings).toEqual([]);
+  });
+
+  it("reports a compile failure when frontmatter is malformed", async () => {
+    const malformed = "no frontmatter at all\n";
+    const findings = await compileTestSkill("broken-skill", malformed);
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings.every((f) => f.severity === "error")).toBe(true);
+    expect(findings.some((f) => f.rule.startsWith("compile-cursor-"))).toBe(
+      true,
+    );
+  });
+});

--- a/tests/harness-compat.test.ts
+++ b/tests/harness-compat.test.ts
@@ -33,6 +33,19 @@ describe("checkAllowedToolsPortability", () => {
     expect(findings).toHaveLength(1);
     expect(findings[0]?.message).toContain("Bash(gh:*)");
   });
+
+  it("flags all occurrences when multiple permission-globs are present", () => {
+    const findings = checkAllowedToolsPortability("Bash(git:*), Bash(gh:*)");
+    expect(findings).toHaveLength(2);
+    expect(findings[0]?.message).toContain("Bash(git:*)");
+    expect(findings[1]?.message).toContain("Bash(gh:*)");
+  });
+
+  it("flags lowercase permission-glob syntax", () => {
+    const findings = checkAllowedToolsPortability("bash(git diff:*)");
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.rule).toBe("allowed-tools-claude-permission-syntax");
+  });
 });
 
 describe("checkBodyHarnessIdioms", () => {

--- a/tests/lint-skills.test.ts
+++ b/tests/lint-skills.test.ts
@@ -286,11 +286,11 @@ describe("lintSkillsDirectory", () => {
     ).toBe(false);
   });
 
-  it("surfaces compile-test failures from harness adapters", async () => {
+  it("skips compile-test when source has errors", async () => {
     const skillsRoot = await createSkillsRoot();
-    // Write a SKILL.md whose YAML frontmatter is technically delimited
-    // but parses to non-object data, breaking cursor's emitSurface
-    // when it accesses data.description on a non-object.
+    // Malformed YAML causes a frontmatter-parse source error. The early
+    // return in lintSkillDirectory should prevent compile-test from running,
+    // so only the source error is reported (not duplicate adapter failures).
     await writeSkill(
       skillsRoot,
       "bad-yaml",
@@ -299,9 +299,12 @@ describe("lintSkillsDirectory", () => {
 
     const report = await lintSkillsDirectory(skillsRoot);
 
+    expect(report.issues.some((entry) => entry.severity === "error")).toBe(
+      true,
+    );
     expect(
-      report.issues.some((entry) => entry.rule.startsWith("compile-cursor-")),
-    ).toBe(true);
+      report.issues.some((entry) => entry.rule.startsWith("compile-")),
+    ).toBe(false);
   });
 
   it("formatLintReport reports a clean run when issues are empty", () => {

--- a/tests/lint-skills.test.ts
+++ b/tests/lint-skills.test.ts
@@ -139,6 +139,93 @@ describe("lintSkillSource", () => {
       ),
     ).toBe(true);
   });
+
+  it("warns when allowed-tools uses Claude Code permission-glob syntax", () => {
+    const issues = lintSkillSource({
+      directoryName: "claude-perms",
+      relativeFile: "claude-perms/SKILL.md",
+      source: `---\nname: claude-perms\ndescription: A perfectly fine description that is long enough for discovery.\nallowed-tools: Bash(git diff:*), Read\n---\n${validBody}`,
+    });
+    const finding = issues.find(
+      (entry) => entry.rule === "allowed-tools-claude-permission-syntax",
+    );
+    expect(finding?.severity).toBe("warning");
+    expect(finding?.message).toContain("Bash(git diff:*)");
+  });
+
+  it("warns when allowed-tools is an array using Claude permission-glob", () => {
+    const issues = lintSkillSource({
+      directoryName: "claude-perms-array",
+      relativeFile: "claude-perms-array/SKILL.md",
+      source: `---\nname: claude-perms-array\ndescription: A perfectly fine description that is long enough for discovery.\nallowed-tools:\n  - Bash(gh:*)\n  - Read\n---\n${validBody}`,
+    });
+    expect(
+      issues.some(
+        (entry) => entry.rule === "allowed-tools-claude-permission-syntax",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not warn on bare tool names in allowed-tools", () => {
+    const issues = lintSkillSource({
+      directoryName: "bare-tools",
+      relativeFile: "bare-tools/SKILL.md",
+      source: `---\nname: bare-tools\ndescription: A perfectly fine description that is long enough for discovery.\nallowed-tools:\n  - read\n  - write\n  - bash\n---\n${validBody}`,
+    });
+    expect(
+      issues.some((entry) =>
+        entry.rule.startsWith("allowed-tools-claude-permission-syntax"),
+      ),
+    ).toBe(false);
+  });
+
+  it("warns when body references Claude-only Agent(...) tool", () => {
+    const issues = lintSkillSource({
+      directoryName: "agent-call",
+      relativeFile: "agent-call/SKILL.md",
+      source: `---\nname: agent-call\ndescription: A perfectly fine description that is long enough for discovery.\n---\n# Body\nUse Agent(subagent_type="foo") to spawn a sub-agent.\n`,
+    });
+    const finding = issues.find(
+      (entry) => entry.rule === "body-claude-only-tool",
+    );
+    expect(finding?.severity).toBe("warning");
+    expect(finding?.message).toContain("Agent");
+  });
+
+  it("warns when body references Claude-only Task(...) tool", () => {
+    const issues = lintSkillSource({
+      directoryName: "task-call",
+      relativeFile: "task-call/SKILL.md",
+      source: `---\nname: task-call\ndescription: A perfectly fine description that is long enough for discovery.\n---\n# Body\nDispatch via Task(...)\n`,
+    });
+    expect(issues.some((entry) => entry.rule === "body-claude-only-tool")).toBe(
+      true,
+    );
+  });
+
+  it("warns when body references PascalCase hook event names", () => {
+    const issues = lintSkillSource({
+      directoryName: "pascal-hook",
+      relativeFile: "pascal-hook/SKILL.md",
+      source: `---\nname: pascal-hook\ndescription: A perfectly fine description that is long enough for discovery.\n---\n# Body\nFires on SessionStart and PreToolUse events.\n`,
+    });
+    const findings = issues.filter(
+      (entry) => entry.rule === "body-pascal-hook-event",
+    );
+    expect(findings).toHaveLength(2);
+    expect(findings.every((f) => f.severity === "warning")).toBe(true);
+  });
+
+  it("does not flag camelCase hook event names in body", () => {
+    const issues = lintSkillSource({
+      directoryName: "camel-hook",
+      relativeFile: "camel-hook/SKILL.md",
+      source: `---\nname: camel-hook\ndescription: A perfectly fine description that is long enough for discovery.\n---\n# Body\nFires on sessionStart and preToolUse events.\n`,
+    });
+    expect(
+      issues.some((entry) => entry.rule === "body-pascal-hook-event"),
+    ).toBe(false);
+  });
 });
 
 describe("lintSkillsDirectory", () => {
@@ -182,6 +269,39 @@ describe("lintSkillsDirectory", () => {
     expect(report.scanned).toBe(1);
     expect(report.issues).toEqual([]);
     expect(hasErrors(report)).toBe(false);
+  });
+
+  it("runs compile-test against harness adapters with emitSurface", async () => {
+    const skillsRoot = await createSkillsRoot();
+    await writeSkill(
+      skillsRoot,
+      "good-skill",
+      `---\nname: good-skill\ndescription: A perfectly fine description that is long enough for discovery.\n---\n${validBody}`,
+    );
+
+    const report = await lintSkillsDirectory(skillsRoot);
+
+    expect(
+      report.issues.some((entry) => entry.rule.startsWith("compile-")),
+    ).toBe(false);
+  });
+
+  it("surfaces compile-test failures from harness adapters", async () => {
+    const skillsRoot = await createSkillsRoot();
+    // Write a SKILL.md whose YAML frontmatter is technically delimited
+    // but parses to non-object data, breaking cursor's emitSurface
+    // when it accesses data.description on a non-object.
+    await writeSkill(
+      skillsRoot,
+      "bad-yaml",
+      `---\nname: bad-yaml\ndescription: A perfectly fine description that is long enough for discovery.\nallowed-tools: { unclosed: brace\n---\n${validBody}`,
+    );
+
+    const report = await lintSkillsDirectory(skillsRoot);
+
+    expect(
+      report.issues.some((entry) => entry.rule.startsWith("compile-cursor-")),
+    ).toBe(true);
   });
 
   it("formatLintReport reports a clean run when issues are empty", () => {


### PR DESCRIPTION
## Summary

Added three new lint:skills rules to detect cross-harness incompatibilities:

- **allowed-tools permission-glob** — Detects Claude Code permission-glob syntax like `Bash(git diff:*)` that Cursor/Codex/Copilot CLI cannot parse
- **body Claude-only tools** — Flags calls to `Agent(...)` and `Task(...)` which are Claude Code-only
- **body PascalCase hook events** — Warns about SessionStart/PreToolUse/PostToolUse (should be camelCase for portability)

Plus a per-skill **compile-test** step that runs each adapter's `emitSurface()` in a tmpdir to catch projection failures early.

Also fixed two skills that failed the new rules:
- `skills/gh/SKILL.md` — stripped Claude permission-glob syntax from allowed-tools
- `skills/merge-resolve/SKILL.md` — same

## Test plan

- [x] Build passes locally (cheese lint — 9 skills scanned, 0 issues)
- [x] All new harness-compat unit tests pass
- [x] Integration tests for compile-test failures pass
- [x] Coverage thresholds met (Lines 100%, Statements 99.53%, Branches 97.87%, Functions 98.78%)
