### PR TITLE
refactor(adapters): lift Claude-only knowledge into per-adapter capabilities

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -133,7 +133,15 @@ here than for agents:
 
 ## Portable Fields
 
-Portable fields should mean the same thing regardless of target harness:
+A field is portable when every harness adapter declares it in its `capabilities`
+block. Fields not declared by any adapter are implicitly portable — they are
+part of the universal source schema. Fields declared by only some adapters will
+be silently dropped at compile time for adapters that do not declare them; the
+`cheese lint` portability check surfaces a `frontmatter-portability` warning so
+authors know to re-state the constraint in the skill body if other harnesses
+also need to honor it.
+
+Universal (implicitly portable) skill fields:
 
 - `name` is the stable kebab-case skill identifier and must match the directory name.
 - `description` is the short human-readable purpose.
@@ -143,16 +151,22 @@ Portable fields should mean the same thing regardless of target harness:
   names (`Bash`, `Read`) for portability — Claude Code's permission-glob syntax
   (`Bash(git diff:*)`) is not parsed by Cursor, Codex, or Copilot CLI.
 - `metadata` carries repository-owned details that may not be emitted everywhere.
-- `model` is an optional model hint (e.g. `opus`, `haiku`); each adapter resolves
-  it to a concrete identifier or drops it.
-- `context` is `fork` or `inline`. **`fork` is a Claude Code-only hint** that
-  asks the host to run the skill in a forked sub-agent context (Claude Code's
-  `Agent` tool). Codex, Cursor, and Copilot CLI ignore the field and run the
-  skill body inline, so the body must still produce useful output without the
-  fork. Default behavior when the field is absent is `inline`.
 
-Adapters may preserve, transform, or omit these fields depending on the target
-harness.
+Currently declared only by the `claude-code` adapter (will trigger a
+`frontmatter-portability` warning on other harnesses):
+
+- `model` — an optional model hint (e.g. `opus`, `haiku`); each adapter resolves
+  it to a concrete identifier or drops it.
+- `context` — `fork` or `inline`. `fork` asks the host to run the skill in a
+  forked sub-agent context (Claude Code's `Agent` tool). Codex, Cursor, and
+  Copilot CLI run the skill body inline regardless, so the body must still
+  produce useful output without the fork. `inline` is the portable default and
+  does not trigger a warning.
+
+Adapters may preserve, transform, or omit fields depending on the target
+harness. Adding a new adapter that supports `model` or `context` means editing
+that adapter's `capabilities` declaration — no changes to the schema or lint
+constants needed.
 
 ## Agent Portable Fields
 
@@ -166,19 +180,19 @@ per template; the frontmatter contract is:
 | `description` | yes | all | one-line summary surfaced in agent menus |
 | `models` | yes | all (resolved) | per-harness identifiers; `default` is the fallback |
 | `tools` | optional (defaults to `[]`) | all | bare tool names; permission-glob syntax is Claude-Code-only |
-| `skills` | optional | **Claude Code only** | sub-agent skill bindings; non-Claude harnesses ignore the field |
-| `color` | optional | **Claude Code only** | UI hint for `/agents` listings; ignored elsewhere |
-| `effort` | optional (`low` / `medium` / `high`) | **Claude Code only** | run-budget hint; ignored elsewhere |
-| `disallowedTools` | optional | **Claude Code only** | structural block-list; non-Claude harnesses fall back to the prompt contract |
-| `permissionMode` | optional (`plan` / `acceptEdits` / `default`) | **Claude Code only** | dispatch-time permission hint |
+| `skills` | optional | `claude-code` adapter only | sub-agent skill bindings; non-Claude harnesses ignore the field |
+| `color` | optional | `claude-code` adapter only | UI hint for `/agents` listings; ignored elsewhere |
+| `effort` | optional (`low` / `medium` / `high`) | `claude-code` adapter only | run-budget hint; ignored elsewhere |
+| `disallowedTools` | optional | `claude-code` adapter only | structural block-list; non-Claude harnesses fall back to the prompt contract |
+| `permissionMode` | optional (`plan` / `acceptEdits` / `default`) | `claude-code` adapter only | dispatch-time permission hint |
 | `metadata` | optional | repository-only | not emitted to any harness; useful for CI/lint analytics |
 
-Fields marked **Claude Code only** are accepted and validated portably so the
-source can stay in one place, but they will be dropped at compile time for
-Codex, Cursor, and Copilot CLI. The `cheese lint` portability checks surface a
-`frontmatter-claude-only-field` warning when an author sets one, so the
-constraint must be re-stated in the prompt body if non-Claude harnesses also
-need to honor it.
+Fields listed as "`claude-code` adapter only" are currently declared in
+`src/adapters/claude-code.ts`'s `capabilities.agentFrontmatterKeys`. The
+`cheese lint` portability check surfaces a `frontmatter-portability` warning
+when an author sets one of these fields; the constraint must be re-stated in the
+prompt body if non-Claude harnesses also need to honor it. Adding adapter support
+for a field means editing the relevant adapter's `capabilities` declaration.
 
 ## Harness Overrides
 

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -17,4 +17,33 @@ export const claudeCodeAdapter: HarnessAdapter = {
   buildManifest: buildBaseManifest,
   mcpFileName: ".mcp.json",
   buildHookConfig: (portable) => ({ hooks: camelCaseHooks(portable) }),
+  capabilities: {
+    skillFrontmatterKeys: new Set(["model", "context"]),
+    agentFrontmatterKeys: new Set([
+      "skills",
+      "color",
+      "effort",
+      "disallowedTools",
+      "permissionMode",
+    ]),
+    hookEvents: new Set([
+      "sessionStart",
+      "sessionEnd",
+      "preToolUse",
+      "postToolUse",
+      "stop",
+      "subagentStop",
+      "notification",
+      "preCompact",
+      "userPromptSubmit",
+    ]),
+    toolNames: new Set([
+      "Agent",
+      "Task",
+      "NotebookEdit",
+      "WebSearch",
+      "WebFetch",
+      "TodoWrite",
+    ]),
+  },
 };

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -17,4 +17,10 @@ export const codexAdapter: HarnessAdapter = {
   buildManifest: buildBaseManifest,
   mcpFileName: ".mcp.json",
   buildHookConfig: (portable) => ({ hooks: pascalMatcherHooks(portable) }),
+  capabilities: {
+    skillFrontmatterKeys: new Set<string>(),
+    agentFrontmatterKeys: new Set<string>(),
+    hookEvents: new Set(["sessionStart", "preToolUse", "postToolUse"]),
+    toolNames: new Set<string>(),
+  },
 };

--- a/src/adapters/copilot-cli.ts
+++ b/src/adapters/copilot-cli.ts
@@ -28,4 +28,10 @@ export const copilotCliAdapter: HarnessAdapter = {
     version: 1,
     hooks: camelCaseHooks(portable),
   }),
+  capabilities: {
+    skillFrontmatterKeys: new Set<string>(),
+    agentFrontmatterKeys: new Set<string>(),
+    hookEvents: new Set(["sessionStart", "preToolUse", "postToolUse"]),
+    toolNames: new Set<string>(),
+  },
 };

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -102,4 +102,10 @@ export const cursorAdapter: HarnessAdapter = {
   mcpFileName: "mcp.json",
   buildHookConfig: () => null,
   emitSurface: emitCursorSkillSurface,
+  capabilities: {
+    skillFrontmatterKeys: new Set<string>(),
+    agentFrontmatterKeys: new Set<string>(),
+    hookEvents: new Set<string>(),
+    toolNames: new Set<string>(),
+  },
 };

--- a/src/domain/harness.ts
+++ b/src/domain/harness.ts
@@ -71,6 +71,13 @@ export type SurfaceEmissionResult = {
   commands: string[];
 };
 
+export type HarnessCapabilities = {
+  skillFrontmatterKeys: ReadonlySet<string>;
+  agentFrontmatterKeys: ReadonlySet<string>;
+  hookEvents: ReadonlySet<string>;
+  toolNames: ReadonlySet<string>;
+};
+
 export interface HarnessAdapter {
   name: HarnessName;
   displayName: string;
@@ -92,4 +99,6 @@ export interface HarnessAdapter {
     skillsDir: string,
     outputRoot: string,
   ) => Promise<SurfaceEmissionResult>;
+
+  capabilities: HarnessCapabilities;
 }

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -1,0 +1,50 @@
+import { harnessAdapters } from "../adapters/index.js";
+import type { HarnessName } from "../domain/harness.js";
+
+export function fieldSupport(
+  kind: "skill" | "agent",
+): Map<string, HarnessName[]> {
+  const result = new Map<string, HarnessName[]>();
+  for (const [name, adapter] of Object.entries(harnessAdapters) as Array<
+    [HarnessName, (typeof harnessAdapters)[HarnessName]]
+  >) {
+    const keys =
+      kind === "skill"
+        ? adapter.capabilities.skillFrontmatterKeys
+        : adapter.capabilities.agentFrontmatterKeys;
+    for (const key of keys) {
+      const existing = result.get(key) ?? [];
+      existing.push(name);
+      result.set(key, existing);
+    }
+  }
+  return result;
+}
+
+export function eventSupport(): Map<string, HarnessName[]> {
+  const result = new Map<string, HarnessName[]>();
+  for (const [name, adapter] of Object.entries(harnessAdapters) as Array<
+    [HarnessName, (typeof harnessAdapters)[HarnessName]]
+  >) {
+    for (const event of adapter.capabilities.hookEvents) {
+      const existing = result.get(event) ?? [];
+      existing.push(name);
+      result.set(event, existing);
+    }
+  }
+  return result;
+}
+
+export function toolSupport(): Map<string, HarnessName[]> {
+  const result = new Map<string, HarnessName[]>();
+  for (const [name, adapter] of Object.entries(harnessAdapters) as Array<
+    [HarnessName, (typeof harnessAdapters)[HarnessName]]
+  >) {
+    for (const tool of adapter.capabilities.toolNames) {
+      const existing = result.get(tool) ?? [];
+      existing.push(name);
+      result.set(tool, existing);
+    }
+  }
+  return result;
+}

--- a/src/lib/harness-compat.ts
+++ b/src/lib/harness-compat.ts
@@ -10,13 +10,10 @@ import {
 import os from "node:os";
 import path from "node:path";
 import { harnessAdapters } from "../adapters/index.js";
-import type { HarnessAdapter } from "../domain/harness.js";
+import type { HarnessAdapter, HarnessName } from "../domain/harness.js";
+import { eventSupport, fieldSupport, toolSupport } from "./capabilities.js";
 import { parseFrontmatter } from "./frontmatter.js";
-import {
-  CLAUDE_ONLY_AGENT_KEYS,
-  CLAUDE_ONLY_SKILL_KEYS,
-  parseSkillFrontmatter,
-} from "./schemas.js";
+import { parseSkillFrontmatter } from "./schemas.js";
 
 export type HarnessCompatFinding = {
   rule: string;
@@ -26,27 +23,6 @@ export type HarnessCompatFinding = {
 };
 
 const CLAUDE_PERMISSION_GLOB = /\b([A-Za-z]\w*)\(([^)]*:[^)]*)\)/u;
-
-const CLAUDE_ONLY_TOOL_NAMES = [
-  "Agent",
-  "Task",
-  "NotebookEdit",
-  "WebSearch",
-  "WebFetch",
-  "TodoWrite",
-] as const;
-
-const PASCAL_HOOK_EVENTS = [
-  "SessionStart",
-  "SessionEnd",
-  "PreToolUse",
-  "PostToolUse",
-  "Stop",
-  "SubagentStop",
-  "Notification",
-  "PreCompact",
-  "UserPromptSubmit",
-] as const;
 
 const HARNESS_PATH_MARKERS = [
   ".claude/",
@@ -58,18 +34,8 @@ const HARNESS_PATH_MARKERS = [
   "copilot-instructions.md",
 ] as const;
 
-export function checkContextPortability(
-  context: string | undefined,
-): HarnessCompatFinding[] {
-  if (context !== "fork") return [];
-  return [
-    {
-      rule: "context-fork-claude-only",
-      severity: "warning",
-      message:
-        "context: fork is a Claude Code-only hint (forked subagent context). Codex, Cursor, and Copilot CLI ignore it — the skill body must still work when run inline. Document the fallback or set context: inline for harness-portable skills.",
-    },
-  ];
+function displayName(harness: HarnessName): string {
+  return harnessAdapters[harness].displayName;
 }
 
 export function checkAllowedToolsPortability(
@@ -90,20 +56,26 @@ export function checkAllowedToolsPortability(
   }));
 }
 
-export function checkClaudeOnlyFields(
+export function checkFrontmatterPortability(
   frontmatter: Record<string, unknown>,
   kind: "skill" | "agent",
 ): HarnessCompatFinding[] {
-  const claudeOnlyKeys =
-    kind === "skill" ? CLAUDE_ONLY_SKILL_KEYS : CLAUDE_ONLY_AGENT_KEYS;
+  const support = fieldSupport(kind);
+  const allAdapters = Object.keys(harnessAdapters) as HarnessName[];
   const findings: HarnessCompatFinding[] = [];
-  for (const key of claudeOnlyKeys) {
+
+  for (const [key, supportedBy] of support) {
     if (frontmatter[key] === undefined) continue;
+    if (supportedBy.length === allAdapters.length) continue;
     if (key === "context" && frontmatter[key] === "inline") continue;
+
+    const unsupported = allAdapters.filter((n) => !supportedBy.includes(n));
+    const supportedNames = supportedBy.map(displayName).join(", ");
+    const unsupportedNames = unsupported.map(displayName).join(", ");
     findings.push({
-      rule: `frontmatter-claude-only-field`,
+      rule: "frontmatter-portability",
       severity: "warning",
-      message: `frontmatter field "${key}" is Claude Code-only and is dropped by Codex, Cursor, and Copilot CLI. Move the constraint into the body, or accept that non-Claude harnesses will ignore it.`,
+      message: `frontmatter field "${key}" is supported only by ${supportedNames}; ${unsupportedNames} drop it. Move the constraint into the body, or accept the field will be ignored.`,
     });
   }
   return findings;
@@ -125,29 +97,56 @@ function findFirstMatchLine(body: string, pattern: RegExp): number | undefined {
 
 export function checkBodyHarnessIdioms(body: string): HarnessCompatFinding[] {
   const findings: HarnessCompatFinding[] = [];
+  const allAdapters = Object.keys(harnessAdapters) as HarnessName[];
+  const hookAdapterCount = allAdapters.filter(
+    (n) => harnessAdapters[n].capabilities.hookEvents.size > 0,
+  ).length;
 
-  for (const tool of CLAUDE_ONLY_TOOL_NAMES) {
+  const toolSupportMap = toolSupport();
+  for (const [tool, supportedBy] of toolSupportMap) {
     const pattern = new RegExp(`\\b${tool}\\(`, "u");
     const line = findFirstMatchLine(body, pattern);
-    if (line !== undefined) {
-      findings.push({
-        rule: "body-claude-only-tool",
-        severity: "warning",
-        message: `body references Claude-only tool "${tool}(...)"; non-Claude harnesses do not expose this tool. Rephrase generically (e.g. "spawn a sub-agent").`,
-        line,
-      });
+    if (line === undefined) continue;
+    const unsupported = allAdapters.filter((n) => !supportedBy.includes(n));
+    const unsupportedNames = unsupported.map(displayName).join(", ");
+    findings.push({
+      rule: "body-claude-only-tool",
+      severity: "warning",
+      message: `body references tool "${tool}(...)"; ${unsupportedNames} do not expose this tool. Rephrase generically (e.g. "spawn a sub-agent").`,
+      line,
+    });
+  }
+
+  const eventSupportMap = eventSupport();
+  const allCamelEvents = new Set<string>();
+  for (const adapter of Object.values(harnessAdapters)) {
+    for (const event of adapter.capabilities.hookEvents) {
+      allCamelEvents.add(event);
     }
   }
 
-  for (const event of PASCAL_HOOK_EVENTS) {
-    const camel = `${event.charAt(0).toLowerCase()}${event.slice(1)}`;
-    const pattern = new RegExp(`\\b${event}\\b`, "u");
+  for (const camelEvent of allCamelEvents) {
+    const pascalEvent = `${camelEvent.charAt(0).toUpperCase()}${camelEvent.slice(1)}`;
+    const pattern = new RegExp(`\\b${pascalEvent}\\b`, "u");
     const line = findFirstMatchLine(body, pattern);
-    if (line !== undefined) {
+    if (line === undefined) continue;
+
+    const supportedBy = eventSupportMap.get(camelEvent) ?? [];
+    if (supportedBy.length === hookAdapterCount) {
       findings.push({
         rule: "body-pascal-hook-event",
         severity: "warning",
-        message: `body references PascalCase hook event "${event}"; cheese-flow's portable hooks use camelCase ("${camel}"). Per-harness mapping is applied at compile time.`,
+        message: `body references PascalCase hook event "${pascalEvent}"; cheese-flow's portable hooks use camelCase ("${camelEvent}"). Per-harness mapping is applied at compile time.`,
+        line,
+      });
+    } else {
+      const unsupported = allAdapters.filter((n) => !supportedBy.includes(n));
+      const supportedNames = supportedBy.map(displayName).join(", ");
+      const unsupportedNames = unsupported.map(displayName).join(", ");
+      findings.push({
+        rule: "body-harness-only-hook-event",
+        severity: "warning",
+        message: `body references hook event "${pascalEvent}" which is supported only by ${supportedNames}; ${unsupportedNames} do not expose it.`,
         line,
       });
     }

--- a/src/lib/lint-skill-rules.ts
+++ b/src/lib/lint-skill-rules.ts
@@ -3,8 +3,7 @@ import { parseFrontmatter } from "./frontmatter.js";
 import {
   checkAllowedToolsPortability,
   checkBodyHarnessIdioms,
-  checkClaudeOnlyFields,
-  checkContextPortability,
+  checkFrontmatterPortability,
 } from "./harness-compat.js";
 import { parseSkillFrontmatter, type SkillFrontmatter } from "./schemas.js";
 
@@ -96,9 +95,7 @@ function validateFrontmatter(
 
   if (typeof data === "object" && data !== null) {
     const raw = data as Record<string, unknown>;
-    issues.push(
-      ...portabilityChecks(raw["allowed-tools"], raw.context, raw, issue),
-    );
+    issues.push(...portabilityChecks(raw["allowed-tools"], raw, issue));
   }
 
   return issues;
@@ -167,7 +164,6 @@ function nameAndDescriptionChecks(
 
 function portabilityChecks(
   allowedTools: unknown,
-  contextField: unknown,
   rawFrontmatter: Record<string, unknown>,
   issue: IssueFactory,
 ): LintIssue[] {
@@ -179,11 +175,7 @@ function portabilityChecks(
   for (const finding of checkAllowedToolsPortability(allowed)) {
     issues.push(issue(finding.severity, finding.rule, finding.message));
   }
-  const ctx = typeof contextField === "string" ? contextField : undefined;
-  for (const finding of checkContextPortability(ctx)) {
-    issues.push(issue(finding.severity, finding.rule, finding.message));
-  }
-  for (const finding of checkClaudeOnlyFields(rawFrontmatter, "skill")) {
+  for (const finding of checkFrontmatterPortability(rawFrontmatter, "skill")) {
     issues.push(issue(finding.severity, finding.rule, finding.message));
   }
   return issues;

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -59,17 +59,6 @@ export type SkillFrontmatter = z.infer<typeof skillFrontmatterSchema>;
 export type CommandFrontmatter = z.infer<typeof commandFrontmatterSchema>;
 export type AgentFrontmatter = z.infer<typeof agentFrontmatterSchema>;
 
-// Frontmatter keys that compile-trip cleanly only on Claude Code. The portability
-// linter surfaces a warning when authors set these on portable skills/agents.
-export const CLAUDE_ONLY_SKILL_KEYS = ["model", "context"] as const;
-export const CLAUDE_ONLY_AGENT_KEYS = [
-  "skills",
-  "color",
-  "effort",
-  "disallowedTools",
-  "permissionMode",
-] as const;
-
 export function parseSkillFrontmatter(data: unknown): SkillFrontmatter {
   return skillFrontmatterSchema.parse(data);
 }

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import { harnessAdapters } from "../src/adapters/index.js";
+import { PORTABLE_EVENTS } from "../src/domain/harness.js";
+import {
+  eventSupport,
+  fieldSupport,
+  toolSupport,
+} from "../src/lib/capabilities.js";
+
+describe("adapter capabilities declarations", () => {
+  it("every adapter has a capabilities object", () => {
+    for (const [name, adapter] of Object.entries(harnessAdapters)) {
+      expect(
+        adapter.capabilities,
+        `${name} missing capabilities`,
+      ).toBeDefined();
+      expect(adapter.capabilities.skillFrontmatterKeys).toBeInstanceOf(Set);
+      expect(adapter.capabilities.agentFrontmatterKeys).toBeInstanceOf(Set);
+      expect(adapter.capabilities.hookEvents).toBeInstanceOf(Set);
+      expect(adapter.capabilities.toolNames).toBeInstanceOf(Set);
+    }
+  });
+
+  it("claude-code declares the expected claude-only skill keys", () => {
+    const cc = harnessAdapters["claude-code"].capabilities;
+    expect(cc.skillFrontmatterKeys.has("model")).toBe(true);
+    expect(cc.skillFrontmatterKeys.has("context")).toBe(true);
+  });
+
+  it("claude-code declares the expected claude-only agent keys", () => {
+    const cc = harnessAdapters["claude-code"].capabilities;
+    for (const key of [
+      "skills",
+      "color",
+      "effort",
+      "disallowedTools",
+      "permissionMode",
+    ]) {
+      expect(
+        cc.agentFrontmatterKeys.has(key),
+        `missing agent key: ${key}`,
+      ).toBe(true);
+    }
+  });
+
+  it("claude-code declares all 9 hook events", () => {
+    const cc = harnessAdapters["claude-code"].capabilities;
+    expect(cc.hookEvents.size).toBe(9);
+    for (const event of [
+      "sessionStart",
+      "sessionEnd",
+      "preToolUse",
+      "postToolUse",
+      "stop",
+    ]) {
+      expect(cc.hookEvents.has(event), `missing event: ${event}`).toBe(true);
+    }
+  });
+
+  it("claude-code declares all claude-only tools", () => {
+    const cc = harnessAdapters["claude-code"].capabilities;
+    for (const tool of [
+      "Agent",
+      "Task",
+      "NotebookEdit",
+      "WebSearch",
+      "WebFetch",
+      "TodoWrite",
+    ]) {
+      expect(cc.toolNames.has(tool), `missing tool: ${tool}`).toBe(true);
+    }
+  });
+
+  it("codex and copilot-cli declare the 3 portable hook events", () => {
+    for (const name of ["codex", "copilot-cli"] as const) {
+      const adapter = harnessAdapters[name];
+      for (const event of PORTABLE_EVENTS) {
+        expect(
+          adapter.capabilities.hookEvents.has(event),
+          `${name} missing portable event: ${event}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("cursor declares zero hook events (no hook system)", () => {
+    expect(harnessAdapters.cursor.capabilities.hookEvents.size).toBe(0);
+  });
+
+  it("non-claude adapters declare no claude-only skill or agent keys", () => {
+    for (const name of ["codex", "cursor", "copilot-cli"] as const) {
+      const cap = harnessAdapters[name].capabilities;
+      expect(cap.skillFrontmatterKeys.size).toBe(0);
+      expect(cap.agentFrontmatterKeys.size).toBe(0);
+    }
+  });
+
+  it("non-claude adapters declare no tool names", () => {
+    for (const name of ["codex", "cursor", "copilot-cli"] as const) {
+      expect(harnessAdapters[name].capabilities.toolNames.size).toBe(0);
+    }
+  });
+});
+
+describe("fieldSupport", () => {
+  it("model is mapped to only claude-code", () => {
+    expect(fieldSupport("skill").get("model")).toEqual(["claude-code"]);
+  });
+
+  it("context is mapped to only claude-code", () => {
+    expect(fieldSupport("skill").get("context")).toEqual(["claude-code"]);
+  });
+
+  it("returns a map for agent kind with all expected keys", () => {
+    const support = fieldSupport("agent");
+    for (const key of [
+      "skills",
+      "color",
+      "effort",
+      "disallowedTools",
+      "permissionMode",
+    ]) {
+      expect(support.has(key), `missing agent key: ${key}`).toBe(true);
+    }
+  });
+
+  it("portable fields like name/description are absent from the map", () => {
+    const support = fieldSupport("skill");
+    expect(support.has("name")).toBe(false);
+    expect(support.has("description")).toBe(false);
+  });
+});
+
+describe("eventSupport", () => {
+  it("portable events are supported by all hook-using adapters", () => {
+    const support = eventSupport();
+    const hookAdapters = Object.entries(harnessAdapters)
+      .filter(([, a]) => a.capabilities.hookEvents.size > 0)
+      .map(([name]) => name);
+    for (const event of PORTABLE_EVENTS) {
+      const supportedBy = support.get(event) ?? [];
+      expect(supportedBy.length).toBe(hookAdapters.length);
+    }
+  });
+
+  it("stop is supported only by claude-code", () => {
+    expect(eventSupport().get("stop")).toEqual(["claude-code"]);
+  });
+
+  it("sessionEnd is supported only by claude-code", () => {
+    expect(eventSupport().get("sessionEnd")).toEqual(["claude-code"]);
+  });
+});
+
+describe("toolSupport", () => {
+  it("all tools are supported only by claude-code", () => {
+    const support = toolSupport();
+    for (const [tool, supportedBy] of support) {
+      expect(supportedBy, `${tool} should only be claude-code`).toEqual([
+        "claude-code",
+      ]);
+    }
+  });
+
+  it("union of all adapter toolNames covers the full claude-only set", () => {
+    const support = toolSupport();
+    for (const tool of [
+      "Agent",
+      "Task",
+      "NotebookEdit",
+      "WebSearch",
+      "WebFetch",
+      "TodoWrite",
+    ]) {
+      expect(support.has(tool), `missing tool: ${tool}`).toBe(true);
+    }
+  });
+});

--- a/tests/harness-compat.test.ts
+++ b/tests/harness-compat.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { fieldSupport } from "../src/lib/capabilities.js";
 import {
   checkAllowedToolsPortability,
   checkBodyHarnessIdioms,
-  checkClaudeOnlyFields,
-  checkContextPortability,
+  checkFrontmatterPortability,
   compileTestSkill,
 } from "../src/lib/harness-compat.js";
 
@@ -50,6 +50,63 @@ describe("checkAllowedToolsPortability", () => {
   });
 });
 
+describe("checkFrontmatterPortability", () => {
+  it("returns no findings for skills using only portable fields", () => {
+    expect(
+      checkFrontmatterPortability({ name: "x", description: "y" }, "skill"),
+    ).toEqual([]);
+  });
+
+  it("flags model and context: fork on a skill (2 findings)", () => {
+    const findings = checkFrontmatterPortability(
+      { name: "x", description: "y", model: "opus", context: "fork" },
+      "skill",
+    );
+    expect(findings).toHaveLength(2);
+    expect(findings.every((f) => f.rule === "frontmatter-portability")).toBe(
+      true,
+    );
+    expect(findings.some((f) => f.message.includes('"model"'))).toBe(true);
+    expect(findings.some((f) => f.message.includes('"context"'))).toBe(true);
+  });
+
+  it("does not flag context: inline because it is the portable default", () => {
+    const findings = checkFrontmatterPortability(
+      { name: "x", description: "y", context: "inline" },
+      "skill",
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it("flags all Claude-only agent fields", () => {
+    const findings = checkFrontmatterPortability(
+      {
+        name: "x",
+        description: "y",
+        skills: ["foo"],
+        color: "red",
+        effort: "high",
+        disallowedTools: ["Edit"],
+        permissionMode: "default",
+      },
+      "agent",
+    );
+    expect(findings).toHaveLength(5);
+    expect(findings.every((f) => f.rule === "frontmatter-portability")).toBe(
+      true,
+    );
+  });
+
+  it("is driven by adapter capabilities, not hardcoded constants", () => {
+    // model is supported only by claude-code; if a future adapter also declares it,
+    // the map grows and the warning would no longer fire for that adapter.
+    // Verify the current mapping is capability-driven.
+    const support = fieldSupport("skill");
+    expect(support.get("model")).toEqual(["claude-code"]);
+    expect(support.get("context")).toEqual(["claude-code"]);
+  });
+});
+
 describe("checkBodyHarnessIdioms", () => {
   it("returns no findings on plain markdown body", () => {
     const body = "# Heading\n\nUse the harness's native tools.\n";
@@ -68,13 +125,29 @@ describe("checkBodyHarnessIdioms", () => {
     expect(findings[0]?.message).toContain("Task");
   });
 
-  it("flags multiple PascalCase hook events including the extended set", () => {
+  it("flags portable PascalCase hook events with body-pascal-hook-event", () => {
     const findings = checkBodyHarnessIdioms(
-      "Fires SessionStart, PreToolUse, PostToolUse, Stop, SubagentStop, Notification.",
+      "Fires SessionStart, PreToolUse, PostToolUse.",
     );
     expect(
       findings.filter((f) => f.rule === "body-pascal-hook-event"),
-    ).toHaveLength(6);
+    ).toHaveLength(3);
+  });
+
+  it("flags claude-only PascalCase hook events with body-harness-only-hook-event", () => {
+    const findings = checkBodyHarnessIdioms(
+      "Fires Stop, SubagentStop, Notification.",
+    );
+    expect(
+      findings.filter((f) => f.rule === "body-harness-only-hook-event"),
+    ).toHaveLength(3);
+    expect(findings.every((f) => f.severity === "warning")).toBe(true);
+  });
+
+  it("Stop emits body-harness-only-hook-event, not body-pascal-hook-event", () => {
+    const findings = checkBodyHarnessIdioms("Triggers on Stop.");
+    const stopFinding = findings.find((f) => f.message.includes("Stop"));
+    expect(stopFinding?.rule).toBe("body-harness-only-hook-event");
   });
 
   it("does not flag camelCase hook events", () => {
@@ -82,6 +155,17 @@ describe("checkBodyHarnessIdioms", () => {
       "Fires sessionStart, preToolUse, postToolUse.",
     );
     expect(findings).toEqual([]);
+  });
+
+  it("does not flag camelCase stop in body", () => {
+    const findings = checkBodyHarnessIdioms("Fires stop, subagentStop events.");
+    expect(
+      findings.some(
+        (f) =>
+          f.rule === "body-pascal-hook-event" ||
+          f.rule === "body-harness-only-hook-event",
+      ),
+    ).toBe(false);
   });
 
   it("flags Claude-only tools beyond Agent/Task", () => {
@@ -117,70 +201,6 @@ describe("checkBodyHarnessIdioms", () => {
       (f) => f.rule === "body-claude-only-tool",
     );
     expect(agentFinding?.line).toBe(2);
-  });
-});
-
-describe("checkClaudeOnlyFields", () => {
-  it("returns no findings for skills using only portable fields", () => {
-    expect(
-      checkClaudeOnlyFields({ name: "x", description: "y" }, "skill"),
-    ).toEqual([]);
-  });
-
-  it("flags model and context: fork on a skill", () => {
-    const findings = checkClaudeOnlyFields(
-      { name: "x", description: "y", model: "opus", context: "fork" },
-      "skill",
-    );
-    expect(findings).toHaveLength(2);
-    expect(
-      findings.every((f) => f.rule === "frontmatter-claude-only-field"),
-    ).toBe(true);
-  });
-
-  it("does not flag context: inline because it is the portable default", () => {
-    const findings = checkClaudeOnlyFields(
-      { name: "x", description: "y", context: "inline" },
-      "skill",
-    );
-    expect(findings).toEqual([]);
-  });
-
-  it("flags Claude-only agent fields", () => {
-    const findings = checkClaudeOnlyFields(
-      {
-        name: "x",
-        description: "y",
-        skills: ["foo"],
-        color: "red",
-        effort: "high",
-        disallowedTools: ["Edit"],
-        permissionMode: "default",
-      },
-      "agent",
-    );
-    expect(findings).toHaveLength(5);
-    expect(
-      findings.every((f) => f.rule === "frontmatter-claude-only-field"),
-    ).toBe(true);
-  });
-});
-
-describe("checkContextPortability", () => {
-  it("returns no findings when context is undefined", () => {
-    expect(checkContextPortability(undefined)).toEqual([]);
-  });
-
-  it("returns no findings on context: inline", () => {
-    expect(checkContextPortability("inline")).toEqual([]);
-  });
-
-  it("flags context: fork as Claude-only", () => {
-    const findings = checkContextPortability("fork");
-    expect(findings).toHaveLength(1);
-    expect(findings[0]?.rule).toBe("context-fork-claude-only");
-    expect(findings[0]?.severity).toBe("warning");
-    expect(findings[0]?.message).toContain("forked subagent");
   });
 });
 

--- a/tests/lint-skills.test.ts
+++ b/tests/lint-skills.test.ts
@@ -289,17 +289,18 @@ describe("lintSkillSource", () => {
     }
   });
 
-  it("flags Claude-only frontmatter fields with the dedicated rule", () => {
+  it("flags Claude-only frontmatter fields via adapter capabilities", () => {
     const issues = lintSkillSource({
       directoryName: "claude-only-fields",
       relativeFile: "claude-only-fields/SKILL.md",
       source: `---\nname: claude-only-fields\ndescription: A perfectly fine description that is long enough for discovery.\nmodel: opus\ncontext: fork\n---\n${validBody}`,
     });
-    const claudeOnly = issues.filter(
-      (entry) => entry.rule === "frontmatter-claude-only-field",
+    // context: fork and model each produce one frontmatter-portability warning.
+    const portability = issues.filter(
+      (entry) => entry.rule === "frontmatter-portability",
     );
-    expect(claudeOnly).toHaveLength(2);
-    expect(claudeOnly.every((entry) => entry.severity === "warning")).toBe(
+    expect(portability).toHaveLength(2);
+    expect(portability.every((entry) => entry.severity === "warning")).toBe(
       true,
     );
   });
@@ -311,7 +312,48 @@ describe("lintSkillSource", () => {
       source: `---\nname: inline-context\ndescription: A perfectly fine description that is long enough for discovery.\ncontext: inline\n---\n${validBody}`,
     });
     expect(
-      issues.some((entry) => entry.rule === "frontmatter-claude-only-field"),
+      issues.some((entry) => entry.rule === "frontmatter-portability"),
+    ).toBe(false);
+  });
+
+  it("context: fork produces exactly one portability warning (no duplicate)", () => {
+    const issues = lintSkillSource({
+      directoryName: "fork-context",
+      relativeFile: "fork-context/SKILL.md",
+      source: `---\nname: fork-context\ndescription: A perfectly fine description that is long enough for discovery.\ncontext: fork\n---\n${validBody}`,
+    });
+    const portability = issues.filter(
+      (entry) => entry.rule === "frontmatter-portability",
+    );
+    expect(portability).toHaveLength(1);
+  });
+
+  it("Stop in body emits body-harness-only-hook-event, not body-pascal-hook-event", () => {
+    const issues = lintSkillSource({
+      directoryName: "stop-hook",
+      relativeFile: "stop-hook/SKILL.md",
+      source: `---\nname: stop-hook\ndescription: A perfectly fine description that is long enough for discovery.\n---\n# Body\nFires on Stop events.\n`,
+    });
+    expect(
+      issues.some((entry) => entry.rule === "body-harness-only-hook-event"),
+    ).toBe(true);
+    expect(
+      issues.some((entry) => entry.rule === "body-pascal-hook-event"),
+    ).toBe(false);
+  });
+
+  it("stop (camelCase) in body does not emit any hook warning", () => {
+    const issues = lintSkillSource({
+      directoryName: "stop-camel",
+      relativeFile: "stop-camel/SKILL.md",
+      source: `---\nname: stop-camel\ndescription: A perfectly fine description that is long enough for discovery.\n---\n# Body\nFires on stop events.\n`,
+    });
+    expect(
+      issues.some(
+        (entry) =>
+          entry.rule === "body-harness-only-hook-event" ||
+          entry.rule === "body-pascal-hook-event",
+      ),
     ).toBe(false);
   });
 
@@ -328,7 +370,7 @@ describe("lintSkillSource", () => {
       issues.some((entry) => entry.rule.startsWith("frontmatter:name")),
     ).toBe(true);
     expect(
-      issues.some((entry) => entry.rule === "context-fork-claude-only"),
+      issues.some((entry) => entry.rule === "frontmatter-portability"),
     ).toBe(true);
     expect(issues.some((entry) => entry.rule === "body-claude-only-tool")).toBe(
       true,


### PR DESCRIPTION
## Summary

- Adds `HarnessCapabilities` type to `HarnessAdapter` interface; each adapter now declares `skillFrontmatterKeys`, `agentFrontmatterKeys`, `hookEvents`, and `toolNames`
- New `src/lib/capabilities.ts` with `fieldSupport()`, `eventSupport()`, `toolSupport()` — lint layer derives all portability warnings from adapter declarations, no more hardcoded `CLAUDE_ONLY_*` constants
- Splits `body-pascal-hook-event` into two rules: portable events (in all hook adapters) keep the rule; Claude-only events (`Stop`, `SubagentStop`, `Notification`) get new `body-harness-only-hook-event` with accurate "supported only by..." messaging
- Replaces `checkContextPortability` + `checkClaudeOnlyFields` with single `checkFrontmatterPortability` — fixes duplicate warning for `context: fork`
- Removes `CLAUDE_ONLY_SKILL_KEYS`/`CLAUDE_ONLY_AGENT_KEYS` from `schemas.ts` and `CLAUDE_ONLY_TOOL_NAMES`/`PASCAL_HOOK_EVENTS` from `harness-compat.ts`

Addresses Copilot review threads on PR 25.

## Test plan

- [ ] `npm test` — 197/197 passing
- [ ] `npm run lint:skills` — 9 skills, 0 issues
- [ ] `npm run build` — no TypeScript errors
- [ ] `npm run lint` — biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)