### PR TITLE
feat: harness-agnostic .cheese/ runtime dir + SessionStart bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 coverage/
+.cheese/
 .cheese-flow/
 .codex/
 .claude/

--- a/commands/age.md
+++ b/commands/age.md
@@ -29,11 +29,8 @@ use a 0-100 confidence scale; only >= 50 is surfaced to the user.
 | Architecture | `age-arch` | Complexity budgets (lines, params, nesting), Sliced Bread organization |
 | Encapsulation | `age-encap` | Leaky abstractions, overly wide public APIs, cross-boundary imports |
 | YAGNI / de-slop | `age-yagni` | Unjustified dead code, speculative abstractions, AI-generated noise |
-| Spec adherence | `age-spec` | Drift from `<harness>/specs/<slug>.md`, monkey patches, shortcuts |
+| Spec adherence | `age-spec` | Drift from `.cheese/specs/<slug>.md`, monkey patches, shortcuts |
 | History risk | `age-history` | Per-file risk modifiers derived from git blame / churn patterns |
-
-`<harness>` is the active harness output root — `.claude` for Claude Code,
-`.codex` for Codex.
 
 ## Output contract
 

--- a/commands/briesearch.md
+++ b/commands/briesearch.md
@@ -1,6 +1,6 @@
 ---
 name: briesearch
-description: Multi-source research orchestrator. Routes a question across Tavily, Context7 library docs, GitHub, and in-repo tools, writes findings to <harness>/research/<slug>.md, and returns a compact synthesis to the main context.
+description: Multi-source research orchestrator. Routes a question across Tavily, Context7 library docs, GitHub, and in-repo tools, writes findings to .cheese/research/<slug>.md, and returns a compact synthesis to the main context.
 argument-hint: "<question | library | API | dependency>"
 ---
 
@@ -8,9 +8,8 @@ argument-hint: "<question | library | API | dependency>"
 
 `/briesearch` is the research orchestrator. It routes a question across
 multiple information sources in parallel, writes full findings to
-`<harness>/research/<slug>.md`, and returns a compact synthesis back to the
-main context so it does not pollute the caller's window. `<harness>` is the
-active harness output root — `.claude` for Claude Code, `.codex` for Codex.
+`.cheese/research/<slug>.md`, and returns a compact synthesis back to the
+main context so it does not pollute the caller's window.
 
 ## Execution
 
@@ -36,7 +35,7 @@ merged; conflicts are flagged in the synthesis.
 
 ## Output contract
 
-- **Full report** written to `<harness>/research/<slug>.md`:
+- **Full report** written to `.cheese/research/<slug>.md`:
   - Question and scope.
   - Source-by-source findings with inline citations.
   - Conflicts, caveats, and freshness notes.

--- a/commands/cheese.md
+++ b/commands/cheese.md
@@ -21,15 +21,12 @@ dispatch occurs.
 | Input shape | Example | Target skill |
 |---|---|---|
 | Feature description / rough idea | "add dark mode", "support webhooks" | `/mold` (if non-trivial) → `/cook` |
-| Spec path | `<harness>/specs/add-dark-mode.md` | `/cook` |
+| Spec path | `.cheese/specs/add-dark-mode.md` | `/cook` |
 | PR reference | `PR#142`, `https://github.com/.../pull/142` | `/age` |
 | Issue reference | `#87`, `issue 87` | triage → likely `/mold` |
 | Bug report / stack trace | pasted error, reproduction steps | debug flow (investigate → `/cook`) |
 | File path or glob | `src/auth/login.ts`, `src/**/*.tsx` | focused review (`/age --scope`) |
 | Research question | "what's the best rate limiter library?" | `/briesearch` |
-
-`<harness>` is the active harness output root — `.claude` for Claude Code,
-`.codex` for Codex.
 
 ## Dispatch contract
 

--- a/commands/cook.md
+++ b/commands/cook.md
@@ -27,7 +27,7 @@ spec into tested code through red-green-refactor discipline.
 
 Accept one of:
 
-- A spec path (typically `<harness>/specs/<slug>.md` from `/mold`).
+- A spec path (typically `.cheese/specs/<slug>.md` from `/mold`).
 - A pasted spec.
 - A precise implementation request with acceptance criteria.
 

--- a/commands/mold.md
+++ b/commands/mold.md
@@ -15,9 +15,8 @@ generator: the dialogue is the point, the artifact is the by-product.
 
 Invoke the `mold` skill with `$ARGUMENTS`. The skill owns mode routing,
 Validate Cycle dispatch, interface lockdown via pseudocode, the two-key
-handshake, and atomic artifact extraction to `<harness>/specs/<slug>.md`
-and `<harness>/issues/<slug>-NNN.md`. `<harness>` is the active output
-root for the harness in use.
+handshake, and atomic artifact extraction to `.cheese/specs/<slug>.md`
+and `.cheese/issues/<slug>-NNN.md`.
 
 Do not reimplement the dialogue or extraction logic in this command.
 This file is the user-facing alias and contract; `skills/mold/SKILL.md`
@@ -33,11 +32,11 @@ is the implementation source of truth.
 
 ## What you get
 
-- **Spec** — rich container, written to `<harness>/specs/<slug>.md`.
+- **Spec** — rich container, written to `.cheese/specs/<slug>.md`.
   Always present unless the dialogue produced only standalone bug
   tickets.
 - **Issues** — separate, GitHub-flavored, written to
-  `<harness>/issues/<slug>-NNN.md`. Present when the dialogue surfaced
+  `.cheese/issues/<slug>-NNN.md`. Present when the dialogue surfaced
   side-channel actionables (out-of-scope bugs, follow-ups, parking-lot
   work).
 

--- a/hooks.json
+++ b/hooks.json
@@ -1,0 +1,8 @@
+{
+  "sessionStart": [
+    {
+      "type": "command",
+      "command": "bash hooks/cheese-bootstrap.sh"
+    }
+  ]
+}

--- a/hooks/cheese-bootstrap.sh
+++ b/hooks/cheese-bootstrap.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p .cheese
+
+if [ ! -f .gitignore ]; then
+  : > .gitignore
+fi
+
+if ! grep -qxF '.cheese/' .gitignore; then
+  if [ -s .gitignore ] && [ "$(tail -c1 .gitignore | od -An -c | tr -d ' ')" != "\n" ]; then
+    printf '\n' >> .gitignore
+  fi
+  printf '%s\n' '.cheese/' >> .gitignore
+fi
+
+exit 0

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -59,7 +59,7 @@ dialogue actually produced — never more, never less.
 | Input shape | Start mode | Heuristic |
 | --- | --- | --- |
 | Stack trace, "X is broken/slow/flaky" | Diagnose | error markers, `file:line` refs, symptom verbs |
-| File path, PR ref, existing spec under `<harness>/specs/` | Ground | concrete artifact exists; read it first |
+| File path, PR ref, existing spec under `.cheese/specs/` | Ground | concrete artifact exists; read it first |
 | Half-baked design doc with signatures or schemas | Sketch | already has interfaces; refine them |
 | "I want to add X" with concrete nouns | Shape | named the thing → jump to options |
 | "Should we do X? thinking about Y" | Grill | tentative plan exists → stress-test it |
@@ -261,14 +261,13 @@ Confirm in **one** approval prompt covering the artifact set, the slug, and
 the target paths. Render drafts inline first if the user wants to iterate
 before any disk writes.
 
-Output paths (relative to the active harness output root, surfaced as
-`<harness>/...`):
+Output paths (relative to the project root):
 
 | Output | Path |
 | --- | --- |
-| Spec only | `<harness>/specs/<slug>.md` |
-| Issues only | `<harness>/issues/<slug>-001.md`, `-002.md`, ... |
-| Spec + Issues | spec at `<harness>/specs/<slug>.md`; issues at `<harness>/issues/<slug>-001.md`, ... |
+| Spec only | `.cheese/specs/<slug>.md` |
+| Issues only | `.cheese/issues/<slug>-001.md`, `-002.md`, ... |
+| Spec + Issues | spec at `.cheese/specs/<slug>.md`; issues at `.cheese/issues/<slug>-001.md`, ... |
 
 Slug derivation: lowercase the working problem statement, drop stopwords,
 kebab-case, cap at 5 words. Honour user-passed slugs verbatim.
@@ -294,7 +293,7 @@ After writing, offer the next step inline. Never auto-invoke.
 
 | Artifact | Suggested next step |
 | --- | --- |
-| Spec | `/cook <harness>/specs/<slug>.md` |
+| Spec | `/cook .cheese/specs/<slug>.md` |
 | Issues | `gh issue create --body-file <path>` (per file) |
 
 ## Loop detection

--- a/skills/mold/references/issue.md
+++ b/skills/mold/references/issue.md
@@ -150,9 +150,9 @@ offers:
 
 ```
 Filed:
-  - <harness>/specs/<slug>.md       (1 spec)
-  - <harness>/issues/<slug>-001.md  (1 issue)
-  - <harness>/issues/<slug>-002.md  (1 issue)
+  - .cheese/specs/<slug>.md       (1 spec)
+  - .cheese/issues/<slug>-001.md  (1 issue)
+  - .cheese/issues/<slug>-002.md  (1 issue)
 
 File these as GitHub issues now? (y/N)
 ```

--- a/skills/mold/references/routing.md
+++ b/skills/mold/references/routing.md
@@ -50,7 +50,7 @@ considered, and explicitly invite a knob redirect.
 | Input | Mode | Reason |
 | --- | --- | --- |
 | `TypeError: cannot read property 'foo' of undefined at app.ts:142` | Diagnose | error keyword + file:line |
-| `<harness>/specs/dark-mode.md` | Ground | spec path; read first |
+| `.cheese/specs/dark-mode.md` | Ground | spec path; read first |
 | `def dispatch(...): ... # what should the return type be?` | Sketch | existing signature with question |
 | `I want to add idempotency to the dispatcher` | Shape | concrete noun, additive verb |
 | `Should we extract the dedup layer into its own slice?` | Grill | tentative verb on a plan |

--- a/skills/mold/references/spec.md
+++ b/skills/mold/references/spec.md
@@ -252,8 +252,7 @@ silent overwrite.
 
 ## Atomic write
 
-Stage to `<harness>/.mold-staging-<run_id>/` (a sibling of the destination,
+Stage to `.cheese/.mold-staging-<run_id>/` (a sibling of the destination,
 guaranteed same filesystem) and `mv` into place. This ensures `mv` is an
 atomic rename rather than a cross-filesystem copy+delete. On failure, the
-staging directory is removed and no partial files exist in the harness output
-root.
+staging directory is removed and no partial files exist in `.cheese/`.

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -31,12 +31,11 @@ Run the orchestration inline, but keep raw evidence out of the main context:
 3. Have fetchers write findings to scratch files under `$TMPDIR`.
 4. Have one synthesis sub-agent read those scratch files and return the final
    answer.
-5. Write the full report to `<harness>/research/<slugified-topic>.md`.
+5. Write the full report to `.cheese/research/<slugified-topic>.md`.
 6. Delete the scratch directory after the report is written.
 
-`<harness>` is the active harness output root — `.claude` for Claude Code,
-`.codex` for Codex, etc. The caller should see only the routing decision,
-fetcher status, synthesis, and the report path.
+The caller should see only the routing decision, fetcher status, synthesis,
+and the report path.
 
 ## Arguments
 
@@ -255,7 +254,7 @@ Synthesis task:
 After the synthesis block, append a fenced `report-body` block containing a
 full markdown report with source URLs, file refs, and repo links. The
 orchestration layer writes that report body verbatim to
-`<harness>/research/<slug>.md`.
+`.cheese/research/<slug>.md`.
 
 ## Cleanup
 

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -53,5 +53,6 @@ export const claudeCodeAdapter: HarnessAdapter = {
       "WebFetch",
       "TodoWrite",
     ]),
+    bootstrapHook: true,
   },
 };

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -27,5 +27,6 @@ export const codexAdapter: HarnessAdapter = {
     agentFrontmatterKeys: new Set<string>(),
     hookEvents: new Set(["sessionStart", "preToolUse", "postToolUse"]),
     toolNames: new Set<string>(),
+    bootstrapHook: true,
   },
 };

--- a/src/adapters/copilot-cli.ts
+++ b/src/adapters/copilot-cli.ts
@@ -38,5 +38,6 @@ export const copilotCliAdapter: HarnessAdapter = {
     agentFrontmatterKeys: new Set<string>(),
     hookEvents: new Set(["sessionStart", "preToolUse", "postToolUse"]),
     toolNames: new Set<string>(),
+    bootstrapHook: true,
   },
 };

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -108,5 +108,6 @@ export const cursorAdapter: HarnessAdapter = {
     agentFrontmatterKeys: new Set<string>(),
     hookEvents: new Set<string>(),
     toolNames: new Set<string>(),
+    bootstrapHook: false,
   },
 };

--- a/src/domain/harness.ts
+++ b/src/domain/harness.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 
 export type HarnessName = "claude-code" | "codex" | "cursor" | "copilot-cli";
 
+export const CHEESE_DIR = ".cheese";
+
 export const PORTABLE_EVENTS = [
   "sessionStart",
   "preToolUse",
@@ -97,6 +99,7 @@ export type HarnessCapabilities = {
   agentFrontmatterKeys: ReadonlySet<string>;
   hookEvents: ReadonlySet<string>;
   toolNames: ReadonlySet<string>;
+  bootstrapHook: boolean;
 };
 
 export interface HarnessAdapter {

--- a/src/lib/emit.ts
+++ b/src/lib/emit.ts
@@ -12,6 +12,8 @@ import {
   pluginMetadataSchema,
 } from "../domain/harness.js";
 
+const BOOTSTRAP_COMMAND_MARKER = "hooks/cheese-bootstrap.sh";
+
 function filterPortableEvents(source: HooksSource): PortableHooks {
   const portable: PortableHooks = {};
   const portableSet: ReadonlySet<string> = new Set(PORTABLE_EVENTS);
@@ -26,6 +28,20 @@ function filterPortableEvents(source: HooksSource): PortableHooks {
   }
 
   return portable;
+}
+
+function filterBootstrapEntries(portable: PortableHooks): PortableHooks {
+  const result: PortableHooks = {};
+  for (const [event, entries] of Object.entries(portable)) {
+    if (entries === undefined) continue;
+    const kept = entries.filter(
+      (entry) => !entry.command.includes(BOOTSTRAP_COMMAND_MARKER),
+    );
+    if (kept.length > 0) {
+      result[event as PortableEvent] = kept;
+    }
+  }
+  return result;
 }
 
 export async function emitPluginManifest(
@@ -72,7 +88,10 @@ export async function emitHooks(
   outputRoot: string,
 ): Promise<false | string> {
   const adapter = harnessAdapters[harness];
-  const portable = filterPortableEvents(source);
+  let portable = filterPortableEvents(source);
+  if (!adapter.capabilities.bootstrapHook) {
+    portable = filterBootstrapEntries(portable);
+  }
   const payload = adapter.buildHookConfig(portable);
 
   if (payload === null) {

--- a/src/lib/harness-compat.ts
+++ b/src/lib/harness-compat.ts
@@ -100,6 +100,21 @@ export function checkBodyHarnessIdioms(body: string): HarnessCompatFinding[] {
     ...collectToolFindings(body),
     ...collectEventFindings(body),
     ...collectPathFindings(body),
+    ...collectPlaceholderFindings(body),
+  ];
+}
+
+function collectPlaceholderFindings(body: string): HarnessCompatFinding[] {
+  const line = findFirstMatchLine(body, /<harness>\//u);
+  if (line === undefined) return [];
+  return [
+    {
+      rule: "body-harness-placeholder",
+      severity: "warning",
+      message:
+        'body uses the "<harness>/" placeholder; replace with ".cheese/" so all four harnesses share a single project-root runtime directory.',
+      line,
+    },
   ];
 }
 

--- a/src/lib/harness-compat.ts
+++ b/src/lib/harness-compat.ts
@@ -110,7 +110,7 @@ function collectPlaceholderFindings(body: string): HarnessCompatFinding[] {
   return [
     {
       rule: "body-harness-placeholder",
-      severity: "warning",
+      severity: "error",
       message:
         'body uses the "<harness>/" placeholder; replace with ".cheese/" so all four harnesses share a single project-root runtime directory.',
       line,

--- a/tests/cheese-bootstrap.test.ts
+++ b/tests/cheese-bootstrap.test.ts
@@ -1,0 +1,106 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const SCRIPT_PATH = path.join(REPO_ROOT, "hooks", "cheese-bootstrap.sh");
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(async (dir) => {
+      await rm(dir, { recursive: true, force: true });
+    }),
+  );
+});
+
+async function makeTempCwd(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "cheese-bootstrap-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function runScript(cwd: string): {
+  code: number;
+  stdout: string;
+  stderr: string;
+} {
+  const result = spawnSync("bash", [SCRIPT_PATH], {
+    cwd,
+    encoding: "utf8",
+  });
+  return {
+    code: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+describe("AC5: hooks/cheese-bootstrap.sh idempotent bootstrap", () => {
+  it("creates .cheese/ and adds .cheese/ exactly once when run twice", async () => {
+    const cwd = await makeTempCwd();
+    await writeFile(
+      path.join(cwd, ".gitignore"),
+      "node_modules/\ndist/\n",
+      "utf8",
+    );
+
+    const first = runScript(cwd);
+    expect(first.code, `first run stderr: ${first.stderr}`).toBe(0);
+
+    const second = runScript(cwd);
+    expect(second.code, `second run stderr: ${second.stderr}`).toBe(0);
+
+    const cheeseStat = await stat(path.join(cwd, ".cheese"));
+    expect(cheeseStat.isDirectory()).toBe(true);
+
+    const gitignore = await readFile(path.join(cwd, ".gitignore"), "utf8");
+    const matchingLines = gitignore
+      .split(/\r?\n/)
+      .filter((line: string) => line === ".cheese/");
+    expect(matchingLines).toHaveLength(1);
+  });
+
+  it("creates .gitignore containing .cheese/ when .gitignore is missing", async () => {
+    const cwd = await makeTempCwd();
+
+    const result = runScript(cwd);
+    expect(result.code, `stderr: ${result.stderr}`).toBe(0);
+
+    const cheeseStat = await stat(path.join(cwd, ".cheese"));
+    expect(cheeseStat.isDirectory()).toBe(true);
+
+    const gitignore = await readFile(path.join(cwd, ".gitignore"), "utf8");
+    const matchingLines = gitignore
+      .split(/\r?\n/)
+      .filter((line: string) => line === ".cheese/");
+    expect(matchingLines).toHaveLength(1);
+  });
+
+  it("preserves existing entries when .gitignore lacks a trailing newline", async () => {
+    const cwd = await makeTempCwd();
+    await writeFile(
+      path.join(cwd, ".gitignore"),
+      "node_modules/\ndist/",
+      "utf8",
+    );
+
+    const result = runScript(cwd);
+    expect(result.code, `stderr: ${result.stderr}`).toBe(0);
+
+    const lines = (await readFile(path.join(cwd, ".gitignore"), "utf8"))
+      .split(/\r?\n/)
+      .filter((line: string) => line.length > 0);
+    expect(lines).toContain("node_modules/");
+    expect(lines).toContain("dist/");
+    expect(lines).toContain(".cheese/");
+    expect(lines.filter((line: string) => line === ".cheese/")).toHaveLength(1);
+  });
+});

--- a/tests/cheese-bootstrap.test.ts
+++ b/tests/cheese-bootstrap.test.ts
@@ -1,5 +1,12 @@
 import { spawnSync } from "node:child_process";
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -102,5 +109,48 @@ describe("AC5: hooks/cheese-bootstrap.sh idempotent bootstrap", () => {
     expect(lines).toContain("dist/");
     expect(lines).toContain(".cheese/");
     expect(lines.filter((line: string) => line === ".cheese/")).toHaveLength(1);
+  });
+
+  it("writes a single .cheese/ line when .gitignore is empty (zero bytes)", async () => {
+    const cwd = await makeTempCwd();
+    await writeFile(path.join(cwd, ".gitignore"), "", "utf8");
+
+    const result = runScript(cwd);
+    expect(result.code, `stderr: ${result.stderr}`).toBe(0);
+
+    const contents = await readFile(path.join(cwd, ".gitignore"), "utf8");
+    expect(contents).toBe(".cheese/\n");
+  });
+
+  it("preserves existing contents inside a pre-existing .cheese/ directory", async () => {
+    const cwd = await makeTempCwd();
+    await mkdir(path.join(cwd, ".cheese", "specs"), { recursive: true });
+    await writeFile(
+      path.join(cwd, ".cheese", "specs", "existing.md"),
+      "preserve me",
+      "utf8",
+    );
+
+    const result = runScript(cwd);
+    expect(result.code, `stderr: ${result.stderr}`).toBe(0);
+
+    const preserved = await readFile(
+      path.join(cwd, ".cheese", "specs", "existing.md"),
+      "utf8",
+    );
+    expect(preserved).toBe("preserve me");
+  });
+
+  it("treats .cheese (no trailing slash) as distinct and still appends .cheese/", async () => {
+    const cwd = await makeTempCwd();
+    await writeFile(path.join(cwd, ".gitignore"), ".cheese\n", "utf8");
+
+    const result = runScript(cwd);
+    expect(result.code, `stderr: ${result.stderr}`).toBe(0);
+
+    const lines = (await readFile(path.join(cwd, ".gitignore"), "utf8"))
+      .split(/\r?\n/)
+      .filter((line: string) => line.length > 0);
+    expect(lines).toEqual([".cheese", ".cheese/"]);
   });
 });

--- a/tests/cheese-dir.test.ts
+++ b/tests/cheese-dir.test.ts
@@ -100,6 +100,7 @@ describe("AC4: body-harness-placeholder lint rule", () => {
       (f) => f.rule === "body-harness-placeholder",
     );
     expect(placeholderFindings.length).toBeGreaterThanOrEqual(1);
+    expect(placeholderFindings[0]?.severity).toBe("error");
   });
 
   it("does not flag '.cheese/specs/foo.md' with body-harness-placeholder", () => {

--- a/tests/cheese-dir.test.ts
+++ b/tests/cheese-dir.test.ts
@@ -1,0 +1,166 @@
+import type { Dirent } from "node:fs";
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { harnessAdapters } from "../src/adapters/index.js";
+import { CHEESE_DIR } from "../src/domain/harness.js";
+import { checkBodyHarnessIdioms } from "../src/lib/harness-compat.js";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+async function readMarkdownFiles(dir: string): Promise<string[]> {
+  const collected: string[] = [];
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return collected;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collected.push(...(await readMarkdownFiles(full)));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      collected.push(full);
+    }
+  }
+  return collected;
+}
+
+describe("AC1: CHEESE_DIR constant", () => {
+  it('exports CHEESE_DIR === ".cheese" from src/domain/harness.ts', () => {
+    expect(CHEESE_DIR).toBe(".cheese");
+  });
+});
+
+describe("AC2: bootstrapHook capability flag", () => {
+  it("declares bootstrapHook as a boolean on every adapter's capabilities", () => {
+    for (const [name, adapter] of Object.entries(harnessAdapters)) {
+      const caps = adapter.capabilities as { bootstrapHook?: unknown };
+      expect(
+        typeof caps.bootstrapHook,
+        `adapter ${name} must expose capabilities.bootstrapHook as boolean`,
+      ).toBe("boolean");
+    }
+  });
+
+  it("enables bootstrapHook for claude-code, codex, and copilot-cli", () => {
+    const caps = (name: string) =>
+      (
+        harnessAdapters[name as keyof typeof harnessAdapters].capabilities as {
+          bootstrapHook?: boolean;
+        }
+      ).bootstrapHook;
+    expect(caps("claude-code")).toBe(true);
+    expect(caps("codex")).toBe(true);
+    expect(caps("copilot-cli")).toBe(true);
+  });
+
+  it("disables bootstrapHook for cursor", () => {
+    const cursorCaps = harnessAdapters.cursor.capabilities as {
+      bootstrapHook?: boolean;
+    };
+    expect(cursorCaps.bootstrapHook).toBe(false);
+  });
+});
+
+describe("AC3: <harness>/ placeholder removal", () => {
+  it("contains no '<harness>/' substring in commands/ or skills/ markdown", async () => {
+    const commandsDir = path.join(REPO_ROOT, "commands");
+    const skillsDir = path.join(REPO_ROOT, "skills");
+    const files = [
+      ...(await readMarkdownFiles(commandsDir)),
+      ...(await readMarkdownFiles(skillsDir)),
+    ];
+    expect(files.length).toBeGreaterThan(0);
+    const offenders: string[] = [];
+    for (const file of files) {
+      const body = await readFile(file, "utf8");
+      if (body.includes("<harness>/")) {
+        offenders.push(path.relative(REPO_ROOT, file));
+      }
+    }
+    expect(
+      offenders,
+      `files still containing "<harness>/": ${offenders.join(", ")}`,
+    ).toEqual([]);
+  });
+});
+
+describe("AC4: body-harness-placeholder lint rule", () => {
+  it("flags '<harness>/specs/foo.md' with rule body-harness-placeholder", () => {
+    const findings = checkBodyHarnessIdioms(
+      "This writes to `<harness>/specs/foo.md`",
+    );
+    const placeholderFindings = findings.filter(
+      (f) => f.rule === "body-harness-placeholder",
+    );
+    expect(placeholderFindings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not flag '.cheese/specs/foo.md' with body-harness-placeholder", () => {
+    const findings = checkBodyHarnessIdioms(
+      "This writes to `.cheese/specs/foo.md`",
+    );
+    const placeholderFindings = findings.filter(
+      (f) => f.rule === "body-harness-placeholder",
+    );
+    expect(placeholderFindings).toEqual([]);
+  });
+
+  it("includes '.cheese/' as the recommended replacement in the message", () => {
+    const findings = checkBodyHarnessIdioms(
+      "This writes to `<harness>/research/foo.md`",
+    );
+    const placeholderFindings = findings.filter(
+      (f) => f.rule === "body-harness-placeholder",
+    );
+    expect(placeholderFindings.length).toBeGreaterThanOrEqual(1);
+    const finding = placeholderFindings[0];
+    expect(finding?.message).toContain(".cheese/");
+  });
+});
+
+describe("AC6: .gitignore contains .cheese/", () => {
+  it("repo-root .gitignore contains a line matching exactly '.cheese/'", async () => {
+    const gitignorePath = path.join(REPO_ROOT, ".gitignore");
+    const body = await readFile(gitignorePath, "utf8");
+    const lines = body.split(/\r?\n/);
+    expect(lines).toContain(".cheese/");
+  });
+});
+
+describe("AC5: project-root hooks.json registers cheese-bootstrap.sh", () => {
+  it("hooks.json exists at the repo root", async () => {
+    const hooksPath = path.join(REPO_ROOT, "hooks.json");
+    const stats = await stat(hooksPath);
+    expect(stats.isFile()).toBe(true);
+  });
+
+  it("hooks.json parses as JSON and registers cheese-bootstrap.sh on sessionStart", async () => {
+    const hooksPath = path.join(REPO_ROOT, "hooks.json");
+    const body = await readFile(hooksPath, "utf8");
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    // The portable hook source uses camelCase event keys (top-level or under .hooks).
+    const hooksRoot =
+      (parsed.hooks as Record<string, unknown> | undefined) ?? parsed;
+    const sessionStart = (hooksRoot as Record<string, unknown>)
+      .sessionStart as unknown;
+    expect(Array.isArray(sessionStart)).toBe(true);
+    const entries = sessionStart as Array<Record<string, unknown>>;
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+    const referencesScript = entries.some((entry) => {
+      const command =
+        typeof entry.command === "string" ? entry.command : undefined;
+      return command !== undefined && command.includes("cheese-bootstrap.sh");
+    });
+    expect(
+      referencesScript,
+      "expected at least one sessionStart entry to reference cheese-bootstrap.sh",
+    ).toBe(true);
+  });
+});

--- a/tests/harness-compat.test.ts
+++ b/tests/harness-compat.test.ts
@@ -144,6 +144,7 @@ describe("checkFrontmatterPortability", () => {
         agentFrontmatterKeys: new Set<string>(),
         hookEvents: new Set<string>(),
         toolNames: new Set<string>(),
+        bootstrapHook: false,
       },
     } as HarnessAdapter;
     registry["fifth"] = fifth;

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { harnessAdapters } from "../src/adapters/index.js";
 import { emitHooks } from "../src/lib/emit.js";
 
 const createdDirectories: string[] = [];
@@ -104,6 +105,112 @@ describe("emitHooks", () => {
 
     expect(config.hooks.sessionStart).toBeDefined();
     expect(config.hooks.preToolUse).toBeUndefined();
+  });
+
+  it("emits sessionStart bootstrap entry for every bootstrapHook=true harness", async () => {
+    const source = {
+      sessionStart: [
+        { type: "command", command: "bash hooks/cheese-bootstrap.sh" },
+      ],
+    };
+    const enabled: Array<keyof typeof harnessAdapters> = [
+      "claude-code",
+      "codex",
+      "copilot-cli",
+    ];
+    for (const harness of enabled) {
+      const caps = harnessAdapters[harness].capabilities as {
+        bootstrapHook?: boolean;
+      };
+      expect(
+        caps.bootstrapHook,
+        `${harness} must have bootstrapHook=true`,
+      ).toBe(true);
+
+      const outputRoot = await mkdtemp(path.join(os.tmpdir(), "cheese-flow-"));
+      createdDirectories.push(outputRoot);
+
+      const result = await emitHooks(harness, source, outputRoot);
+      expect(result, `${harness} should emit hooks.json`).not.toBe(false);
+
+      const hooksPath = path.join(outputRoot, "hooks.json");
+      const content = await readFile(hooksPath, "utf8");
+      expect(content).toContain("cheese-bootstrap.sh");
+    }
+  });
+
+  it("places bootstrap command at the structurally correct path per harness", async () => {
+    const source = {
+      sessionStart: [
+        { type: "command", command: "bash hooks/cheese-bootstrap.sh" },
+      ],
+    };
+
+    const claudeRoot = await mkdtemp(path.join(os.tmpdir(), "cheese-flow-"));
+    createdDirectories.push(claudeRoot);
+    await emitHooks("claude-code", source, claudeRoot);
+    const claudeConfig = JSON.parse(
+      await readFile(path.join(claudeRoot, "hooks.json"), "utf8"),
+    ) as {
+      hooks: { sessionStart: Array<{ type: string; command: string }> };
+    };
+    expect(claudeConfig.hooks.sessionStart).toHaveLength(1);
+    expect(claudeConfig.hooks.sessionStart[0]?.type).toBe("command");
+    expect(claudeConfig.hooks.sessionStart[0]?.command).toBe(
+      "bash hooks/cheese-bootstrap.sh",
+    );
+
+    const codexRoot = await mkdtemp(path.join(os.tmpdir(), "cheese-flow-"));
+    createdDirectories.push(codexRoot);
+    await emitHooks("codex", source, codexRoot);
+    const codexConfig = JSON.parse(
+      await readFile(path.join(codexRoot, "hooks.json"), "utf8"),
+    ) as {
+      hooks: {
+        SessionStart: Array<{
+          matcher: string;
+          hooks: Array<{ type: string; command: string; timeout: number }>;
+        }>;
+      };
+    };
+    expect(codexConfig.hooks.SessionStart).toHaveLength(1);
+    expect(codexConfig.hooks.SessionStart[0]?.matcher).toBe("*");
+    expect(codexConfig.hooks.SessionStart[0]?.hooks[0]?.command).toBe(
+      "bash hooks/cheese-bootstrap.sh",
+    );
+
+    const copilotRoot = await mkdtemp(path.join(os.tmpdir(), "cheese-flow-"));
+    createdDirectories.push(copilotRoot);
+    await emitHooks("copilot-cli", source, copilotRoot);
+    const copilotConfig = JSON.parse(
+      await readFile(path.join(copilotRoot, "hooks.json"), "utf8"),
+    ) as {
+      version: number;
+      hooks: { sessionStart: Array<{ type: string; command: string }> };
+    };
+    expect(copilotConfig.version).toBe(1);
+    expect(copilotConfig.hooks.sessionStart).toHaveLength(1);
+    expect(copilotConfig.hooks.sessionStart[0]?.command).toBe(
+      "bash hooks/cheese-bootstrap.sh",
+    );
+  });
+
+  it("skips emission for cursor (bootstrapHook=false)", async () => {
+    const cursorCaps = harnessAdapters.cursor.capabilities as {
+      bootstrapHook?: boolean;
+    };
+    expect(cursorCaps.bootstrapHook).toBe(false);
+
+    const outputRoot = await mkdtemp(path.join(os.tmpdir(), "cheese-flow-"));
+    createdDirectories.push(outputRoot);
+
+    const source = {
+      sessionStart: [
+        { type: "command", command: "bash hooks/cheese-bootstrap.sh" },
+      ],
+    };
+    const result = await emitHooks("cursor", source, outputRoot);
+    expect(result).toBe(false);
   });
 
   it("skips non-portable events with warn", async () => {

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -213,6 +213,63 @@ describe("emitHooks", () => {
     expect(result).toBe(false);
   });
 
+  it("filters bootstrap entry when bootstrapHook=false even if buildHookConfig returns a payload", async () => {
+    const cursorAdapter = harnessAdapters.cursor;
+    const buildSpy = vi
+      .spyOn(cursorAdapter, "buildHookConfig")
+      .mockImplementation((portable) => ({ hooks: portable }));
+
+    try {
+      const outputRoot = await mkdtemp(path.join(os.tmpdir(), "cheese-flow-"));
+      createdDirectories.push(outputRoot);
+
+      const source = {
+        sessionStart: [
+          { type: "command", command: "bash hooks/cheese-bootstrap.sh" },
+          { type: "command", command: "echo other-hook" },
+        ],
+      };
+
+      const result = await emitHooks("cursor", source, outputRoot);
+      expect(result).not.toBe(false);
+
+      const content = await readFile(
+        path.join(outputRoot, "hooks.json"),
+        "utf8",
+      );
+      expect(content).not.toContain("cheese-bootstrap.sh");
+      expect(content).toContain("echo other-hook");
+    } finally {
+      buildSpy.mockRestore();
+    }
+  });
+
+  it("omits sessionStart entirely when filtering removes the only entry", async () => {
+    const cursorAdapter = harnessAdapters.cursor;
+    const buildSpy = vi
+      .spyOn(cursorAdapter, "buildHookConfig")
+      .mockImplementation((portable) => ({ hooks: portable }));
+
+    try {
+      const outputRoot = await mkdtemp(path.join(os.tmpdir(), "cheese-flow-"));
+      createdDirectories.push(outputRoot);
+
+      const source = {
+        sessionStart: [
+          { type: "command", command: "bash hooks/cheese-bootstrap.sh" },
+        ],
+      };
+
+      await emitHooks("cursor", source, outputRoot);
+      const config = JSON.parse(
+        await readFile(path.join(outputRoot, "hooks.json"), "utf8"),
+      );
+      expect(config.hooks.sessionStart).toBeUndefined();
+    } finally {
+      buildSpy.mockRestore();
+    }
+  });
+
   it("skips non-portable events with warn", async () => {
     const outputRoot = await mkdtemp(path.join(os.tmpdir(), "cheese-flow-"));
     createdDirectories.push(outputRoot);


### PR DESCRIPTION
## Summary

- Replace the unresolved `<harness>/{specs,research,issues}/` prose placeholder across `commands/` and `skills/` with a single literal `.cheese/` directory at the project root. All four targeted harnesses (claude-code, codex, cursor, copilot-cli) now read and write the same path — no resolver, no per-harness fan-out.
- New `bootstrapHook: boolean` field on `HarnessCapabilities` (true for claude-code/codex/copilot-cli, false for cursor due to a [known sessionStart bug](https://forum.cursor.com/t/sessionstart-hook-output-is-accepted-and-merged-but-the-injected-context-does-not-reach-agent-window/157141) and plugin.json-based hook config).
- New `body-harness-placeholder` lint rule prevents the `<harness>/` placeholder from regressing.
- Idempotent `hooks/cheese-bootstrap.sh` + project-root `hooks.json` `sessionStart` entry. Flows through the existing `emitHooks` pipeline to `.claude/hooks.json`, `.codex/hooks.json`, `.copilot/hooks.json`. Cursor is gated off via the new capability flag.
- `.cheese/` added to `.gitignore`.

The adapter pattern is preserved: the new capability rides on the existing `HarnessCapabilities` interface; the bootstrap hook flows through `emitHooks` unchanged; Cursor's existing `buildHookConfig: () => null` already handles the skip path.

## Test plan

- [x] `just build` green (vitest 221/221, pytest 150/150, coverage lines 100%, branches 95.57%, statements 99.33%, functions 99.19%)
- [x] AC1: `CHEESE_DIR` exported and equals `.cheese`
- [x] AC2: `bootstrapHook` is boolean per adapter; true on three, false on cursor
- [x] AC3: no `<harness>/` substring remains in `commands/*.md` or `skills/**/*.md`
- [x] AC4: lint rule fires on `<harness>/specs/foo.md`, stays quiet on `.cheese/specs/foo.md`, message recommends `.cheese/`
- [x] AC5: bootstrap script idempotent across two runs; works when `.gitignore` is missing; preserves existing entries when `.gitignore` lacks trailing newline (regression test added after press surfaced a data-loss bug); structural per-harness emission verified for claude-code, codex (PascalCase + matcher envelope), copilot-cli (`version: 1` envelope); cursor skipped
- [x] AC6: `.gitignore` contains exactly one `.cheese/` line
- [x] AC7: full quality gate passes

## Out of scope

- Migrating existing user-side `.claude/specs/` content
- Fixing Cursor's sessionStart context-injection bug
- Eta templating of skill bodies (literal `.cheese/` is harness-agnostic; no template needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)