### PR TITLE
feat(mold): redesign /mold as iterative thinking amplifier

### DIFF
--- a/commands/mold.md
+++ b/commands/mold.md
@@ -1,66 +1,60 @@
 ---
 name: mold
-description: Spec writer. Runs a focused dialogue to shape a feature, surfaces at least two approaches with trade-offs, and saves the resulting spec to <harness>/specs/<slug>.md only after explicit user approval.
-argument-hint: "<rough idea | feature request | issue reference>"
+description: Iterative thinking amplifier for fuzzy ideas. Routes input to a starting mode (Explore, Ground, Shape, Sketch, Grill, Diagnose), runs Validate Cycles, locks down interfaces in pseudocode, and crystallizes a spec (and optional issues) only after a two-key handshake.
+argument-hint: "<rough idea | feature request | bug | spec path | design doc>"
 ---
 
 # /mold
 
-`/mold` shapes a rough idea into an implementable spec. It runs a focused
-dialogue — one clarifying question at a time — and saves the result to
-`<harness>/specs/<slug>.md` only after you explicitly approve. `<harness>`
-is the active harness output root — `.claude` for Claude Code, `.codex`
-for Codex.
+`/mold` shapes a fuzzy idea into a coherent spec (and optional issues)
+that downstream `/cheese` and `/fromage` can consume without re-asking
+design questions. It is a **thinking amplifier**, not a one-shot
+generator: the dialogue is the point, the artifact is the by-product.
 
-## Dialogue style
+## Execution
 
-- **One question at a time.** No interrogation lists. Each question
-  follows from the previous answer.
-- **Always surface alternatives.** Any non-trivial spec produces at least
-  two viable approaches with their trade-offs. "Do nothing" is always a
-  candidate and must be considered.
-- **Approval gate.** Nothing is written to `<harness>/specs/` until the user
-  says yes.
+Invoke the `mold` skill with `$ARGUMENTS`. The skill owns mode routing,
+Validate Cycle dispatch, interface lockdown via pseudocode, the two-key
+handshake, and atomic artifact extraction to `<harness>/specs/<slug>.md`
+and `<harness>/issues/<slug>-NNN.md`. `<harness>` is the active output
+root for the harness in use.
 
-## Spec skeleton
+Do not reimplement the dialogue or extraction logic in this command.
+This file is the user-facing alias and contract; `skills/mold/SKILL.md`
+is the implementation source of truth.
 
-The final spec always includes these sections, in this order:
+## Companions
 
-1. **Problem.** What is broken, missing, or painful today.
-2. **Goals.** What must be true when this is done.
-3. **Non-goals.** Explicit scope boundaries — what is OUT.
-4. **Approach.** The chosen approach, with a brief note on alternatives
-   considered and why they were rejected.
-5. **Risks.** Known risks, unknowns, and mitigations.
-6. **Quality gates.** The exact commands that must pass for this to be
-   considered done (e.g. `npm test`, `cargo clippy`).
-7. **Open questions.** Anything still unresolved at approval time.
+| Skill | Boundary |
+| --- | --- |
+| `/culture` | Same dialogue feel; **never writes**. Use it when there is no artifact intent. |
+| `/briesearch` | External evidence dispatcher. `/mold` calls it through the Validate Cycle. |
+| `/fromage` | Implements a crystallized spec. `/mold` ends with a hand-off offer, never an auto-invoke. |
 
-## Hand-off
+## What you get
 
-Specs produced by `/mold` are designed to be consumed by:
+- **Spec** — rich container, written to `<harness>/specs/<slug>.md`.
+  Always present unless the dialogue produced only standalone bug
+  tickets.
+- **Issues** — separate, GitHub-flavored, written to
+  `<harness>/issues/<slug>-NNN.md`. Present when the dialogue surfaced
+  side-channel actionables (out-of-scope bugs, follow-ups, parking-lot
+  work).
 
-- `/fromagerie` for large features that decompose into many independent
-  work units.
-- `/fromage` for single coherent features.
-- `/cheese` (top-level router), which may redirect an idea to `/mold`
-  before implementation.
+Nothing is written until the user explicitly approves the artifact set,
+slug, and target paths in a single bundled prompt.
 
-Running `/mold` before `/cheese` or `/fromage` is strongly recommended
-for anything above trivial complexity.
+## Use cases
 
-## Deferred behavior
+- Turning "I want to add X" into an implementable spec with locked
+  interfaces.
+- Diagnosing a stack trace or symptom into a bug-shaped spec plus
+  follow-up issues.
+- Refining a half-baked design doc by stress-testing the chosen approach.
+- Reading an existing spec and converging on the next iteration.
 
-> **Scaffold notice.** The conversational loop and approval-gated write
-> to `<harness>/specs/` are not yet wired. This file documents the spec
-> skeleton and the dialogue contract. The current implementation should
-> describe what `/mold` would produce and stop — it does not yet run the
-> interactive session or write any files.
+## When NOT to use
 
-The next iteration will:
-
-- Implement the single-question-at-a-time dialogue.
-- Enforce the "surface at least two approaches" rule on every non-trivial
-  spec.
-- Gate the write to `<harness>/specs/<slug>.md` behind explicit user
-  approval via `AskUserQuestion`.
+- Free-form rubber-ducking with no artifact intent → `/culture`.
+- Single library lookup → `/briesearch` directly.
+- Already-clear spec → skip ahead to `/fromage` or `/fromagerie`.

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -2,7 +2,7 @@
 name: mold
 description: Iterative thinking amplifier for fuzzy ideas. Routes input to the right starting mode (Explore, Ground, Shape, Sketch, Grill, Diagnose), runs Validate Cycles to anchor claims, locks down interfaces in pseudocode, and only crystallizes a spec (and optional issues) after a two-key handshake plus a coherence self-check.
 license: MIT
-compatibility: Works in markdown-based coding harnesses with sub-agent support. Heavy delegation to /briesearch and cheez-* skills; degrades gracefully when those are absent.
+compatibility: Works in markdown-based coding harnesses with sub-agent support. Heavy delegation to /briesearch and cheez-* skills. When tilth MCP is absent, substitute the host Read tool for local file references — the no-speculation invariant (Operating Principle 2) still holds.
 metadata:
   owner: cheese-flow
   category: planning
@@ -139,8 +139,8 @@ Plan:
 Outcomes write to the state file's `Validate cycles` block:
 
 - **SUPPORTED** — evidence aligns; hypothesis becomes a decision.
-- **CONTRADICTED** — evidence disagrees; surface as `[CONFLICT]`; revise or
-  abandon.
+- **CONTRADICTED** — evidence disagrees; surface as `[CONFLICT <id>]` (e.g.
+  `[CONFLICT cf-1]`); revise or abandon.
 - **REFINED** — evidence partially aligns; restate with new precision and
   re-validate or accept.
 
@@ -195,7 +195,7 @@ the Sketch gate unless the user follows up with `crystallize anyway`.
 | `[?]` | Agent uncertain; needs validation |
 | `[TBD]` | User uncertain; decision deferred |
 | `[BLOCKED]` | External dependency unresolved |
-| `[CONFLICT]` | Codebase contradicts a stated assumption |
+| `[CONFLICT <id>]` | Codebase contradicts a stated assumption; `<id>` (e.g. `cf-1`) links back to the contradicted validate cycle's `conflict_id` |
 
 ## Termination — two-key handshake
 

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: mold
+description: Iterative thinking amplifier for fuzzy ideas. Routes input to the right starting mode (Explore, Ground, Shape, Sketch, Grill, Diagnose), runs Validate Cycles to anchor claims, locks down interfaces in pseudocode, and only crystallizes a spec (and optional issues) after a two-key handshake plus a coherence self-check.
+license: MIT
+compatibility: Works in markdown-based coding harnesses with sub-agent support. Heavy delegation to /briesearch and cheez-* skills; degrades gracefully when those are absent.
+metadata:
+  owner: cheese-flow
+  category: planning
+allowed-tools:
+  - read
+  - write
+  - bash
+  - subagent
+---
+# /mold
+
+Use this skill when the user has a fuzzy idea and wants to converge — through
+dialogue, evidence, and interface lockdown — on a coherent spec (and optional
+issues) that downstream `/cheese` and `/fromage` can consume without
+re-asking design questions.
+
+Do not use this skill for one-shot implementation, free-form rubber-ducking
+without artifact intent (use `/culture`), or library-only research (use
+`/briesearch` directly).
+
+## What `/mold` is
+
+A **thinking amplifier**, not a pre-prompt. The dialogue is the point;
+artifacts are the by-product. The terminal step crystallizes whatever the
+dialogue actually produced — never more, never less.
+
+| Companion | Boundary |
+| --- | --- |
+| `/culture` | Same dialogue feel; **never writes**. Use it when there is no artifact intent. |
+| `/briesearch` | External evidence dispatcher. `/mold` calls it through the Validate Cycle. |
+| `/fromage` | Implements a crystallized spec. `/mold` ends with a hand-off offer, never an auto-invoke. |
+
+## Operating principles
+
+1. **No fixed entry point.** Inspect input shape and pick a starting mode.
+   Announce the mode in one line. Low-confidence classifications default to
+   `Explore`.
+2. **Ground every load-bearing claim.** Never speculate about local code or
+   external behavior without a `cheez-*` call or a Validate Cycle.
+3. **State a hypothesis before researching.** A bare research dispatch is
+   discouraged; the Validate Cycle frame forces commitment plus a judgment
+   step.
+4. **Lock down interfaces before crystallizing.** Every cross-module seam
+   gets a pseudocode signature with named unknowns and a recommended answer.
+5. **Two-key handshake.** Both the user (explicit verb) and the agent
+   (coherence self-check) must agree before extraction.
+6. **Heavy delegation.** `/briesearch` for external research, `cheez-search`
+   / `cheez-read` for in-repo grounding. Do not reinvent.
+7. **No production writes during the loop.** The only writes happen on
+   Crystallize, after explicit approval.
+
+## Routing — input shape to starting mode
+
+| Input shape | Start mode | Heuristic |
+| --- | --- | --- |
+| Stack trace, "X is broken/slow/flaky" | Diagnose | error markers, `file:line` refs, symptom verbs |
+| File path, PR ref, existing spec under `<harness>/specs/` | Ground | concrete artifact exists; read it first |
+| Half-baked design doc with signatures or schemas | Sketch | already has interfaces; refine them |
+| "I want to add X" with concrete nouns | Shape | named the thing → jump to options |
+| "Should we do X? thinking about Y" | Grill | tentative plan exists → stress-test it |
+| Vague noun, half-sentence, "thinking about" | Explore | no grounded artifact, no chosen direction |
+
+Detail in `references/routing.md`.
+
+## The six modes
+
+Crystallize is a terminal state, not a mode.
+
+### Explore — intent extraction
+Job: collapse ambiguity with high-leverage questions. Borrow the `Beat 0`
+framing (Job-To-Be-Done, Why Now, What This Unlocks, Who Has The Pain, Do
+Nothing). Use lettered options to compress decisions.
+Exit when: a problem statement plus one concrete pain point is articulated.
+
+### Ground — anti-hallucination
+Job: anchor every claim to evidence — code, docs, prior research. Probe
+glossary conflicts against any harness convention files (`CONTEXT.md`,
+`CLAUDE.md`, project root agent guides) found on entry.
+Invariant: never say "I think the code does X" without a `cheez-*` call.
+Exit when: every load-bearing claim has a citation.
+
+### Shape — option generation
+Job: turn a grounded problem into 2+ candidate approaches with trade-offs.
+Always include `Do Nothing`. Recommend with one-line rationale. Validate
+Cycle any load-bearing assumption behind a recommendation.
+Exit when: an option is picked (→ Sketch) or none survive (→ Explore).
+
+### Sketch — interface lockdown
+Job: lock modules, responsibilities, I/O contracts, and seams in pseudocode
+signatures. Before drafting, parallel `cheez-search` for sibling signatures
+in the same domain so new ones fit conventions.
+Exit when: every public seam has a signature; every cross-module call has a
+contract. Detail in `references/sketch-mode.md`.
+
+### Grill — adversarial clarification
+Job: stress-test the chosen approach plus sketched interfaces. **One question
+at a time**, paired with the agent's recommended answer. The recommendation
+is non-optional. Traverse decision branches and contract corners. When grill
+surfaces an unverified assumption, pause and run a Validate Cycle.
+Exit when: every branch and contract corner is touched and agent confidence
+is at least user confidence.
+
+### Diagnose — symptom inputs
+Job: entry mode for stack traces and "X is broken". Phases:
+`Reproduce → Hypothesize (3-5 ranked, falsifiable, parallel Validate Cycles)
+→ Confirm root cause`. Diagnose is **diagnostic-only** — hand-off to Shape
+("what's the fix?") then Crystallize emits a bug-shaped spec plus optional
+follow-up issues.
+
+## The Validate Cycle (cross-mode sub-pattern)
+
+Any mode can invoke it. Always **announce the cycle** before dispatching.
+
+```
+Launching a validate cycle on hypothesis: "<single declarative sentence>"
+
+Plan:
+  /briesearch  — fetch evidence
+  Judge        — support, contradict, or refine?
+  Settle       — accept, revise, or reject. Continue from current mode.
+```
+
+Outcomes write to the state file's `Validate cycles` block:
+
+- **SUPPORTED** — evidence aligns; hypothesis becomes a decision.
+- **CONTRADICTED** — evidence disagrees; surface as `[CONFLICT]`; revise or
+  abandon.
+- **REFINED** — evidence partially aligns; restate with new precision and
+  re-validate or accept.
+
+Diagnose's parallel hypothesis ranking is the cycle, parallelized.
+
+Cap: max **two** `/briesearch` calls per session unless the user requests
+more. Cycles backed by `cheez-*` evidence alone are unbudgeted.
+
+Detail in `references/validate-cycle.md`.
+
+## Sub-agent dispatch
+
+| Tool | When | Cap |
+| --- | --- | --- |
+| `/briesearch` (via Validate Cycle) | hypothesis needs external evidence | 2/session |
+| `cheez-search` | symbol mention, dependency claim, sibling lookup | unbudgeted |
+| `cheez-read` | file mention, spec read on entry | unbudgeted |
+
+**Parallel sweeps**:
+
+- *Shape Sweep* — one turn fans out 3-4 reads (`cheez-search` + `cheez-deps`
+  plus optional `/briesearch`) before drafting Options.
+- *Sketch Sweep* — parallel `cheez-search` for nearby siblings before drafting
+  signatures for a module.
+- *Hypothesis Probe (Diagnose)* — parallel Validate Cycles, one per ranked
+  hypothesis.
+
+## State tracking
+
+Scratch state file at `${TMPDIR:-/tmp}/cheese-flow-mold-<run_id>/state.md`.
+Mirrors `/briesearch`'s scratch pattern: portable, auto-evicted post-session.
+
+The file records mode, input summary, decisions, locked sketches, validate
+cycles with outcomes, open questions with markers, and mode history. Schema
+in `references/state-schema.md`.
+
+## User knobs (free-form interrupts)
+
+`explore`, `ground`, `shape`, `sketch`, `grill`, `diagnose`,
+`validate <hypothesis>`, `crystallize`, `pause`, `enough`. The agent honours
+these immediately. `crystallize` initiates the handshake; it does not skip
+the Sketch gate unless the user follows up with `crystallize anyway`.
+
+## Uncertainty markers
+
+| Marker | Meaning |
+| --- | --- |
+| `[?]` | Agent uncertain; needs validation |
+| `[TBD]` | User uncertain; decision deferred |
+| `[BLOCKED]` | External dependency unresolved |
+| `[CONFLICT]` | Codebase contradicts a stated assumption |
+
+## Termination — two-key handshake
+
+**User key:** explicit `crystallize`, `ship it`, `extract`, `that's enough`.
+Never inferred.
+
+**Agent key:** structured coherence self-check. Print this checklist and
+require every box checked before extraction (or an explicit override):
+
+```
+Coherence self-check before crystallize:
+- [ ] Problem statement: grounded, agreed
+- [ ] At least 2 options weighed (Do Nothing included)
+- [ ] Chosen option grounded in codebase evidence
+- [ ] Interface sketches: every public seam has a pseudocode signature
+- [ ] Validate cycles: all launched cycles judged
+- [ ] Chosen option Grilled (>=1 question per major branch)
+- [ ] Open questions all marked [TBD] / [BLOCKED] / [?] (none silent)
+- [ ] Quality gates specified
+```
+
+Guard conditions are mandatory before Crystallize except where noted:
+
+- *Ground gate* — at least one Ground pass with a citation before Shape's
+  options. Exception: pure greenfield (the agent must say so).
+- *Shape gate* — at least one Option block weighed (Do Nothing counts).
+- *Sketch gate* — mandatory when the chosen option touches more than one
+  module or introduces a new public interface. Skip only for trivial
+  single-function changes (the agent must say so).
+- *Grill gate* — mandatory for high-blast-radius decisions (per `cheez-deps`).
+- *Open hypotheses must settle* — any Validate Cycle launched but unjudged
+  blocks Crystallize unless the user accepts it as `[TBD]`.
+
+If any box is unchecked, name it and propose the smallest move to fill it.
+The user can override with `crystallize anyway`.
+
+## Crystallize — artifact extraction
+
+Two artifact types:
+
+- **Spec** — the rich container; absorbs problem framing, requirements,
+  approach, decisions, interface sketches, risks, gates. Always present
+  unless the dialogue produced only standalone bug tickets. Template in
+  `references/spec.md`.
+- **Issue** (1..N) — separate, GitHub-flavored, when the dialogue surfaced
+  actionable items independent of the main spec scope. Template in
+  `references/issue.md`.
+
+Format selection table:
+
+| Dialogue signal | Output |
+| --- | --- |
+| Any meaningful design discussion | Spec |
+| Side-channel actionables (out-of-scope bugs, follow-ups) | Spec + Issues |
+| Diagnose root cause + fix design | Spec (bug-shaped) + optional Issues |
+| Pure decision-only (no design) | Spec with only `Decisions` populated |
+
+Confirm in **one** approval prompt covering the artifact set, the slug, and
+the target paths. Render drafts inline first if the user wants to iterate
+before any disk writes.
+
+Output paths (relative to the active harness output root, surfaced as
+`<harness>/...`):
+
+| Output | Path |
+| --- | --- |
+| Spec only | `<harness>/specs/<slug>.md` |
+| Issues only | `<harness>/issues/<slug>-001.md`, `-002.md`, ... |
+| Spec + Issues | spec at `<harness>/specs/<slug>.md`; issues at `<harness>/issues/<slug>-001.md`, ... |
+
+Slug derivation: lowercase the working problem statement, drop stopwords,
+kebab-case, cap at 5 words. Honour user-passed slugs verbatim.
+
+Collisions:
+
+| Existing | Action |
+| --- | --- |
+| Same slug, status `draft` | Overwrite (default) or rev (`<slug>-v2`) |
+| Same slug, status `approved` | Default rev; never silently overwrite |
+| Existing spec, new issues for same slug | Append issues to that slug's series |
+
+Confidence is tagged twice — document-level in spec frontmatter (mechanical
+formula in `references/spec.md`) and inline at decision points in the
+spec body.
+
+Write atomically: stage to a temp directory, then move into place. Never
+leave partial files on a write failure.
+
+## Hand-off
+
+After writing, offer the next step inline. Never auto-invoke.
+
+| Artifact | Suggested next step |
+| --- | --- |
+| Spec (single feature) | `/fromage <harness>/specs/<slug>.md` |
+| Spec (large) | `/fromagerie <harness>/specs/<slug>.md` |
+| Issues | `gh issue create --body-file <path>` (per file) |
+
+## Loop detection
+
+The session can stall. The agent watches for:
+
+- *Drift* — 4 consecutive turns without a new `Decisions`, `Sketches`, or
+  `Validate cycles` entry → surface, propose summary or pause.
+- *Bored user* — terse responses, repeated `meh` → surface escape hatches.
+- *Rabbit hole* — 3+ mode transitions in the last 5 turns and no new state
+  entries → forced synthesis turn.
+
+Rules in `references/loop-detection.md`.
+
+## Rules
+
+- Do not write to production paths during the dialogue. Only Crystallize
+  writes files, only after the two-key handshake.
+- Do not direct-call `/briesearch` for unstated questions; wrap external
+  evidence in a Validate Cycle.
+- Do not skip the Sketch gate for non-trivial features without an explicit
+  declaration.
+- Do not silently drop open hypotheses; they must settle or be marked
+  `[TBD]`.
+- Do not overwrite an `approved` spec without explicit user opt-in.
+- Do not attempt to implement code; pseudocode signatures are plan, not code.

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -212,9 +212,10 @@ Coherence self-check before crystallize:
 - [ ] Chosen option grounded in codebase evidence
 - [ ] Interface sketches: every public seam has a pseudocode signature
 - [ ] Validate cycles: all launched cycles judged
-- [ ] Chosen option Grilled (>=1 question per major branch)
+- [ ] Chosen option Grilled (>=1 `Grill turns` entry per major branch)
 - [ ] Open questions all marked [TBD] / [BLOCKED] / [?] (none silent)
-- [ ] Quality gates specified
+- [ ] Quality gates specified (>=1 `Quality gates` entry, runnable command)
+- [ ] Reproduction loop captured if Diagnose ran (or `[BLOCKED]` if no loop is possible)
 ```
 
 Guard conditions are mandatory before Crystallize except where noted:

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -81,6 +81,11 @@ Exit when: a problem statement plus one concrete pain point is articulated.
 Job: anchor every claim to evidence — code, docs, prior research. Probe
 glossary conflicts against any harness convention files (`CONTEXT.md`,
 `CLAUDE.md`, project root agent guides) found on entry.
+**Sharpen fuzzy language**: when the user uses overloaded or ambiguous
+terms ("account", "session", "user"), pause and resolve with a
+canonical-term question (e.g. "you said 'account' — do you mean Customer
+or User? Those are different things"). Resolved terms get logged in the
+state file's `Decisions` block so later modes use the canonical name.
 Invariant: never say "I think the code does X" without a `cheez-*` call.
 Exit when: every load-bearing claim has a citation.
 
@@ -107,10 +112,16 @@ is at least user confidence.
 
 ### Diagnose — symptom inputs
 Job: entry mode for stack traces and "X is broken". Phases:
-`Reproduce → Hypothesize (3-5 ranked, falsifiable, parallel Validate Cycles)
-→ Confirm root cause`. Diagnose is **diagnostic-only** — hand-off to Shape
-("what's the fix?") then Crystallize emits a bug-shaped spec plus optional
-follow-up issues.
+`Build a Loop → Reproduce → Hypothesize (3-5 ranked, falsifiable, parallel
+Validate Cycles) → Confirm root cause`. Phase 0 (**Build a Loop**) is the
+core discipline — agree on a fast, deterministic, falsifiable feedback
+technique (failing test, curl/CLI script, headless browser, replay,
+bisection harness, differential loop, ...) before chasing hypotheses.
+The chosen loop becomes the Reproduction block in the bug-shaped spec, so
+`/fromage` can verify the fix against the same signal the diagnosis used.
+Diagnose is **diagnostic-only** — hand-off to Shape ("what's the fix?")
+then Crystallize emits a bug-shaped spec plus optional follow-up issues.
+Loop menu and discipline in `references/diagnose-mode.md`.
 
 ## The Validate Cycle (cross-mode sub-pattern)
 
@@ -145,13 +156,17 @@ Detail in `references/validate-cycle.md`.
 | Tool | When | Cap |
 | --- | --- | --- |
 | `/briesearch` (via Validate Cycle) | hypothesis needs external evidence | 2/session |
-| `cheez-search` | symbol mention, dependency claim, sibling lookup | unbudgeted |
+| `cheez-search` | symbol mention, dependency claim, callers/imports lookup, sibling lookup | unbudgeted |
 | `cheez-read` | file mention, spec read on entry | unbudgeted |
+
+`cheez-search` covers blast-radius work via its `kind: "callers"` mode and
+`tilth_deps` tool — use it instead of looking for a separate dependency
+skill.
 
 **Parallel sweeps**:
 
-- *Shape Sweep* — one turn fans out 3-4 reads (`cheez-search` + `cheez-deps`
-  plus optional `/briesearch`) before drafting Options.
+- *Shape Sweep* — one turn fans out 3-4 `cheez-search` reads (symbol +
+  callers + deps) plus optional `/briesearch` before drafting Options.
 - *Sketch Sweep* — parallel `cheez-search` for nearby siblings before drafting
   signatures for a module.
 - *Hypothesis Probe (Diagnose)* — parallel Validate Cycles, one per ranked
@@ -210,7 +225,9 @@ Guard conditions are mandatory before Crystallize except where noted:
 - *Sketch gate* — mandatory when the chosen option touches more than one
   module or introduces a new public interface. Skip only for trivial
   single-function changes (the agent must say so).
-- *Grill gate* — mandatory for high-blast-radius decisions (per `cheez-deps`).
+- *Grill gate* — mandatory for high-blast-radius decisions, where blast
+  radius is measured by `cheez-search` callers/imports for the touched
+  symbols.
 - *Open hypotheses must settle* — any Validate Cycle launched but unjudged
   blocks Crystallize unless the user accepts it as `[TBD]`.
 
@@ -234,7 +251,8 @@ Format selection table:
 | Dialogue signal | Output |
 | --- | --- |
 | Any meaningful design discussion | Spec |
-| Side-channel actionables (out-of-scope bugs, follow-ups) | Spec + Issues |
+| Side-channel actionables (out-of-scope bugs, follow-ups) | Spec + Issues (`bug`/`chore` flavor) |
+| Plan broke down into independently-grabbable atoms | Spec + Issues (`slice` flavor — vertical slices, AFK/HITL, blocked-by graph) |
 | Diagnose root cause + fix design | Spec (bug-shaped) + optional Issues |
 | Pure decision-only (no design) | Spec with only `Decisions` populated |
 

--- a/skills/mold/references/diagnose-mode.md
+++ b/skills/mold/references/diagnose-mode.md
@@ -1,0 +1,141 @@
+# Diagnose mode — disciplined symptom triage
+
+Diagnose is the entry mode for stack traces, "X is broken", "Y is slow",
+flake reports, and other symptom-shaped inputs. `/mold` Diagnose is
+**diagnostic-only**: it shapes the bug and the fix into a spec (plus
+optional follow-up issues), then hands off to `/fromage` for the actual
+patch.
+
+The single most important thing Diagnose does is force agreement on a
+**feedback loop** before hypothesising. A fast, deterministic pass/fail
+signal is what makes every later step mechanical.
+
+## Phase 0 — Build a Loop (the discipline)
+
+Before generating hypotheses, the agent and user pick **one** feedback
+loop technique. The chosen loop is recorded in the state file and becomes
+the bug-shaped spec's Reproduction block.
+
+### Menu (try in roughly this order)
+
+| Technique | When to use | Loop output |
+| --- | --- | --- |
+| Failing test | a unit / integration / e2e seam reaches the bug | red-green at a known seam |
+| Curl / HTTP script | bug reproduces against a running dev server | status code + body diff |
+| CLI invocation | command-line tool with a fixture input | stdout diff vs known-good snapshot |
+| Headless browser | UI-only bug | DOM / console / network assertions |
+| Replay captured trace | bug came from a real production payload | replay through code path in isolation |
+| Throwaway harness | system is too tangled to test through | minimal subset exercising the bug code path |
+| Property / fuzz loop | "sometimes wrong output" with random inputs | failure mode across N inputs |
+| Bisection harness | bug appeared between two known states | `git bisect run`-able pass/fail |
+| Differential loop | regression between two configs / versions | diff of outputs |
+| HITL bash script | last resort, human must click | structured loop driving a human, captured output |
+
+### Iterating on the loop
+
+Once a loop exists, it becomes a product the agent can refine:
+
+- **Faster?** Cache setup, skip unrelated init, narrow the test scope.
+- **Sharper signal?** Assert the specific symptom, not "didn't crash".
+- **More deterministic?** Pin time, seed RNG, isolate filesystem, freeze
+  network.
+
+A 30-second flaky loop is barely better than no loop. A 2-second
+deterministic loop is a debugging superpower.
+
+### Non-deterministic bugs
+
+The goal is not a clean repro but a **higher reproduction rate**. Loop the
+trigger 100×, parallelise, add stress, narrow timing windows, inject
+sleeps. A 50%-flake bug is debuggable; 1% is not — keep raising the rate
+until it's debuggable.
+
+### When you genuinely cannot build a loop
+
+Stop and say so explicitly. List what you tried. Ask the user for: (a)
+access to the environment that reproduces it, (b) a captured artifact (HAR
+file, log dump, core dump, screen recording with timestamps), or (c)
+permission to add temporary production instrumentation. Do **not** proceed
+to hypothesise without a loop.
+
+If the answer is still "no loop", Crystallize emits an issue with the
+Reproduction block marked `[BLOCKED]` so `/fromage` does not silently try
+to fix a bug it cannot verify.
+
+## Phase 1 — Reproduce
+
+Run the loop. Watch the bug appear. Confirm:
+
+- The loop produces the failure mode the **user** described — not a
+  different failure that happens to be nearby. Wrong bug = wrong fix.
+- The failure is reproducible across multiple runs (or, for
+  non-deterministic bugs, at a high enough rate to debug against).
+- The exact symptom (error message, wrong output, slow timing) is
+  captured so later phases can verify the fix actually addresses it.
+
+## Phase 2 — Hypothesize
+
+Generate **3-5 ranked, falsifiable hypotheses** before testing any of
+them. Single-hypothesis generation anchors on the first plausible idea.
+
+Each hypothesis takes the form:
+
+> If `<X>` is the cause, then `<changing Y>` will make the bug disappear /
+> `<changing Z>` will make it worse.
+
+If the prediction cannot be stated, the hypothesis is a vibe — discard or
+sharpen it.
+
+The Hypothesis Probe runs the ranked list as **parallel Validate Cycles**
+— one cycle per hypothesis, dispatched simultaneously. The cycle that
+returns SUPPORTED with the strongest evidence becomes the working root
+cause; cycles that return CONTRADICTED are recorded so future debuggers
+can see what was ruled out.
+
+Show the ranked list to the user before running the probe. They often
+have domain knowledge that re-ranks instantly ("we just deployed a change
+to #3"), or know hypotheses they've already ruled out. Cheap checkpoint,
+big time saver.
+
+## Phase 3 — Confirm root cause
+
+The surviving hypothesis becomes the working root cause. Before
+Crystallize, the agent must:
+
+- Run the Phase 0 loop again with the working root cause held in mind —
+  the prediction the hypothesis makes must match what the loop reports.
+- Distinguish "necessary" from "sufficient": is fixing this hypothesis
+  enough to make the loop go green, or are there contributing causes?
+- If the loop only goes green when **multiple** hypotheses are addressed,
+  Crystallize emits one spec for the primary fix plus an issue for each
+  contributing cause.
+
+## Hand-off to Crystallize
+
+The bug-shaped spec absorbs:
+
+- **Reproduction block** — the Phase 0 loop, verbatim. Anyone running the
+  spec can re-run the loop.
+- **Decisions** — the surviving hypothesis as a decision (`Context: ranked
+  list of N hypotheses; Decision: cause is X (cycle K SUPPORTED);
+  Consequences: fix touches Y`).
+- **Interface Sketches** — only if the fix shape requires a new seam or
+  changes a public signature. Trivial fixes skip Sketch.
+- **Open Questions** — every CONTRADICTED hypothesis stays as `[?]` for
+  posterity unless the user explicitly drops it.
+
+Follow-up bugs spotted along the way (out-of-scope to the primary fix)
+become **issues** with their own Reproduction blocks (each with its own
+loop, even if just "TBD: needs a loop before fix").
+
+## Anti-patterns
+
+- Skipping Phase 0 because "I already know what's wrong". The loop is
+  what makes the diagnosis falsifiable; without it, the agent is just
+  asserting.
+- Generating one hypothesis and confirming it. Ranked lists exist
+  because cheap eliminations are how you avoid expensive wrong fixes.
+- Treating a flaky loop as a real loop. Flake is a symptom of a loop
+  that hasn't been iterated on yet.
+- Letting Diagnose write code. The fix is `/fromage`'s job; Diagnose
+  produces the spec that lets `/fromage` verify the fix.

--- a/skills/mold/references/issue.md
+++ b/skills/mold/references/issue.md
@@ -6,13 +6,30 @@ GitHub-flavored and stand alone — independent enough to be filed as
 
 Issues exist when the dialogue surfaced **side-channel actionables**:
 out-of-scope follow-ups, bugs spotted along the way, parallel parking-lot
-work that happens to belong in the tracker, not the spec.
+work that happens to belong in the tracker, not the spec — or when a
+spec's plan was broken down into independently-grabbable vertical slices.
+
+## Flavors
+
+| Flavor | When | Body shape |
+| --- | --- | --- |
+| `bug` | dialogue surfaced a defect (Diagnose, or sighted during Ground/Grill) | Reproduction → Expected/Actual → Suggested Fix |
+| `slice` | spec's plan broke into thin vertical slices (tracer bullets) | What to build → Acceptance Criteria → Type/Blocked-by |
+| `chore` | follow-up cleanup, dependency bump, parking-lot work | Background → Suggested Fix |
+
+A slice issue is a **tracer bullet**: a thin vertical cut through every
+layer (schema, API, UI, tests) that delivers a complete, demoable
+behaviour change. Many thin slices beat a few thick ones. Each slice is
+either `AFK` (can be implemented and merged without human interaction) or
+`HITL` (requires human-in-the-loop — a design review, an architectural
+decision, a stakeholder sign-off). Prefer AFK over HITL.
 
 ## Frontmatter
 
 ```yaml
 ---
 kind: issue
+flavor: bug | slice | chore
 slug: <parent-slug>-<NNN>
 title: <Imperative summary, < 70 chars>
 created: <YYYY-MM-DD>
@@ -20,14 +37,17 @@ status: draft
 labels: [<bug|feature|chore|...>, <area-tag>]
 priority: <P0|P1|P2|P3>
 parent_spec: <slug of the parent spec, if any>
+slice_type: AFK | HITL              # slice flavor only
+blocked_by: [<sibling issue path>]  # slice flavor only; empty list if none
 ---
 ```
 
 `slug` carries a numeric suffix tied to the parent spec's series
 (`dark-mode-001`, `dark-mode-002`). Stand-alone issues with no parent use
-their own slug (`broken-rate-limit-001`).
+their own slug (`broken-rate-limit-001`). Slices keep the same series so
+`blocked_by` references stay readable.
 
-## Body template
+## Body template — bug flavor
 
 ```markdown
 # <Imperative title>
@@ -41,16 +61,11 @@ conversation that surfaced it>.
 2. <Step>
 3. <Step>
 
-(Drop this section for non-bug issues. Replace with `## Background` for
-chores or follow-ups).
-
 ## Expected Behavior
 <What should happen>.
 
 ## Actual Behavior
 <What happens instead>.
-
-(Drop both for non-bug issues).
 
 ## Suggested Fix
 <One paragraph or a fenced pseudocode block, where applicable>.
@@ -63,17 +78,70 @@ chores or follow-ups).
 <What this issue intentionally does not cover>.
 ```
 
+## Body template — slice flavor
+
+```markdown
+# <Imperative title>
+
+## Parent
+<Reference to the parent spec or umbrella issue. Omit for stand-alone
+slices>.
+
+## What to build
+<End-to-end behaviour change this slice delivers. Layer-agnostic — describe
+the behaviour, not the schema/API/UI breakdown>.
+
+## Acceptance Criteria
+- [ ] <Specific, verifiable criterion — not "works correctly">
+- [ ] <Another criterion>
+
+## Type
+<AFK | HITL — and one sentence on why if HITL>.
+
+## Blocked by
+- <Reference to the blocking sibling issue>
+
+(Or `None — can start immediately` if no blockers.)
+
+## Out of Scope
+<What this slice intentionally does not cover>.
+```
+
+## Body template — chore flavor
+
+```markdown
+# <Imperative title>
+
+## Context
+<2-4 sentences. Why this is filed>.
+
+## Background
+<Why now, what triggered the chore. Replaces Reproduction for non-bugs>.
+
+## Suggested Fix
+<One paragraph or a fenced pseudocode block, where applicable>.
+
+## Acceptance Criteria
+- [ ] <Specific, verifiable criterion>.
+
+## Out of Scope
+<What this issue intentionally does not cover>.
+```
+
 ## Section presence
 
-| Section | Always | Drop when |
-| --- | --- | --- |
-| Context | yes | — |
-| Reproduction | bug only | issue is a follow-up or chore |
-| Expected / Actual | bug only | issue is a follow-up or chore |
-| Background | non-bug only | issue is a bug |
-| Suggested Fix | yes | — |
-| Acceptance Criteria | yes | — |
-| Out of Scope | when ambiguous | scope is obvious |
+| Section | bug | slice | chore |
+| --- | --- | --- | --- |
+| Context | yes | as Parent | yes |
+| Reproduction | yes | — | — |
+| Expected / Actual | yes | — | — |
+| What to build | — | yes | — |
+| Background | — | — | yes |
+| Type (AFK/HITL) | — | yes | — |
+| Blocked by | — | yes | — |
+| Suggested Fix | yes | — | yes |
+| Acceptance Criteria | yes | yes | yes |
+| Out of Scope | when ambiguous | when ambiguous | when ambiguous |
 
 ## Filing flow
 

--- a/skills/mold/references/issue.md
+++ b/skills/mold/references/issue.md
@@ -1,0 +1,107 @@
+# Issue template
+
+Issues are the second artifact type `/mold` can crystallize. They are
+GitHub-flavored and stand alone — independent enough to be filed as
+`gh issue create --body-file <path>` without the parent spec.
+
+Issues exist when the dialogue surfaced **side-channel actionables**:
+out-of-scope follow-ups, bugs spotted along the way, parallel parking-lot
+work that happens to belong in the tracker, not the spec.
+
+## Frontmatter
+
+```yaml
+---
+kind: issue
+slug: <parent-slug>-<NNN>
+title: <Imperative summary, < 70 chars>
+created: <YYYY-MM-DD>
+status: draft
+labels: [<bug|feature|chore|...>, <area-tag>]
+priority: <P0|P1|P2|P3>
+parent_spec: <slug of the parent spec, if any>
+---
+```
+
+`slug` carries a numeric suffix tied to the parent spec's series
+(`dark-mode-001`, `dark-mode-002`). Stand-alone issues with no parent use
+their own slug (`broken-rate-limit-001`).
+
+## Body template
+
+```markdown
+# <Imperative title>
+
+## Context
+<2-4 sentences. Why this is filed. Reference the parent spec or the
+conversation that surfaced it>.
+
+## Reproduction
+1. <Step>
+2. <Step>
+3. <Step>
+
+(Drop this section for non-bug issues. Replace with `## Background` for
+chores or follow-ups).
+
+## Expected Behavior
+<What should happen>.
+
+## Actual Behavior
+<What happens instead>.
+
+(Drop both for non-bug issues).
+
+## Suggested Fix
+<One paragraph or a fenced pseudocode block, where applicable>.
+
+## Acceptance Criteria
+- [ ] <Specific, verifiable criterion — not "works correctly">
+- [ ] <Another criterion>
+
+## Out of Scope
+<What this issue intentionally does not cover>.
+```
+
+## Section presence
+
+| Section | Always | Drop when |
+| --- | --- | --- |
+| Context | yes | — |
+| Reproduction | bug only | issue is a follow-up or chore |
+| Expected / Actual | bug only | issue is a follow-up or chore |
+| Background | non-bug only | issue is a bug |
+| Suggested Fix | yes | — |
+| Acceptance Criteria | yes | — |
+| Out of Scope | when ambiguous | scope is obvious |
+
+## Filing flow
+
+After the spec write succeeds (or the user picks "Issues only"), `/mold`
+offers:
+
+```
+Filed:
+  - <harness>/specs/<slug>.md       (1 spec)
+  - <harness>/issues/<slug>-001.md  (1 issue)
+  - <harness>/issues/<slug>-002.md  (1 issue)
+
+File these as GitHub issues now? (y/N)
+```
+
+If yes, run one `gh issue create --title <frontmatter title> --body-file
+<path>` per issue file. Surface the resulting issue URLs back to the user.
+
+## Linkage
+
+- Each issue's `parent_spec` field points at its sibling spec slug.
+- The spec's `related` frontmatter array lists the issue file paths.
+
+This bidirectional link is the only structural relationship between the two
+artifact types. Everything else is content.
+
+## Collisions
+
+If an issue with the same slug already exists, default to `<slug>-<NNN+1>`
+(append next number in series). Never silently overwrite an existing issue
+file.

--- a/skills/mold/references/loop-detection.md
+++ b/skills/mold/references/loop-detection.md
@@ -68,7 +68,7 @@ From here, the smallest move is <X>. Confirm or redirect.
 The state file is the source of truth. After every turn the agent:
 
 1. Updates `Mode history`.
-2. Increments a `Drift counter` if the turn produced no new entry in
+2. Increments `drift_counter` if the turn produced no new entry in
    `Decisions`, `Sketches`, or `Validate cycles`.
 3. Resets the counter when an entry lands.
 4. Compares the user's last 2 messages against the bored-user pattern.

--- a/skills/mold/references/loop-detection.md
+++ b/skills/mold/references/loop-detection.md
@@ -1,0 +1,96 @@
+# Loop detection
+
+The `/mold` dialogue can stall in three predictable ways. The agent watches
+for them and surfaces an intervention before the user has to.
+
+## Triggers
+
+### Drift
+
+**Definition.** Four consecutive turns without a new entry in
+`Decisions`, `Sketches`, or `Validate cycles` blocks of the state file.
+
+**Signal.** The conversation is *moving* but not *converging* — questions
+chase questions, options proliferate, no decisions land.
+
+**Action.**
+
+```
+We've gone four turns without a new decision, sketch, or validate cycle.
+Two ways to break out:
+  A. Synthesis turn — I summarize what we have and propose the next concrete
+     step.
+  B. Pause — save state to scratch and resume later.
+
+Which?
+```
+
+### Bored user
+
+**Definition.** Terse responses (`ok`, `meh`, `idk`, `whatever`, single-word
+acknowledgements) **two or more turns in a row**.
+
+**Signal.** The user is no longer engaged. Continuing burns trust.
+
+**Action.** Surface the escape hatches explicitly:
+
+```
+You sound disengaged. Options:
+  A. Switch modes — `explore` (back up) | `shape` (skip to options) |
+     `sketch` (lock interfaces now).
+  B. Crystallize what we have, even if rough — I'll mark gaps as [TBD].
+  C. Pause — bail out, no artifacts.
+
+Or just type the knob you want.
+```
+
+### Rabbit hole
+
+**Definition.** Three or more mode transitions in the last five turns AND no
+new state-file entries during that window.
+
+**Signal.** The session is thrashing — every mode change is a context switch
+that costs more than it produces.
+
+**Action.** Force a synthesis turn before any further mode change:
+
+```
+We have transitioned modes three times in the last five turns without
+producing a decision, sketch, or validate cycle. Forcing a synthesis turn:
+
+<one paragraph summarizing where we actually are>
+
+From here, the smallest move is <X>. Confirm or redirect.
+```
+
+## Detection mechanics
+
+The state file is the source of truth. After every turn the agent:
+
+1. Updates `Mode history`.
+2. Increments a `Drift counter` if the turn produced no new entry in
+   `Decisions`, `Sketches`, or `Validate cycles`.
+3. Resets the counter when an entry lands.
+4. Compares the user's last 2 messages against the bored-user pattern.
+5. Inspects the last five entries of `Mode history` for the rabbit-hole
+   condition.
+
+When any trigger fires, the agent **must** surface it before answering the
+substantive question that came in. Loop detection always pre-empts
+content.
+
+## False positives
+
+Some legitimate sessions look like drift but are not:
+
+- The user is reading along while the agent does a Sketch sweep — turns
+  produce sketches, so the counter resets.
+- The user is reading a `/briesearch` synthesis — that synthesis writes a
+  `Validate cycles` entry, which resets the counter.
+- The user is intentionally exploring options without picking one — the
+  Shape mode produces an Option block in the state file's `Decisions` (as
+  a candidate, marked `[?]`), which still resets the counter.
+
+If the user pushes back on an intervention ("we're fine, keep going"),
+record the override and skip the next two trigger checks. Do not let loop
+detection itself become noise.

--- a/skills/mold/references/routing.md
+++ b/skills/mold/references/routing.md
@@ -1,0 +1,63 @@
+# Routing — input shape to starting mode
+
+`/mold` chooses one starting mode on entry. The agent announces the choice
+in one line so the user can override (`explore`, `ground`, `shape`, ...).
+
+## Classifier
+
+Walk the heuristics top-down. The **first** match wins.
+
+1. **Diagnose** — the input contains:
+   - Stack frames or `file.ext:NNN` references plus an exception or error
+     keyword (`TypeError`, `panic`, `Traceback`, `Exception`, ...), OR
+   - Symptom verbs combined with a subject ("X is broken", "Y is slow",
+     "Z hangs", "flaky", "crashing", "intermittent failure").
+2. **Ground** — the input is, or points at, a concrete artifact:
+   - File path that exists in the repo, OR
+   - PR or issue reference (URL, `#1234`), OR
+   - A spec path under the active harness root, OR
+   - "Read X and tell me ..." style requests.
+3. **Sketch** — the input contains existing structure to refine:
+   - Fenced code blocks containing function signatures or schemas, OR
+   - "Here's my draft design ..." with module names and contracts, OR
+   - The user explicitly asks "lock down the interfaces for ...".
+4. **Shape** — the input names a concrete *thing* to add or change:
+   - "I want to add ...", "Let's build ...", "We should support ..." with
+     concrete nouns, OR
+   - The user explicitly asks for options ("give me options", "how should
+     I approach ...").
+5. **Grill** — the input is a tentative plan looking for stress-testing:
+   - "Should we do X?", "I'm thinking about Y", "Is this approach sane?",
+     OR
+   - The user explicitly asks "interrogate this" / "poke holes".
+6. **Explore** — default fallback for vague nouns, half-sentences, "thinking
+   about", or anything that did not match above.
+
+## Confidence
+
+Score the chosen mode 0-100 from the strength of its trigger:
+
+- 90+ — multiple strong signals (stack trace + file:line + error keyword).
+- 60-89 — single strong signal (named artifact, named approach + nouns).
+- 40-59 — soft signal only (vague noun + tentative verb).
+- < 40 — no clear signal; default to **Explore** regardless.
+
+If confidence is below 60, announce the mode plus the alternative the agent
+considered, and explicitly invite a knob redirect.
+
+## Examples
+
+| Input | Mode | Reason |
+| --- | --- | --- |
+| `TypeError: cannot read property 'foo' of undefined at app.ts:142` | Diagnose | error keyword + file:line |
+| `<harness>/specs/dark-mode.md` | Ground | spec path; read first |
+| `def dispatch(...): ... # what should the return type be?` | Sketch | existing signature with question |
+| `I want to add idempotency to the dispatcher` | Shape | concrete noun, additive verb |
+| `Should we extract the dedup layer into its own slice?` | Grill | tentative verb on a plan |
+| `thinking about how we handle retries someday` | Explore | hedged, no chosen direction |
+
+## Pivots
+
+A user knob immediately changes mode. The classifier only runs at entry —
+mid-session pivots come from knobs or from the agent surfacing a guard
+condition (e.g. "we have not Grounded yet; switching to Ground for one pass").

--- a/skills/mold/references/sketch-mode.md
+++ b/skills/mold/references/sketch-mode.md
@@ -1,0 +1,110 @@
+# Sketch mode — interface lockdown
+
+Sketch is the cognitive job of turning a chosen approach into pseudocode
+signatures and contracts. It is **not** writing code. It is plan, expressed
+in a shape `/fromage` can compile into target idioms.
+
+## Entry
+
+Enter Sketch when:
+
+- Shape picked an option, OR
+- The starting input was already a half-baked design doc with signatures.
+
+If Sketch is mandatory (chosen option touches more than one module or
+introduces a new public interface) and the user tries to skip to Crystallize,
+the coherence gate blocks the handshake until Sketch runs.
+
+## The pseudocode-driven question pattern
+
+For each public seam, the agent:
+
+1. **Drafts a signature** with named arguments and a return type.
+2. **Names the unknowns** — places where a decision is needed.
+3. **Recommends an answer** for each unknown, with one-line rationale.
+4. **Invites compact confirmation** (`1A 2A`) or push-back.
+
+Example:
+
+```
+Draft signature for the dispatcher:
+
+    def dispatch_notification(
+        recipient: NotificationRecipient,
+        payload: NotificationPayload,
+        idempotency_key: str,             # ← unknown #1
+    ) -> DeliveryReceipt:                  # ← unknown #2
+
+Unknowns:
+  1. `idempotency_key: str` — caller-generated or middleware-injected?
+     I'd say caller-generated. The caller owns "what counts as the same event."
+  2. Return — sync `DeliveryReceipt` or async event?
+     I'd say async. The receipt becomes a `NotificationDelivered` event.
+
+Push back on either, or `1A 2A` to confirm.
+```
+
+## Pseudocode style
+
+- **Python-flavored** as the universal shape (function-style signatures,
+  type hints). `/fromage` translates to the target language at implement
+  time.
+- **Names + types + contracts.** Not bodies. Not implementations.
+- **Error shape** is part of the contract — name the exception or result
+  variants explicitly when failure is part of the seam.
+- **Side effects** declared at signature level when they cross a slice
+  boundary ("emits `NotificationDelivered`", "reads from `dedup_cache`").
+
+## Sibling sweep
+
+Before drafting a signature for a module, run a **parallel** `cheez-search`
+for nearby siblings in the same domain so new signatures fit the
+conventions already there.
+
+```
+Parallel sketches sweep:
+  cheez-search query: "dispatch" scope: "src/notifications/"
+  cheez-search query: "queue, enqueue" scope: "src/notifications/"
+  cheez-deps path: "src/notifications/index.ts"
+```
+
+If the sweep surfaces a sibling that mirrors what we are about to design,
+adopt the sibling's shape unless there is a stated reason to diverge.
+
+## Validate Cycle inside Sketch
+
+When a signature mirrors an external API ("our `dispatch` matches Stripe's
+`PaymentIntent.create` shape"), invoke a Validate Cycle on that hypothesis
+before locking the signature. Common cycles:
+
+- "Library X exposes `<method>(<args>) -> <return>`."
+- "Convention Y in our codebase puts `<arg>` in the body, not the headers."
+- "Sibling Z returns `<type>` rather than `<other type>`."
+
+## Output
+
+Sketches live in the state file's `Sketches (locked interfaces)` block
+during the loop, then migrate verbatim into the spec's `Interface Sketches`
+section at Crystallize. Each sketch carries:
+
+- `module` — slice or path.
+- `signature` — pseudocode block.
+- `responsibilities` — bullet list (1-3 items).
+- `seams` — named external integrations (queue, cache, event bus, ...).
+- `error shape` — exceptions or result variants.
+
+## Exit
+
+Exit Sketch when **every** public seam touched by the chosen option has a
+signature and every cross-module call has a contract. Trivial single-function
+changes can skip Sketch entirely; the agent must say so explicitly so the
+coherence gate records the override.
+
+## Anti-patterns
+
+- Drafting code, not signatures. Sketch is plan.
+- Skipping the sibling sweep, then producing a signature that fights existing
+  conventions.
+- Locking a signature without a Validate Cycle when it mirrors an external
+  API.
+- Leaving unknowns implicit instead of named with a recommended answer.

--- a/skills/mold/references/sketch-mode.md
+++ b/skills/mold/references/sketch-mode.md
@@ -65,8 +65,13 @@ conventions already there.
 Parallel sketches sweep:
   cheez-search query: "dispatch" scope: "src/notifications/"
   cheez-search query: "queue, enqueue" scope: "src/notifications/"
-  cheez-deps path: "src/notifications/index.ts"
+  cheez-search query: "dispatch" kind: "callers" scope: "src/"
+  cheez-search deps: "src/notifications/index.ts"
 ```
+
+`cheez-search` exposes both `tilth_search` (definitions, usages, callers)
+and `tilth_deps` (imports, imported-by). The blast-radius and sibling
+work happens through that single skill.
 
 If the sweep surfaces a sibling that mirrors what we are about to design,
 adopt the sibling's shape unless there is a stated reason to diverge.

--- a/skills/mold/references/spec.md
+++ b/skills/mold/references/spec.md
@@ -1,0 +1,193 @@
+# Spec template
+
+The spec is the rich container produced at Crystallize. It absorbs
+PRD-leaning, ERD-leaning, decision-log, and interface-sketch content as
+named sections. Functional and non-functional requirements are always
+present. All other conditional sections are populated only when the
+dialogue produced relevant signal — never as empty placeholders.
+
+A "small spec" (the engineering one-pager) is just a spec where most
+conditional sections are dropped and FR / NFR are minimal. Same template,
+less content.
+
+## Frontmatter
+
+```yaml
+---
+kind: spec
+slug: <kebab-case>
+title: <Human Readable>
+created: <YYYY-MM-DD>
+status: draft
+related: [<sibling issue paths>]
+confidence: <0-100>
+sketches_locked: true|false
+---
+```
+
+## Section presence rules
+
+| Section | Always | Conditional trigger |
+| --- | --- | --- |
+| Executive Summary | yes | — |
+| Problem Statement | yes | — |
+| Users & Pain | no | dialogue surfaced user/business signal |
+| Goals | yes | — |
+| Non-Goals | yes | — |
+| Functional Requirements | yes | — |
+| Non-Functional Requirements | yes | — |
+| Context (Existing Landscape, Constraints, Dependencies) | yes | — |
+| Entity Model | no | dialogue surfaced schema or relationships |
+| Approach (Options A/B/Do-Nothing) | yes | — |
+| Interface Sketches | no | Sketch mode produced any signatures |
+| Decisions | no | dialogue resolved hard-to-reverse choices |
+| Risks & Mitigations | yes | — |
+| Quality Gates | yes | — |
+| Open Questions | yes | — |
+
+Empty conditional sections are dropped at write time. Do not leave headings
+followed by `_(none)_` placeholders.
+
+## Body template
+
+```markdown
+# <Feature>
+
+## Executive Summary
+<3-5 sentences: what we're building, why, and the key decision>.
+
+## Problem Statement
+<JTBD framing — the job this feature does for the user. Drawn from Beat 0
+of Explore mode>.
+
+## Users & Pain
+- Who feels this today
+- Why now
+- What this unlocks
+
+## Goals
+- [ ] <Goal>
+
+## Non-Goals
+<What we're explicitly NOT doing>.
+
+## Functional Requirements
+- FR-1: The system must <verb> when <condition>.
+- FR-2: <...>
+
+## Non-Functional Requirements
+- NFR-1: <latency, availability, security, observability constraint>.
+- NFR-2: <...>
+
+## Context
+
+### Existing Landscape
+<What already exists, with file refs from cheez-search>.
+
+### Constraints
+<Technical, business, timeline>.
+
+### Dependencies
+<What we depend on; what depends on us>.
+
+## Entity Model
+
+```mermaid
+erDiagram
+  USER ||--o{ SUBSCRIPTION : owns
+```
+
+### Entities
+- **USER** — <description>
+- **SUBSCRIPTION** — <description>
+
+## Approach
+
+### Option A: <Name> (Recommended)
+<Description, trade-offs, why recommended>.
+> [confidence: 80] Evidence: <validate cycle ref, cheez-search refs, briesearch ref>
+
+### Option B: <Name>
+<Description, why not chosen, what would flip the decision>.
+> [confidence: 65] Evidence: <...>
+
+### Option C: Do Nothing
+<What happens if we don't build this; conditions under which Do Nothing wins>.
+
+## Interface Sketches
+> Pseudocode signatures locked during /mold. Names + types + contracts; not
+> final code. /fromage translates to the target idioms.
+
+### `<module path>`
+**Responsibilities:** <one>, <two>, <three>.
+**Seams:** <queue>, <cache>, <event_bus>.
+
+```pseudo
+def <name>(
+    <arg>: <Type>,
+    ...
+) -> <Return>
+```
+
+**Error shape:** `<ExceptionA>` — <when>; `<ExceptionB>` — <when>.
+
+## Decisions
+> Append-only. Each decision: Context, Decision, Consequences.
+
+### D-1: <Decision title>
+**Context:** <one paragraph>.
+**Decision:** <one paragraph>.
+**Consequences:** <one paragraph>.
+> [confidence: 85] <Validate cycle ref>; <Grill turn ref>.
+
+## Risks & Mitigations
+- **Risk:** <what could fail> → **Mitigation:** <how we prevent or recover>.
+
+## Quality Gates
+- `<command>` — <what it checks>.
+
+## Open Questions
+- [?] <agent uncertainty>
+- [TBD] <user-deferred decision>
+- [BLOCKED] <external dependency>
+```
+
+## Confidence formula
+
+Document-level `confidence` in the frontmatter is mechanical:
+
+```
+base       = min(rounds * 15, 100)
+penalties  = 20 * count([BLOCKED]) + 10 * count([TBD]) + 5 * count([?])
+bonuses    = 5 * count(SUPPORTED validate cycles)
+malus      = 10 * count(CONTRADICTED validate cycles)
+confidence = clamp(base - penalties + bonuses - malus, 0, 100)
+```
+
+Inline confidence at decision points uses the same scale and cites the
+specific evidence (validate cycle id, Grill turn, sibling file ref).
+
+## Migration from state file
+
+At Crystallize:
+
+- `Decisions (resolved)` block in state → `Decisions` section in spec
+  (with Context / Decision / Consequences expanded by the agent).
+- `Sketches (locked interfaces)` block → `Interface Sketches` section.
+- `Validate cycles` block → cited inline in Approach, Decisions, and
+  Interface Sketches sections via `> [confidence: ...] Evidence: ...`.
+- `Open questions` block → `Open Questions` section verbatim.
+
+## Collisions
+
+| Existing | Default | Override |
+| --- | --- | --- |
+| Same slug, status `draft` | overwrite | `<slug>-v2` rev |
+| Same slug, status `approved` | rev to `<slug>-v2` | never silently overwrite |
+| Existing spec, new issues for same slug | append issues to that slug's series | — |
+
+## Atomic write
+
+Stage to `${TMPDIR:-/tmp}/cheese-flow-mold-<run_id>/staged/` and `mv` into
+place. On failure, the temp directory is removed and no partial files exist
+in the harness output root.

--- a/skills/mold/references/spec.md
+++ b/skills/mold/references/spec.md
@@ -185,6 +185,9 @@ def <name>(
 Document-level `confidence` in the frontmatter is mechanical:
 
 ```
+# rounds = count of distinct mode entries in the state file's Mode history
+#          (each Explore/Ground/Shape/Sketch/Grill/Diagnose segment counts as 1;
+#           inline validate-cycle markers are excluded from the count)
 base       = min(rounds * 15, 100)
 penalties  = 20 * count([BLOCKED]) + 10 * count([TBD]) + 5 * count([?])
 bonuses    = 5 * count(SUPPORTED validate cycles)
@@ -216,6 +219,8 @@ At Crystallize:
 
 ## Atomic write
 
-Stage to `${TMPDIR:-/tmp}/cheese-flow-mold-<run_id>/staged/` and `mv` into
-place. On failure, the temp directory is removed and no partial files exist
-in the harness output root.
+Stage to `<harness>/.mold-staging-<run_id>/` (a sibling of the destination,
+guaranteed same filesystem) and `mv` into place. This ensures `mv` is an
+atomic rename rather than a cross-filesystem copy+delete. On failure, the
+staging directory is removed and no partial files exist in the harness output
+root.

--- a/skills/mold/references/spec.md
+++ b/skills/mold/references/spec.md
@@ -34,6 +34,7 @@ sketches_locked: true|false
 | Users & Pain | no | dialogue surfaced user/business signal |
 | Goals | yes | — |
 | Non-Goals | yes | — |
+| User Stories | yes | for pure-refactor specs, a single maintainer story is fine |
 | Functional Requirements | yes | — |
 | Non-Functional Requirements | yes | — |
 | Context (Existing Landscape, Constraints, Dependencies) | yes | — |
@@ -43,6 +44,7 @@ sketches_locked: true|false
 | Decisions | no | dialogue resolved hard-to-reverse choices |
 | Risks & Mitigations | yes | — |
 | Quality Gates | yes | — |
+| Red/Green Paths | no | dialogue produced end-to-end verification scenarios |
 | Open Questions | yes | — |
 
 Empty conditional sections are dropped at write time. Do not leave headings
@@ -70,6 +72,25 @@ of Explore mode>.
 
 ## Non-Goals
 <What we're explicitly NOT doing>.
+
+## User Stories
+> Format: `As a <user>, I want <feature> so that <benefit>.` Each story
+> carries machine-checkable acceptance criteria so `/fromage` can plan
+> against them without re-asking. Pure-refactor specs can ship with a
+> single maintainer story; the section is never empty.
+
+### US-001: <Title>
+**Story:** As a <user>, I want <feature> so that <benefit>.
+
+**Acceptance criteria:**
+- [ ] <Specific, verifiable criterion — not "works correctly".>
+- [ ] <Another criterion>.
+
+### US-002: <Title>
+**Story:** As a <user>, I want <feature> so that <benefit>.
+
+**Acceptance criteria:**
+- [ ] <...>.
 
 ## Functional Requirements
 - FR-1: The system must <verb> when <condition>.
@@ -145,6 +166,13 @@ def <name>(
 
 ## Quality Gates
 - `<command>` — <what it checks>.
+
+## Red/Green Paths
+> End-to-end verification scenarios. The agent picks one Green path per
+> US-NNN and at least one Red path that exercises the unhappy seam.
+
+- **Green:** <user does X> → <system responds with Y> → <state becomes Z>.
+- **Red:** <user does X without <precondition>> → <system returns <error>> → <no state change>.
 
 ## Open Questions
 - [?] <agent uncertainty>

--- a/skills/mold/references/spec.md
+++ b/skills/mold/references/spec.md
@@ -31,6 +31,7 @@ sketches_locked: true|false
 | --- | --- | --- |
 | Executive Summary | yes | — |
 | Problem Statement | yes | — |
+| Reproduction | no | Diagnose mode populated a Phase 0 loop |
 | Users & Pain | no | dialogue surfaced user/business signal |
 | Goals | yes | — |
 | Non-Goals | yes | — |
@@ -61,6 +62,27 @@ followed by `_(none)_` placeholders.
 ## Problem Statement
 <JTBD framing — the job this feature does for the user. Drawn from Beat 0
 of Explore mode>.
+
+## Reproduction
+> Bug-shaped specs only. The Phase 0 feedback loop from Diagnose mode lands
+> here verbatim. Human-supplied; the agent does not infer steps or signals.
+
+**Loop technique:** <failing-test | curl-script | cli-invocation | headless-browser | replay | throwaway-harness | property-fuzz | bisection | differential | HITL-bash>
+
+**Loop command:** <exact, deterministic command or script — runnable by `/fromage` to verify the fix>
+
+**Failure signal:** <specific symptom: error message, wrong output, slow timing — what the loop reports when the bug is present>
+
+**Reproduction rate:** <100% | high (e.g. 50/100 runs) | flaky (low single digits — must be raised before debugging)>
+
+### Steps
+1. <step>
+2. <step>
+3. <step>
+
+### Expected vs Actual
+- **Expected:** <what should happen>.
+- **Actual:** <what happens instead>.
 
 ## Users & Pain
 - Who feels this today
@@ -208,6 +230,11 @@ At Crystallize:
 - `Validate cycles` block → cited inline in Approach, Decisions, and
   Interface Sketches sections via `> [confidence: ...] Evidence: ...`.
 - `Open questions` block → `Open Questions` section verbatim.
+- `Reproduction loop` block (Diagnose only) → `Reproduction` section verbatim;
+  agent fills in Steps and Expected/Actual from the loop's recorded behaviour.
+- `Grill turns` block → not migrated to spec; serves the coherence checklist
+  (turn-completion proof) and stays in scratch state.
+- `Quality gates` block → `Quality Gates` section verbatim.
 
 ## Collisions
 
@@ -216,6 +243,12 @@ At Crystallize:
 | Same slug, status `draft` | overwrite | `<slug>-v2` rev |
 | Same slug, status `approved` | rev to `<slug>-v2` | never silently overwrite |
 | Existing spec, new issues for same slug | append issues to that slug's series | — |
+
+`/mold` writes new specs as `status: draft`. The `draft` → `approved`
+transition is **external** — a human reviewer flips the field after sign-off.
+`/mold` never auto-promotes. The `approved` collision branch fires when a
+later `/mold` run encounters a previously-approved spec, and protects it from
+silent overwrite.
 
 ## Atomic write
 

--- a/skills/mold/references/state-schema.md
+++ b/skills/mold/references/state-schema.md
@@ -1,0 +1,98 @@
+# State file schema
+
+`/mold` keeps one scratch state file per run. The path mirrors `/briesearch`'s
+scratch convention so cleanup is predictable.
+
+## Path
+
+```
+${TMPDIR:-/tmp}/cheese-flow-mold-<run_id>/state.md
+```
+
+Where `<run_id>` is `<YYYYmmdd-HHMMSS>-<slug>`. The slug is derived from the
+input (lowercase, drop stopwords, kebab-case, cap at 5 words). The directory
+is auto-evicted at the OS's `$TMPDIR` schedule.
+
+## Schema
+
+```markdown
+# /mold state — <run_id>
+mode: <Explore|Ground|Shape|Sketch|Grill|Diagnose>
+input_summary: <one paragraph in the user's words, paraphrased>
+drift_counter: <integer>
+briesearch_used: <integer>      # 0..2 unless user lifts the cap
+
+## Decisions (resolved)
+- <Decision title> — <one-line summary> (agreed turn <N>)
+- ...
+
+## Sketches (locked interfaces)
+- module: <slice or path>
+  signature: |
+    def <name>(
+        <arg>: <Type>,
+        ...
+    ) -> <Return>
+  responsibilities: [<one>, <two>, <three>]
+  seams: [<queue>, <cache>, <event_bus>, ...]
+  error_shape: [<ExceptionA>, <ResultVariantB>]
+
+## Validate cycles
+- cycle 1: "<hypothesis>" → SUPPORTED (briesearch turn 6)
+- cycle 2: "<hypothesis>" → REFINED (cheez-search turn 9; see cycle 3)
+- cycle 3: "<refined hypothesis>" → SUPPORTED (cheez-read turn 10)
+  refined_from: cycle 2
+- cycle 4: "<hypothesis>" → CONTRADICTED (briesearch turn 14)
+  conflict_id: cf-1
+
+## Open questions
+- [?] <agent uncertainty> — agent recommends <answer>
+- [TBD] <user-deferred decision> — user wants to think
+- [BLOCKED] <external dependency>
+- [CONFLICT cf-1] <statement> contradicted by <evidence>
+
+## Mode history
+Explore (1-3) → Ground (4-5) → Shape (6-8) → [validate cycle 1] → Sketch (9-11)
+  → [validate cycle 2] → [validate cycle 3] → Grill (12-now)
+```
+
+## Field rules
+
+- **mode** — current mode. Updated on every transition.
+- **input_summary** — frozen on entry. Only updated if the user explicitly
+  redirects the problem.
+- **drift_counter** — integer, see `loop-detection.md`. Reset to 0 on any
+  new `Decisions`, `Sketches`, or `Validate cycles` entry.
+- **briesearch_used** — incremented when a Validate Cycle dispatches
+  `/briesearch`. Capped at 2 by default. Lifted only on explicit user
+  request.
+- **Decisions** — append-only. Each line is `<title> — <summary> (agreed
+  turn <N>)`. Decisions stand until the user explicitly reverses one.
+- **Sketches** — append-only. Locked sketches feed the spec verbatim.
+  Each sketch is a small block with `module`, `signature`, `responsibilities`,
+  `seams`, `error_shape`.
+- **Validate cycles** — append-only. Outcomes are exactly one of `SUPPORTED`,
+  `CONTRADICTED`, `REFINED`. REFINED cycles point at their refined-form id.
+  CONTRADICTED cycles get a `conflict_id` that ties to an `Open questions`
+  entry.
+- **Open questions** — every entry carries one of `[?]`, `[TBD]`,
+  `[BLOCKED]`, `[CONFLICT <id>]`. The Crystallize coherence gate fails if
+  any entry lacks a marker.
+- **Mode history** — turn-numbered, includes inline cycle markers.
+
+## Lifecycle
+
+- **Create** — on first turn, after routing picks the entry mode.
+- **Update** — every turn the agent writes the file (replace, not append).
+- **Read** — the agent reads the previous state at the start of each turn.
+- **Migrate to spec** — on Crystallize, the spec template absorbs
+  `Decisions` and `Sketches` verbatim into named sections. Validate cycles
+  feed confidence and the spec's evidence rows.
+- **Cleanup** — after a successful Crystallize *and* the user accepts the
+  hand-off offer, the run directory is removed. Otherwise it stays for the
+  OS to evict.
+
+## Resume (deferred)
+
+`v1` does not support resume. The state path is documented so a future
+`--resume` can read it. Do not rely on resume in the current iteration.

--- a/skills/mold/references/state-schema.md
+++ b/skills/mold/references/state-schema.md
@@ -51,6 +51,26 @@ briesearch_used: <integer>      # 0..2 unless user lifts the cap
 - [BLOCKED] <external dependency>
 - [CONFLICT cf-1] <statement> contradicted by <evidence>
 
+## Grill turns
+- turn <N>: branch=<name> question="<short>" recommendation=<choice> user_answer=<choice>
+- ...
+
+## Quality gates
+- `<command>` — <what it checks> (agreed turn <N>)
+- ...
+
+## Reproduction loop  # Diagnose mode only
+technique: <failing-test|curl-script|cli-invocation|headless-browser|replay|throwaway-harness|property-fuzz|bisection|differential|HITL-bash>
+command: |
+  <exact, deterministic command or script>
+failure_signal: <specific symptom>
+reproduction_rate: <100% | high | flaky>
+steps:
+  - <step 1>
+  - <step 2>
+expected: <what should happen>
+actual: <what happens>
+
 ## Mode history
 Explore (1-3) → Ground (4-5) → Shape (6-8) → [validate cycle 1] → Sketch (9-11)
   → [validate cycle 2] → [validate cycle 3] → Grill (12-now)
@@ -78,6 +98,17 @@ Explore (1-3) → Ground (4-5) → Shape (6-8) → [validate cycle 1] → Sketch
 - **Open questions** — every entry carries one of `[?]`, `[TBD]`,
   `[BLOCKED]`, `[CONFLICT <id>]`. The Crystallize coherence gate fails if
   any entry lacks a marker.
+- **Grill turns** — append-only. One line per Grill question. Records the
+  branch traversed, the question asked, the agent's recommended answer, and
+  the user's chosen answer. Tracks turn-completion (presence), not content
+  quality. The coherence checklist's "Chosen option Grilled" item counts
+  branches covered against the agent's branch list at Sketch exit.
+- **Quality gates** — append-only. Each entry is a runnable command with a
+  one-line description. Migrates verbatim into the spec's `Quality Gates`
+  section. Empty if the dialogue did not specify gates.
+- **Reproduction loop** — populated only when Diagnose ran a Phase 0 loop.
+  Migrates verbatim into the spec's `Reproduction` section. Human-supplied;
+  the agent does not infer steps or signals.
 - **Mode history** — turn-numbered, includes inline cycle markers.
 
 ## Lifecycle
@@ -86,13 +117,11 @@ Explore (1-3) → Ground (4-5) → Shape (6-8) → [validate cycle 1] → Sketch
 - **Update** — every turn the agent writes the file (replace, not append).
 - **Read** — the agent reads the previous state at the start of each turn.
 - **Migrate to spec** — on Crystallize, the spec template absorbs
-  `Decisions` and `Sketches` verbatim into named sections. Validate cycles
-  feed confidence and the spec's evidence rows.
+  `Decisions`, `Sketches`, `Quality gates`, and (if Diagnose ran) `Reproduction
+  loop` verbatim into named sections. Validate cycles feed confidence and the
+  spec's evidence rows. `Grill turns` is not migrated — it serves the
+  coherence checklist and stays in scratch state.
 - **Cleanup** — after a successful Crystallize *and* the user accepts the
   hand-off offer, the run directory is removed. Otherwise it stays for the
   OS to evict.
 
-## Resume (deferred)
-
-`v1` does not support resume. The state path is documented so a future
-`--resume` can read it. Do not rely on resume in the current iteration.

--- a/skills/mold/references/validate-cycle.md
+++ b/skills/mold/references/validate-cycle.md
@@ -61,7 +61,7 @@ A bare `/briesearch` is a research dispatch. The Validate Cycle adds:
 - The **stated hypothesis** (commitment to an assertion).
 - The **judgment step** (verdict tag, not just a summary).
 - The **decision recorded in state** (`Decisions` block on SUPPORTED;
-  `[CONFLICT]` marker on CONTRADICTED; restated hypothesis on REFINED).
+  `[CONFLICT <id>]` marker on CONTRADICTED; restated hypothesis on REFINED).
 
 Direct `/briesearch` calls are allowed but discouraged. The framing matters.
 
@@ -82,7 +82,9 @@ Every cycle gets one line in the state file's `Validate cycles` block:
 Followed by:
 
 - on SUPPORTED — append the decision to `Decisions` with the same cycle id.
-- on CONTRADICTED — append a `[CONFLICT]` line to `Open questions`.
+- on CONTRADICTED — assign a `conflict_id` (e.g. `cf-1`, incrementing per
+  session) to the cycle entry, then append a `[CONFLICT <id>]` line to
+  `Open questions` using that same id so the two stay linked.
 - on REFINED — append the restated hypothesis as a new cycle entry, and
   link the prior id (`refined from cycle <prior>`).
 

--- a/skills/mold/references/validate-cycle.md
+++ b/skills/mold/references/validate-cycle.md
@@ -1,0 +1,93 @@
+# The Validate Cycle
+
+A named cross-mode sub-pattern. Any mode can invoke it when the agent or
+the user holds an unverified claim. The cycle forces a stated hypothesis
+plus a judgment step, which prevents wishy-washy "let me research this and
+come back" patterns.
+
+## Anatomy
+
+1. **State the hypothesis.** Single declarative sentence. Falsifiable. The
+   anchor for the rest of the cycle.
+2. **Dispatch evidence.** Usually `/briesearch`. Sometimes `cheez-search`
+   or `cheez-read` is enough. Sometimes both run in parallel.
+3. **Judge.** Three outcomes — **SUPPORTED**, **CONTRADICTED**, **REFINED**.
+4. **Settle.** Continue from the mode that invoked the cycle. The mode
+   history records the cycle.
+
+## Dialogue script
+
+The agent **announces** the cycle before dispatching. Use this exact shape
+so the user knows what is happening and can interrupt:
+
+```
+Launching a validate cycle on hypothesis:
+  "<single declarative sentence>"
+
+Plan:
+  /briesearch  — fetch <focused question>
+  Judge        — does the evidence support, contradict, or refine?
+  Settle       — accept, revise, or reject. Continue from <current mode>.
+```
+
+After the evidence returns, render a one-paragraph judgment plus the
+verdict tag:
+
+```
+Judgment: <2-3 sentences citing evidence and any caveats>.
+Verdict: SUPPORTED | CONTRADICTED | REFINED
+```
+
+If REFINED, restate the hypothesis with new precision and either re-validate
+or accept the refined form.
+
+## When to invoke
+
+- **Ground** — any user claim about local code or external behaviour the
+  agent can verify.
+- **Shape** — before recommending Option A over B, validate the load-bearing
+  assumption ("Option A is faster" → measure or cite).
+- **Sketch** — before locking a signature that mirrors a third-party API,
+  fetch and compare.
+- **Diagnose** — the existing hypothesis-ranking *is* a Validate Cycle, run
+  in parallel for 3-5 hypotheses at once.
+- **Grill** — when stress-testing surfaces an unverified assumption, pause
+  Grill, run the cycle, return.
+
+## Validate Cycle vs. bare `/briesearch`
+
+A bare `/briesearch` is a research dispatch. The Validate Cycle adds:
+
+- The **stated hypothesis** (commitment to an assertion).
+- The **judgment step** (verdict tag, not just a summary).
+- The **decision recorded in state** (`Decisions` block on SUPPORTED;
+  `[CONFLICT]` marker on CONTRADICTED; restated hypothesis on REFINED).
+
+Direct `/briesearch` calls are allowed but discouraged. The framing matters.
+
+## Cap
+
+Same `/briesearch` budget as the rest of the skill: **max two** calls per
+session unless the user requests more. Validate Cycles backed by `cheez-*`
+evidence alone are unbudgeted because they only touch local code.
+
+## State recording
+
+Every cycle gets one line in the state file's `Validate cycles` block:
+
+```
+- cycle <N>: "<hypothesis>" → SUPPORTED|CONTRADICTED|REFINED (<source> turn <K>)
+```
+
+Followed by:
+
+- on SUPPORTED — append the decision to `Decisions` with the same cycle id.
+- on CONTRADICTED — append a `[CONFLICT]` line to `Open questions`.
+- on REFINED — append the restated hypothesis as a new cycle entry, and
+  link the prior id (`refined from cycle <prior>`).
+
+## Confidence impact
+
+The document-level confidence formula in `references/spec.md` adds points
+for SUPPORTED cycles and subtracts points for CONTRADICTED ones. Keeping
+the state file accurate is what makes the formula honest.

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -189,6 +189,7 @@ describe("installHarnessArtifacts", () => {
       "merge-resolve",
       "milknado-execute",
       "milknado-plan",
+      "mold",
       "nested-dir",
       "research",
     ]);


### PR DESCRIPTION
## Summary

Rewrites `/mold` from a 66-line single-shot spec stub into a portable skill backed by 7 reference docs. Adds Validate Cycle discipline, six routed modes (Explore, Ground, Shape, Sketch, Grill, Diagnose) with a Crystallize terminal, a two-key handshake plus coherence self-check before extraction, and atomic spec + optional GitHub-flavored issues as artifacts.

Built per `.context/attachments/plan.md`. The skill body mirrors `skills/research/SKILL.md`'s scratch-state pattern, delegates external evidence to `/briesearch` (capped at 2 calls/session through the Validate Cycle), and uses `cheez-search` / `cheez-read` for in-repo grounding.

## Files

**New (8)**
- `skills/mold/SKILL.md` — the crust (305 lines, under the 500-line lint cap)
- `skills/mold/references/routing.md` — input-shape → starting-mode classifier
- `skills/mold/references/validate-cycle.md` — anatomy, dialogue script, state recording
- `skills/mold/references/sketch-mode.md` — pseudocode-driven Q pattern + sibling sweep
- `skills/mold/references/loop-detection.md` — drift / boredom / rabbit-hole rules
- `skills/mold/references/state-schema.md` — scratch state file format incl. Validate cycles block
- `skills/mold/references/spec.md` — rich spec template + confidence formula + atomic-write contract
- `skills/mold/references/issue.md` — GH-flavored issue template + filing flow

**Modified (2)**
- `commands/mold.md` — rewritten as thin delegator to the skill (mirrors `commands/briesearch.md`)
- `tests/compiler.test.ts` — adds `"mold"` to the manifest skills assertion

## Test plan
- [x] `just build` passes (format + lint + lint:skills + typecheck + build + vitest coverage + ruff + pytest)
- [x] Skill frontmatter validates against the Zod `SkillFrontmatter` schema
- [x] Skill body stays under the 500-line lint cap
- [x] Cross-harness portability lint clean — no harness path markers, no PascalCase hook events, no harness-only tool name patterns
- [x] Skill `name` matches directory name `mold`
- [ ] Manual: invoke `/mold I want to add dark mode` → Explore entry, JTBD framing, no file writes
- [ ] Manual: invoke `/mold TypeError: cannot read property 'foo' of undefined at app.ts:142` → Diagnose entry
- [ ] Manual: invoke `/mold` with a half-baked design doc → Sketch entry
- [ ] Manual: trigger Crystallize with un-Sketched seams → coherence gate blocks until `crystallize anyway`