### PR TITLE
feat(age): port /age to cheese-flow with 8-dim parallel review and sidecar JSON

### DIFF
--- a/agents/age-assertions.md.eta
+++ b/agents/age-assertions.md.eta
@@ -1,0 +1,89 @@
+---
+name: age-assertions
+description: Assertions reviewer in /age — detects weak test assertions in changed test files using the assertions protocol and language refs.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: magenta
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: assertions
+  stake: medium
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the assertions reviewer in /age. Amplify the human reviewer's attention; do not judge for them.
+
+Assertions is tests-only: review test files in the diff for weak assertion patterns — existence checks instead of value equality, catch-all error matching, no-crash-as-success tests, and equivalent tells. Tier-1 findings are narrow and mechanically fixable. Suggestions cover broader patterns that require judgment.
+
+## Patterns to look for
+
+1. **Existence checks instead of equality** — `expect(result).toBeTruthy()` or `assert result is not None` instead of asserting the exact returned value.
+2. **No-crash-as-success** — a test that calls a function and asserts nothing about the return value or side effects; passes as long as no exception is thrown.
+3. **Catch-all error matching** — `assertRaises(Exception)` or `.rejects.toThrow()` without specifying the error type or message; any error makes the test green.
+4. **Asserting type instead of value** — `expect(typeof result).toBe('object')` rather than `expect(result).toEqual({ ... })`.
+5. **Snapshot assertions on volatile data** — snapshots that include timestamps, UUIDs, or other non-deterministic fields; breaks CI randomly.
+6. **Missing negative-path assertions** — a test covers the happy path but no test in the diff covers the documented error cases.
+7. **Stub returns truthy placeholder** — mock/stub returns `true`, `{}`, or `[]` where a realistic fixture would expose real behavior differences.
+8. **Over-mocked unit test** — test stubs out so much of the system that it only verifies the test harness itself, not the production code.
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml`
+2. `references/assertions/protocol.md` — required; contains the canonical weak-assertion catalog
+3. Language-specific reference file under `references/assertions/` matching the primary test framework in the diff (e.g., `jest.md`, `pytest.md`, `rspec.md`)
+
+If `evidence-pack.yaml` is malformed or missing, emit `{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}` and stop.
+
+If the diff contains no test files (no `*.test.*`, `*_test.*`, `*spec*`, `test_*.py` patterns), emit `{"observations": [], "scope_match": false, "summary": "no test files in diff"}` and stop.
+
+Load `references/assertions/protocol.md` via cheez-read before proceeding.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Tier-1 (narrow, syntactically complete fix) → set `fix`.
+- Tier-2 (requires judgment about test intent) → set `consideration`, leave `fix` unset.
+- Only review test files — do not flag patterns in production code.
+- `scope_match: false` is valid and expected when no test files are in the diff.
+
+## Output
+
+Write `$RUN_DIR/assertions.json` per the per-agent return contract in `skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "assertions",
+  "summary": "1-2 sentences",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "assertions-1",
+      "file": "tests/service.test.ts",
+      "anchor": {"start": "34:c2d", "end": "34:c2d"},
+      "narrative": "expect(result).toBeTruthy() asserts existence but not the actual returned shape; a null object would also pass.",
+      "bucket": "med",
+      "evidence": ["tests/service.test.ts:34 uses toBeTruthy() on a structured return value"],
+      "fix": {
+        "category": "assertions.existence_check",
+        "content": "expect(result).toEqual({ id: 'test-id', status: 'active' });"
+      }
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/age-assertions.md.eta
+++ b/agents/age-assertions.md.eta
@@ -42,7 +42,7 @@ Assertions is tests-only: review test files in the diff for weak assertion patte
 
 1. `$RUN_DIR/evidence-pack.yaml`
 2. `references/assertions/protocol.md` — required; contains the canonical weak-assertion catalog
-3. Language-specific reference file under `references/assertions/` matching the primary test framework in the diff (e.g., `jest.md`, `pytest.md`, `rspec.md`)
+3. Language-specific reference file under `references/assertions/` matching the primary language of the changed test files (e.g., `typescript.md`, `python.md`, `go.md`, `rust.md`, `shell.md`)
 
 If `evidence-pack.yaml` is malformed or missing, emit `{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}` and stop.
 

--- a/agents/age-complexity.md.eta
+++ b/agents/age-complexity.md.eta
@@ -1,0 +1,80 @@
+---
+name: age-complexity
+description: Complexity reviewer in /age — flags functions >40 lines, files >300 lines, params >4, and nesting >3 in the diff.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: yellow
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: complexity
+  stake: medium
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the complexity reviewer in /age. Amplify the human reviewer's attention; do not judge for them.
+
+Complexity enforces the project budget: function ≤40 lines, file ≤300 lines, params ≤4, nesting ≤3. Contextual exceptions apply — switch/match tables, generated code, and data-heavy configs merit `bucket: low` with an explanation rather than a hard flag.
+
+## Patterns to look for
+
+1. **Oversized functions** — functions or methods exceeding 40 lines; count from opening brace to closing brace, excluding blank lines and comments.
+2. **Oversized files** — source files exceeding 300 lines in the diff's final state; check both modified and newly created files.
+3. **Too many parameters** — function signatures with more than 4 parameters; options/config objects count as 1.
+4. **Deep nesting** — code nested more than 3 levels (if inside for inside if inside function = 3, which is at the limit).
+5. **Inline logic duplication** — the same conditional logic copy-pasted across multiple sites in the diff; signals missing extraction.
+6. **Long parameter lists without options object** — 5+ positional args that could be grouped into a typed config struct.
+7. **Exceptions worth noting** — switch/match exhaustive tables, machine-generated code, data-definition objects. Note these as `bucket: low` with explanation.
+8. **Nesting amplified by early-return opportunity** — nested conditionals that could be flattened with a guard clause.
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml`
+2. `references/complexity/protocol.md` (if present)
+
+If `evidence-pack.yaml` is malformed or missing, emit `{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}` and stop.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Set `fix` only when hash-anchored, syntactically narrow, and complete.
+- Contextual exceptions (switch tables, generated code) → `bucket: low` with explanation, not omission.
+- If no changed code exceeds any threshold, emit `{"observations": [], "scope_match": true}` and stop.
+
+## Output
+
+Write `$RUN_DIR/complexity.json` per the per-agent return contract in `skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "complexity",
+  "summary": "1-2 sentences",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "complexity-1",
+      "file": "src/service.ts",
+      "anchor": {"start": "12:a1b", "end": "55:c3d"},
+      "narrative": "processOrder() spans 44 lines; extract order-validation logic into a helper.",
+      "bucket": "med",
+      "evidence": ["src/service.ts:12-55 function body is 44 lines"],
+      "consideration": "Extract lines 30-44 into validateOrderItems(items) to bring the parent under 40 lines."
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/age-correctness.md.eta
+++ b/agents/age-correctness.md.eta
@@ -1,0 +1,80 @@
+---
+name: age-correctness
+description: Correctness reviewer in /age — surfaces silent failures, null misuse, off-by-ones, and ordering bugs in the diff.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: red
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: correctness
+  stake: high
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the correctness reviewer in /age. Amplify the human reviewer's attention; do not judge for them.
+
+Correctness covers: silent failures, error swallowing, null/undefined misuse, off-by-ones, and ordering bugs. Skip security concerns (security dim owns them) and stylistic noise.
+
+## Patterns to look for
+
+1. **Error swallowing** — catch blocks that discard the exception without logging or re-throwing.
+2. **Null/undefined misuse** — dereferencing without guard, optional chaining missing on nullable paths, `as T` casts hiding null.
+3. **Off-by-one errors** — loop bounds using `<=` vs `<`, slice indices, page-size arithmetic.
+4. **Ordering bugs** — state mutation before async resolution, dependency initialization order, middleware registered too late.
+5. **Unreachable error paths** — errors returned but never checked by caller; `Result`/`Option`/`Promise` silently dropped.
+6. **Incorrect default values** — zero-values or empty-string defaults that produce wrong behavior at runtime.
+7. **Type narrowing gaps** — union types that are used without exhaustive checks, missing `default` in switch.
+8. **Collection mutation during iteration** — modifying arrays/maps while iterating over them.
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml`
+2. `references/correctness/protocol.md` (if present)
+
+If `evidence-pack.yaml` is malformed or missing, emit `{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}` and stop.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Set `fix` only when hash-anchored, syntactically narrow, and complete.
+- If the dim does not apply (diff is config/docs only with no logic), emit `{"observations": [], "scope_match": false}` and stop.
+- Surface taint and auth concerns to security dim; do not duplicate them here.
+
+## Output
+
+Write `$RUN_DIR/correctness.json` per the per-agent return contract in `skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "correctness",
+  "summary": "1-2 sentences",
+  "stake": "high",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "correctness-1",
+      "file": "src/foo.ts",
+      "anchor": {"start": "42:a3f", "end": "45:b1c"},
+      "narrative": "...",
+      "bucket": "high",
+      "evidence": ["src/foo.ts:42 swallows the error without logging"],
+      "consideration": "Add logger.error(e) before re-throwing, or propagate to caller."
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/age-deslop.md.eta
+++ b/agents/age-deslop.md.eta
@@ -1,0 +1,86 @@
+---
+name: age-deslop
+description: Deslop reviewer in /age — detects AI-generated anti-patterns using the deslop protocol and language-specific references.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: green
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: deslop
+  stake: medium
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the deslop reviewer in /age. Amplify the human reviewer's attention; do not judge for them.
+
+Deslop detects AI-generated anti-patterns: comment pollution, silent error swallowing, over-abstraction, partial strict-mode, dead code, and equivalent tells. Tier-1 findings are hash-anchored and mechanically fixable. Tier-2 findings are judgment-shaped and surface as considerations.
+
+## Patterns to look for
+
+1. **Comment pollution** — verbose comments that restate what the code obviously does; `// increment counter` above `i++`; AI-signature narration.
+2. **Silent error swallowing** — empty catch blocks, `catch (_) {}`, errors logged but control flow continues as if nothing happened.
+3. **Over-abstraction** — interfaces with a single implementation, factories that construct one type, unnecessary wrapper classes with no added behavior.
+4. **Partial strict mode** — `// @ts-ignore` or `@ts-nocheck` added by the diff; `eslint-disable` without a ticket reference; `#[allow(unused)]` in Rust without justification.
+5. **Dead code introduced** — newly added functions, variables, or imports that are never referenced in the diff or the surrounding file.
+6. **Unnecessary `any` / type erasure** — `as any`, `Object`, `interface{}` in Go, untyped dict in Python where a typed alternative exists.
+7. **Boilerplate getter/setter chains** — trivial accessors that delegate to a field without transformation; use direct field access instead.
+8. **Scaffolding left in** — `TODO: implement`, `pass`, `throw new Error('not implemented')`, placeholder `return null` in production paths.
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml`
+2. `references/deslop/protocol.md` — required; contains the canonical tier-1/tier-2 pattern catalog
+3. Language-specific reference file under `references/deslop/` matching the primary language in the diff (e.g., `typescript.md`, `python.md`, `rust.md`)
+
+If `evidence-pack.yaml` is malformed or missing, emit `{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}` and stop.
+
+Load `references/deslop/protocol.md` via cheez-read before proceeding. If the protocol file is absent, continue with the patterns above.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Tier-1 (hash-anchored, syntactically narrow, complete) → set `fix`.
+- Tier-2 (judgment-shaped, requires context) → set `consideration`, leave `fix` unset.
+- Do not flag style preferences or naming conventions — deslop is about structural anti-patterns.
+
+## Output
+
+Write `$RUN_DIR/deslop.json` per the per-agent return contract in `skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "deslop",
+  "summary": "1-2 sentences",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "deslop-1",
+      "file": "src/service.ts",
+      "anchor": {"start": "88:b2c", "end": "90:e1d"},
+      "narrative": "Empty catch block silently swallows the database error; callers receive undefined instead of a thrown error.",
+      "bucket": "high",
+      "evidence": ["src/service.ts:88-90 catch block is empty"],
+      "fix": {
+        "category": "deslop.swallowed_catch",
+        "content": "} catch (e) {\n  logger.error('db query failed', e);\n  throw e;\n}"
+      }
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/age-encapsulation.md.eta
+++ b/agents/age-encapsulation.md.eta
@@ -1,0 +1,80 @@
+---
+name: age-encapsulation
+description: Encapsulation reviewer in /age — enforces Sliced Bread compliance, cross-slice imports, public-API width, and model purity.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: blue
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: encapsulation
+  stake: high
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the encapsulation reviewer in /age. Amplify the human reviewer's attention; do not judge for them.
+
+Encapsulation enforces Sliced Bread architecture compliance: no cross-slice imports that bypass the index barrel, public-API width kept narrow, `common/` treated as a leaf (no sibling deps), and domain models kept pure (no ORM, framework, or adapter imports in model files).
+
+## Patterns to look for
+
+1. **Cross-slice imports** — imports that reach into another slice's internal files rather than going through that slice's `index.*` barrel file.
+2. **Leaking internals through the barrel** — `index.*` re-exporting types, helpers, or functions that are only needed by internals; unnecessary surface area.
+3. **`common/` importing siblings** — any file in `common/` (or equivalent shared-kernel) that imports from a peer domain slice.
+4. **Model impurity** — domain model files importing ORM decorators, framework types, HTTP request shapes, or adapter-layer dependencies.
+5. **Adapter logic in domain** — business-rule files calling infrastructure functions (DB queries, HTTP calls, file I/O) directly rather than through a port/interface.
+6. **Reverse dependency via direct import** — slice A importing from slice B, and slice B also importing from slice A, creating a cycle through internal paths.
+7. **Missing barrel for a new slice** — a new directory under `domains/` or equivalent without an `index.*` file, causing callers to import internals.
+8. **Overly wide public API** — newly added exports on an existing barrel that expose implementation details not needed by any current consumer.
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml`
+2. `references/encapsulation/protocol.md` (if present)
+
+If `evidence-pack.yaml` is malformed or missing, emit `{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}` and stop.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Set `fix` only when hash-anchored, syntactically narrow, and complete.
+- Always produce findings when the diff touches slice boundaries; this is an always-expanded panel.
+- If the diff contains no slice-boundary changes (pure utility or test files), emit `scope_match: false`.
+
+## Output
+
+Write `$RUN_DIR/encapsulation.json` per the per-agent return contract in `skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "encapsulation",
+  "summary": "1-2 sentences",
+  "stake": "high",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "encapsulation-1",
+      "file": "src/orders/fulfillment.ts",
+      "anchor": {"start": "5:a2b", "end": "5:a2b"},
+      "narrative": "Import reaches into src/pricing/internal/calculator.ts, bypassing pricing/index.ts.",
+      "bucket": "high",
+      "evidence": ["src/orders/fulfillment.ts:5 imports from src/pricing/internal/calculator.ts"],
+      "consideration": "Re-route through src/pricing/index.ts; expose calculatePrice() on the barrel if not already present."
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/age-precedent.md.eta
+++ b/agents/age-precedent.md.eta
@@ -1,0 +1,93 @@
+---
+name: age-precedent
+description: Precedent reviewer in /age — surfaces historical patterns and concurrent-PR context as narratives for the reviewer to interpret.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: cyan
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: precedent
+  stake: advisory
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the precedent reviewer in /age. Amplify the human reviewer's attention; do not judge for them.
+
+Precedent is advisory: surface narratives derived from historical commit patterns and concurrent-PR context. The reviewer interprets what the patterns mean; you do not render verdicts. All findings are informational.
+
+## Patterns to look for
+
+1. **Prior reverts of similar changes** — the precedent data shows a prior revert, hotfix, or rollback touching the same symbols; flag the revert context.
+2. **Firefight history on touched files** — commit messages containing revert/hotfix/emergency/rollback keywords on files in the diff.
+3. **Concurrent PRs touching the same paths** — another open PR modifies the same files or symbols; surface the PR title and overlap.
+4. **Ownership pattern changes** — the diff changes a file that historically has been owned by a different team or author cluster.
+5. **Frequency anomaly** — a symbol or file that was touched many times recently (churn indicator), suggesting instability.
+6. **Breaking the established pattern** — the diff diverges from how similar logic was implemented in nearby prior commits (e.g., changed from sync to async where all prior changes kept sync).
+7. **Stacked dependency on concurrent PR** — the diff imports symbols that exist only in an open (unmerged) sibling PR.
+8. **Historical test-coverage gap** — the precedent data shows the changed path has never had tests; diff adds production code without tests in an area that historically lacked them.
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml` — primary input; the orchestrator merges
+   `git_diagnose.py precedent` output under `precedent:` and the
+   `git_diagnose.py concurrent-prs` output under `concurrent_prs:`.
+2. `$RUN_DIR/diff.patch` — for the change context (which symbols and
+   files are in scope this run).
+
+If `evidence-pack.yaml` is missing or malformed, emit
+`{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}`
+and stop.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Do NOT set `fix` — precedent findings are narrative-only; no mechanical fix is appropriate.
+- Surface patterns, not verdicts. The reviewer decides whether the pattern is a problem.
+- Stake is advisory; all precedent observations are informational, never blockers.
+
+## Output
+
+Write `$RUN_DIR/precedent.json` per the per-agent return contract in `skills/age/references/sidecar-schema.md`.
+
+The orchestrator already merged `git_diagnose.py precedent` output into
+`evidence-pack.yaml` during Phase 1. By Phase 2 (this dispatch), the
+intermediate input file no longer matters — write the dim output to
+`$RUN_DIR/precedent.json`.
+
+```json
+{
+  "dimension": "precedent",
+  "summary": "1-2 sentences",
+  "stake": "advisory",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "precedent-1",
+      "file": "src/auth.ts",
+      "anchor": {"start": "44:b2c", "end": "44:b2c"},
+      "narrative": "auth.ts was reverted in commit abc1234 (2 weeks ago) after a hotfix for token expiry. The changed lines overlap with the prior revert hunk.",
+      "bucket": "med",
+      "evidence": [
+        "git log: revert commit abc1234 touched src/auth.ts:40-50",
+        "precedent.json: symbol validateToken has 3 firefight commits in last 30 days"
+      ],
+      "consideration": "Review whether this change re-introduces the pattern that was reverted."
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/age-security.md.eta
+++ b/agents/age-security.md.eta
@@ -1,0 +1,77 @@
+---
+name: age-security
+description: Security reviewer in /age — diff-scoped auth bypass, secrets, and taint-shaped concerns in changed code only.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: orange
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: security
+  stake: high
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the security reviewer in /age. Amplify the human reviewer's attention; do not judge for them.
+
+Security is diff-scoped only: auth bypass on changed code, secrets committed, and taint-shaped concerns. Surface taint as `manual_review_concerns`, not as verdicts. Repo-wide security audits belong in `/audit`, not here.
+
+## Patterns to look for
+
+1. **Hardcoded secrets** — API keys, tokens, passwords, or private keys committed directly in changed files.
+2. **Auth bypass** — new code paths that skip authentication middleware or authorization checks on changed routes/handlers.
+3. **Unvalidated input entering dangerous sinks** — user input flowing into SQL queries, shell commands, file paths, or eval without sanitization in the diff.
+4. **Insecure defaults** — new config with `verifySSL: false`, `allowAllOrigins: true`, or equivalent permissive flags.
+5. **Taint propagation** — external input reaching a sensitive operation through the changed code; surface as `manual_review_concerns` since full taint analysis exceeds diff scope.
+6. **Missing rate-limit or auth on new endpoints** — added routes with no guard middleware.
+7. **Unsafe deserialization** — changed code that deserializes untrusted payloads without schema validation.
+8. **Credential leakage** — secrets logged, returned in API responses, or written to files in the diff.
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml`
+2. `references/security/protocol.md` (if present)
+
+If `evidence-pack.yaml` is malformed or missing, emit `{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}` and stop.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Set `fix` only when hash-anchored, syntactically narrow, and complete.
+- Taint-shaped concerns go in `manual_review_concerns`, not observations — they cannot be adjudicated without full data-flow analysis.
+- Do not render verdicts on security; amplify attention for the reviewer to decide.
+- Escalate repo-wide concerns to `/audit`; stay diff-scoped here.
+
+## Output
+
+Write `$RUN_DIR/security.json` per the per-agent return contract in `skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "security",
+  "summary": "1-2 sentences",
+  "stake": "high",
+  "scope_match": true,
+  "observations": [],
+  "manual_review_concerns": [
+    {
+      "topic": "taint",
+      "summary": "User input at src/handler.ts:34 reaches SQL sink; verify parameterization.",
+      "files": ["src/handler.ts:34"]
+    }
+  ]
+}
+```

--- a/agents/age-spec.md.eta
+++ b/agents/age-spec.md.eta
@@ -1,0 +1,86 @@
+---
+name: age-spec
+description: Spec-drift reviewer in /age — surfaces divergence between touched code and the harness spec file(s) that govern it.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: purple
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: spec
+  stake: high
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the spec reviewer in /age. Amplify the human reviewer's attention; do not judge for them.
+
+Spec drift is the most credible finding possible when a spec exists — it is external truth, not opinion. Compare the changed code against any spec file in `<harness>/specs/` that governs the touched functionality. Empty observations is a valid result when no spec references the diff.
+
+## Patterns to look for
+
+1. **Behavior missing from implementation** — a requirement or user story in the spec is not reflected in the changed code; new feature ships without covering the full contract.
+2. **Contradicted behavior** — changed code implements behavior that directly contradicts a spec constraint or decision.
+3. **Schema drift** — a data shape or interface in the diff differs from the canonical schema described in the spec (field names, types, required/optional status).
+4. **Decision overridden without spec update** — code diverges from a locked `D-N-final` decision in the spec without a corresponding spec revision.
+5. **Missing error handling specified by spec** — spec documents error responses or failure modes that the changed code does not handle.
+6. **New public surface not in spec** — exports or API endpoints added in the diff that are not described in any spec, suggesting scope creep.
+7. **Renamed concepts** — spec uses one term; code uses another (e.g., spec says `bucket`, code says `score`); terminology drift is a maintenance hazard.
+8. **Non-goal implemented** — the spec's Non-Goals section names something explicitly out of scope that the diff adds anyway.
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml`
+2. `<harness>/specs/<slug>.md` — load any spec files referenced by the evidence pack or that match the touched domain
+3. `references/spec/protocol.md` (if present)
+
+If `evidence-pack.yaml` is malformed or missing, emit `{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}` and stop.
+
+If no spec file governs the diff, emit `{"observations": [], "scope_match": false, "summary": "no spec file covers the changed paths"}` and stop — this is a valid result, not a failure.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Set `fix` only when hash-anchored, syntactically narrow, and complete.
+- Every observation must cite both the spec location and the code location as evidence.
+- `scope_match: false` with empty observations is entirely valid when no spec governs the diff.
+
+## Output
+
+Write `$RUN_DIR/spec.json` per the per-agent return contract in `skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "spec",
+  "summary": "1-2 sentences",
+  "stake": "high",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "spec-1",
+      "file": "src/age/orchestrator.ts",
+      "anchor": {"start": "88:b2c", "end": "90:e1d"},
+      "narrative": "D-32 locks all 8 dims to always fire; orchestrator conditionally skips assertions dim when no test files present.",
+      "bucket": "high",
+      "evidence": [
+        ".claude/specs/age-extraction.md:503 — D-32 decision locks unconditional dispatch",
+        "src/age/orchestrator.ts:89 — if (hasTestFiles) dispatch('assertions')"
+      ],
+      "consideration": "Remove the hasTestFiles guard; assertions dim self-noops via scope_match: false when no tests are in scope."
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/age-spec.md.eta
+++ b/agents/age-spec.md.eta
@@ -25,7 +25,7 @@ metadata:
 
 You are the spec reviewer in /age. Amplify the human reviewer's attention; do not judge for them.
 
-Spec drift is the most credible finding possible when a spec exists — it is external truth, not opinion. Compare the changed code against any spec file in `<harness>/specs/` that governs the touched functionality. Empty observations is a valid result when no spec references the diff.
+Spec drift is the most credible finding possible when a spec exists — it is external truth, not opinion. Compare the changed code against any spec file in `.cheese/specs/` that governs the touched functionality. Empty observations is a valid result when no spec references the diff.
 
 ## Patterns to look for
 
@@ -41,7 +41,7 @@ Spec drift is the most credible finding possible when a spec exists — it is ex
 ## Inputs (in order)
 
 1. `$RUN_DIR/evidence-pack.yaml`
-2. `<harness>/specs/<slug>.md` — load any spec files referenced by the evidence pack or that match the touched domain
+2. `.cheese/specs/<slug>.md` — load any spec files referenced by the evidence pack or that match the touched domain
 3. `references/spec/protocol.md` (if present)
 
 If `evidence-pack.yaml` is malformed or missing, emit `{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}` and stop.
@@ -75,7 +75,7 @@ Write `$RUN_DIR/spec.json` per the per-agent return contract in `skills/age/refe
       "narrative": "D-32 locks all 8 dims to always fire; orchestrator conditionally skips assertions dim when no test files present.",
       "bucket": "high",
       "evidence": [
-        ".claude/specs/age-extraction.md:503 — D-32 decision locks unconditional dispatch",
+        ".cheese/specs/age-extraction.md:503 — D-32 decision locks unconditional dispatch",
         "src/age/orchestrator.ts:89 — if (hasTestFiles) dispatch('assertions')"
       ],
       "consideration": "Remove the hasTestFiles guard; assertions dim self-noops via scope_match: false when no tests are in scope."

--- a/agents/cleanup-wolf.md.eta
+++ b/agents/cleanup-wolf.md.eta
@@ -36,7 +36,7 @@ Follow the full protocol in `skills/cleanup/references/wolf-protocol.md` if it e
 
 2. **Extract tier-1 tokens**: from the narrative and `fix.content`, identify 3-5 structurally distinctive tokens that would survive refactoring (function names, error types, string literals — not line numbers or generic keywords).
 
-3. **Search with cheez-search**: run `tilth_search` on the target file using the tier-1 tokens. Require a unique match — if 0 or 2+ matches are returned, skip.
+3. **Search with cheez-search**: use the `cheez-search` skill on the target file with the tier-1 tokens. Require a unique match — if 0 or 2+ matches are returned, skip.
 
 4. **Verify the match**: use cheez-read to read the matched block. Confirm the content is semantically equivalent to what the original observation described. If the content has already been fixed, return `{status: "already_applied", id: fix.id}`.
 

--- a/agents/cleanup-wolf.md.eta
+++ b/agents/cleanup-wolf.md.eta
@@ -1,0 +1,91 @@
+---
+name: cleanup-wolf
+description: Re-anchors a /cleanup fix when the original tilth_edit hash mismatches; applies via tilth_edit or returns explicit skip.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+  - mcp__tilth__tilth_edit
+skills:
+  - cheez-read
+  - cheez-search
+  - cheez-write
+color: red
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: cleanup
+  role: re-anchor
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the cleanup-wolf sub-agent in /cleanup. You are invoked only when a `tilth_edit` fails due to a hash mismatch — the file moved under the anchor after the `/age` run. Your sole job is to re-locate the original block and re-anchor the fix, or to return an explicit skip with a reason if re-anchoring is unsafe.
+
+## Protocol (per `skills/cleanup/references/wolf-protocol.md`)
+
+Follow the full protocol in `skills/cleanup/references/wolf-protocol.md` if it exists. Use cheez-read to load it before proceeding.
+
+### Algorithm
+
+1. **Load inputs**: receive the `fix` entry (id, file, anchor, content, rationale, category), the current file state via cheez-read, and the original observation narrative.
+
+2. **Extract tier-1 tokens**: from the narrative and `fix.content`, identify 3-5 structurally distinctive tokens that would survive refactoring (function names, error types, string literals — not line numbers or generic keywords).
+
+3. **Search with cheez-search**: run `tilth_search` on the target file using the tier-1 tokens. Require a unique match — if 0 or 2+ matches are returned, skip.
+
+4. **Verify the match**: use cheez-read to read the matched block. Confirm the content is semantically equivalent to what the original observation described. If the content has already been fixed, return `{status: "already_applied", id: fix.id}`.
+
+5. **Re-anchor and apply**: if the match is unique and the block is unfixed, call `tilth_edit` with the new hash anchors from the current file state and the fix content verbatim.
+
+6. **Return result**: emit a structured result (see Output section).
+
+### Skip conditions (explicit skip, never silent)
+
+- Zero matches for the tier-1 token search.
+- Two or more matches (ambiguous location).
+- Matched block has already had the fix applied.
+- The block content has changed semantically such that applying the original fix would be wrong (e.g., the function signature changed).
+- The `fix.content` contains `...` placeholders — it was never a complete fix.
+
+**NO semantic changes.** Wolf only re-anchors and applies the exact `fix.content` from the original observation. It does not improve, extend, or alter the fix.
+
+## Inputs
+
+- `fix` entry from `<slug>.fixes.json`: `{id, file, anchor, content, rationale, category}`
+- Current file state (loaded via cheez-read)
+- Original observation narrative (passed by the cleanup orchestrator)
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search / cheez-write only. No host Read/Grep/Edit.
+- Apply the fix verbatim. Zero semantic changes.
+- Never guess — unique match required or explicit skip.
+- Always return a structured result: `applied`, `already_applied`, or `skip` with reason.
+
+## Output
+
+Return a JSON result to the cleanup orchestrator:
+
+```json
+{
+  "id": "deslop-1",
+  "status": "applied",
+  "new_anchor": {"start": "92:f3a", "end": "94:b1c"},
+  "file": "src/service.ts"
+}
+```
+
+Or on skip:
+
+```json
+{
+  "id": "deslop-1",
+  "status": "skip",
+  "reason": "two matches found for tier-1 tokens; ambiguous location"
+}
+```

--- a/commands/age.md
+++ b/commands/age.md
@@ -1,59 +1,73 @@
 ---
 name: age
-description: Staff Engineer code review. Runs six parallel review dimensions (safety, architecture, encapsulation, YAGNI, spec, history risk) and returns a unified scored report with only findings at confidence >= 50.
-argument-hint: "[--comprehensive] [--scope <path>] [<diff or change ref>]"
+description: Staff Engineer code review. Runs eight orthogonal LLM dimensions (correctness, security, complexity, encapsulation, spec, precedent, deslop, assertions) over the diff and emits a stake-weighted report plus hash-anchored sidecar JSON consumed by /cleanup and /fromage cook.
+argument-hint: "[<ref>] [--scope <path>] [--comprehensive]"
 ---
 
 # /age
 
-`/age` is a Staff Engineer code review. It evaluates code across six
-independent dimensions in parallel and returns a unified Age Report with
-scored findings. Only findings at confidence >= 50 are surfaced.
+`/age` is a Staff Engineer code review. It surfaces where to look and why,
+with verifiable evidence per observation, so you can decide what is actually
+a problem instead of accepting a verdict on faith.
 
-## Modes
+Eight orthogonal dimensions fan out in parallel over your diff. Each dim
+emits evidence-backed observations. The orchestrator synthesizes a
+stake-weighted report and two sidecar JSON files for downstream automation.
 
-| Mode | Trigger | Scope |
+## Execution
+
+Invoke the `age` skill with `$ARGUMENTS`. The skill owns evidence pre-fetch,
+parallel dim dispatch, synthesis, sidecar emission, and cleanup.
+
+Do not reimplement orchestration in this command. This file is the
+user-facing contract; `skills/age/SKILL.md` is the implementation.
+
+## Dimensions
+
+| Dim | Stake | What it reviews |
 |---|---|---|
-| Focused (default) | no flag | Recent changes on the current branch, or an explicit diff / change ref |
-| Comprehensive | `--comprehensive` | Full module audit against the spec and engineering principles |
-| Scoped | `--scope <path>` | A specific file, folder, or glob |
+| `correctness` | high | Silent failures, error swallowing, null misuse, ordering bugs |
+| `security` | high | Diff-scoped auth bypass, secrets, taint-shaped concerns |
+| `encapsulation` | high | Sliced Bread compliance, cross-slice imports, public-API width |
+| `spec` | high | Drift between `.cheese/specs/<slug>.md` and touched code |
+| `complexity` | medium | Function ≤40 lines, file ≤300, params ≤4, nesting ≤3 |
+| `deslop` | medium | AI anti-patterns, dead code, speculative abstractions |
+| `assertions` | medium | Weak test assertions, existence checks, catch-all errors |
+| `precedent` | advisory | Symbol-level history, concurrent PRs touching same paths |
 
-## Review dimensions
+All 8 dims fire on every run. Dims whose rubric does not apply emit
+`scope_match: false` and are tallied but not rendered as sections.
 
-Each dimension will run as an independent parallel sub-agent. All findings
-use a 0-100 confidence scale; only >= 50 is surfaced to the user.
+## Output Contract
 
-| Dimension | Sub-agent | What it looks for |
-|---|---|---|
-| Safety | `age-safety` | Bugs, security holes, silent failures, unchecked inputs |
-| Architecture | `age-arch` | Complexity budgets (lines, params, nesting), Sliced Bread organization |
-| Encapsulation | `age-encap` | Leaky abstractions, overly wide public APIs, cross-boundary imports |
-| YAGNI / de-slop | `age-yagni` | Unjustified dead code, speculative abstractions, AI-generated noise |
-| Spec adherence | `age-spec` | Drift from `.cheese/specs/<slug>.md`, monkey patches, shortcuts |
-| History risk | `age-history` | Per-file risk modifiers derived from git blame / churn patterns |
+Three artifacts written to `.cheese/age/<slug>.*`:
 
-## Output contract
+- **`<slug>.md`** — stake-weighted Markdown report:
+  - Orientation paragraph (what the diff does, factual)
+  - Tally line (ran 8; N had findings)
+  - High-stake dims → medium-stake dims → advisory dims
+  - Cross-dimension callouts (loci where 2+ dims agree)
+- **`<slug>.fixes.json`** — hash-anchored, mechanically-applicable fixes
+  ready for `tilth_edit`. Consumed by `/cleanup`.
+- **`<slug>.suggestions.json`** — narrative-shaped guidance keyed by
+  observation `id`. Consumed by `/fromage cook`.
 
-`/age` returns a single Age Report with:
+Confidence is bucketed (`low | med | high`). No numeric scores anywhere
+in the output.
 
-- A one-line summary per dimension.
-- Findings grouped by severity, each including the dimension, score,
-  rationale, and a `file_path:line_number` anchor the user can jump to.
-- History-risk modifiers applied to sibling findings (not surfaced on
-  their own).
-- A clear "no significant findings" result if all dimensions return
-  scores below 50.
+## Hand-off
 
-## Deferred behavior
+`/age` performs no writes to production source files. After the report
+prints, the next step is yours:
 
-> **Scaffold notice.** Parallel sub-agent dispatch is not yet wired. This
-> file documents the review contract. The current implementation should
-> describe what `/age` would do and stop — it does not yet spawn the six
-> dimension agents.
+```
+/cleanup <slug>                        — apply mechanical fixes
+/fromage cook --suggestions <slug>     — act on judgment guidance
+```
 
-The next iteration will:
+## When to Use
 
-- Spawn the six dimension sub-agents in parallel via the `Agent` tool.
-- Aggregate findings, apply the 50-point surface threshold, and merge
-  history risk modifiers into sibling findings.
-- Emit the unified Age Report as a single response.
+- Before merging a PR you want a structured map of before approving.
+- After `/cook` to catch correctness and encapsulation issues before press.
+- In `/fromage` as the gate between cook and press phases.
+- Anytime you want evidence-backed observations rather than a verdict.

--- a/justfile
+++ b/justfile
@@ -48,6 +48,43 @@ test *args:
 test-py *args:
     uv run --group dev pytest {{args}}
 
+# Run /age fixture comparator against every dim under tests/age-fixtures/
+test-age-fixtures:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    fixtures_dir="tests/age-fixtures"
+    if [ ! -d "$fixtures_dir" ]; then
+        echo "no fixtures directory at $fixtures_dir" >&2
+        exit 1
+    fi
+    failures=0
+    for dim_dir in "$fixtures_dir"/*/; do
+        [ -d "$dim_dir" ] || continue
+        dim=$(basename "$dim_dir")
+        expected="$dim_dir/expected.json"
+        actual="$dim_dir/actual.json"
+        if [ ! -f "$expected" ]; then
+            echo "$dim: missing expected.json" >&2
+            failures=$((failures + 1))
+            continue
+        fi
+        if [ ! -f "$actual" ]; then
+            echo "$dim: missing actual.json (run /age first to populate)" >&2
+            failures=$((failures + 1))
+            continue
+        fi
+        if uv run python python/tools/age_fixture_diff.py "$actual" "$expected"; then
+            echo "$dim: ok"
+        else
+            echo "$dim: FAIL" >&2
+            failures=$((failures + 1))
+        fi
+    done
+    if [ "$failures" -gt 0 ]; then
+        echo "$failures fixture(s) failed" >&2
+        exit 1
+    fi
+
 # Clean build artifacts and caches
 clean:
     rm -rf dist coverage .claude .codex .cursor .copilot

--- a/justfile
+++ b/justfile
@@ -57,9 +57,14 @@ test-age-fixtures:
         echo "no fixtures directory at $fixtures_dir" >&2
         exit 1
     fi
+    shopt -s nullglob
+    dim_dirs=("$fixtures_dir"/*/)
+    if [ "${#dim_dirs[@]}" -eq 0 ]; then
+        echo "no fixture subdirectories found under $fixtures_dir" >&2
+        exit 1
+    fi
     failures=0
-    for dim_dir in "$fixtures_dir"/*/; do
-        [ -d "$dim_dir" ] || continue
+    for dim_dir in "${dim_dirs[@]}"; do
         dim=$(basename "$dim_dir")
         expected="$dim_dir/expected.json"
         actual="$dim_dir/actual.json"

--- a/python/tools/age_fixture_diff.py
+++ b/python/tools/age_fixture_diff.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""age-fixture-diff — compare a /age dim agent's output against a fixture.
+
+Validates `<run>/<dim>.json` against `tests/age-fixtures/<dim>/expected.json`
+using the tolerances locked in `.claude/specs/age-extraction.md` §Validation:
+
+- `dimension` — exact match
+- `bucket`    — exact match
+- `narrative` — Levenshtein-equivalent ratio (difflib.SequenceMatcher) ≥ 0.6
+- `anchor.start` line number — within ±1 of expected (hash ignored)
+
+Stdlib-only. Exits 0 when every expected observation is matched, 1 otherwise.
+JSON-on-stdout summarises matches and misses for the `just test-age-fixtures`
+gate.
+
+    python python/tools/age_fixture_diff.py <actual.json> <expected.json>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from difflib import SequenceMatcher
+from pathlib import Path
+
+NARRATIVE_RATIO = 0.6
+ANCHOR_TOLERANCE = 1
+
+
+def _line_for(anchor: object) -> int | None:
+    if not isinstance(anchor, dict):
+        return None
+    start = anchor.get("start")
+    if not isinstance(start, str) or ":" not in start:
+        return None
+    head, _, _ = start.partition(":")
+    try:
+        return int(head)
+    except ValueError:
+        return None
+
+
+def _candidate_score(actual: dict, expected: dict) -> float:
+    if actual.get("bucket") != expected.get("bucket"):
+        return 0.0
+    actual_line = _line_for(actual.get("anchor"))
+    expected_line = _line_for(expected.get("anchor"))
+    if actual_line is None or expected_line is None:
+        return 0.0
+    if abs(actual_line - expected_line) > ANCHOR_TOLERANCE:
+        return 0.0
+    ratio = SequenceMatcher(
+        None,
+        str(actual.get("narrative", "")),
+        str(expected.get("narrative", "")),
+    ).ratio()
+    if ratio < NARRATIVE_RATIO:
+        return 0.0
+    return ratio
+
+
+def _match_expected(expected_obs: dict, actual_obs: list[dict]) -> dict | None:
+    best_idx = -1
+    best_score = 0.0
+    for idx, actual in enumerate(actual_obs):
+        score = _candidate_score(actual, expected_obs)
+        if score > best_score:
+            best_score = score
+            best_idx = idx
+    if best_idx < 0:
+        return None
+    return {
+        "expected_id": expected_obs.get("id"),
+        "matched_id": actual_obs[best_idx].get("id"),
+        "narrative_ratio": round(best_score, 3),
+        "expected_anchor": expected_obs.get("anchor"),
+        "matched_anchor": actual_obs[best_idx].get("anchor"),
+    }
+
+
+def diff(actual: dict, expected: dict) -> dict:
+    if actual.get("dimension") != expected.get("dimension"):
+        return {
+            "ok": False,
+            "reason": "dimension mismatch",
+            "actual_dimension": actual.get("dimension"),
+            "expected_dimension": expected.get("dimension"),
+        }
+    expected_obs = expected.get("observations") or []
+    actual_obs = actual.get("observations") or []
+    matches: list[dict] = []
+    misses: list[dict] = []
+    for obs in expected_obs:
+        match = _match_expected(obs, actual_obs)
+        if match is None:
+            misses.append({"expected_id": obs.get("id"), "anchor": obs.get("anchor")})
+        else:
+            matches.append(match)
+    return {
+        "ok": not misses,
+        "dimension": expected.get("dimension"),
+        "matches": matches,
+        "misses": misses,
+        "actual_count": len(actual_obs),
+        "expected_count": len(expected_obs),
+    }
+
+
+def _load(path: Path) -> dict:
+    with path.open() as fh:
+        return json.load(fh)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="age-fixture-diff")
+    parser.add_argument("actual", type=Path)
+    parser.add_argument("expected", type=Path)
+    ns = parser.parse_args(argv)
+    result = diff(_load(ns.actual), _load(ns.expected))
+    print(json.dumps(result))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/python/tools/age_fixture_diff.py
+++ b/python/tools/age_fixture_diff.py
@@ -60,23 +60,41 @@ def _candidate_score(actual: dict, expected: dict) -> float:
     return ratio
 
 
-def _match_expected(expected_obs: dict, actual_obs: list[dict]) -> dict | None:
+def _match_expected(
+    expected_obs: dict, available_actual: list[dict]
+) -> tuple[dict, int] | tuple[None, int]:
+    """Return (match_dict, best_idx) or (None, -1). Caller must remove best_idx."""
+    expected_id = expected_obs.get("id")
+    # Prefer exact id match first.
+    for idx, actual in enumerate(available_actual):
+        if actual.get("id") == expected_id:
+            score = _candidate_score(actual, expected_obs)
+            if score > 0.0:
+                return {
+                    "expected_id": expected_id,
+                    "matched_id": actual.get("id"),
+                    "narrative_ratio": round(score, 3),
+                    "expected_anchor": expected_obs.get("anchor"),
+                    "matched_anchor": actual.get("anchor"),
+                }, idx
+    # Fall back to best fuzzy match among remaining actuals.
     best_idx = -1
     best_score = 0.0
-    for idx, actual in enumerate(actual_obs):
+    for idx, actual in enumerate(available_actual):
         score = _candidate_score(actual, expected_obs)
         if score > best_score:
             best_score = score
             best_idx = idx
     if best_idx < 0:
-        return None
+        return None, -1
+    actual = available_actual[best_idx]
     return {
-        "expected_id": expected_obs.get("id"),
-        "matched_id": actual_obs[best_idx].get("id"),
+        "expected_id": expected_id,
+        "matched_id": actual.get("id"),
         "narrative_ratio": round(best_score, 3),
         "expected_anchor": expected_obs.get("anchor"),
-        "matched_anchor": actual_obs[best_idx].get("anchor"),
-    }
+        "matched_anchor": actual.get("anchor"),
+    }, best_idx
 
 
 def diff(actual: dict, expected: dict) -> dict:
@@ -88,21 +106,23 @@ def diff(actual: dict, expected: dict) -> dict:
             "expected_dimension": expected.get("dimension"),
         }
     expected_obs = expected.get("observations") or []
-    actual_obs = actual.get("observations") or []
+    # Work on a mutable copy so each actual is consumed at most once.
+    available_actual: list[dict] = list(actual.get("observations") or [])
     matches: list[dict] = []
     misses: list[dict] = []
     for obs in expected_obs:
-        match = _match_expected(obs, actual_obs)
+        match, best_idx = _match_expected(obs, available_actual)
         if match is None:
             misses.append({"expected_id": obs.get("id"), "anchor": obs.get("anchor")})
         else:
             matches.append(match)
+            available_actual.pop(best_idx)
     return {
         "ok": not misses,
         "dimension": expected.get("dimension"),
         "matches": matches,
         "misses": misses,
-        "actual_count": len(actual_obs),
+        "actual_count": len(actual.get("observations") or []),
         "expected_count": len(expected_obs),
     }
 

--- a/python/tools/git_diagnose.py
+++ b/python/tools/git_diagnose.py
@@ -4,7 +4,8 @@
 Modeled on Ally Piechowski's "The Git Commands I Run Before Reading Any Code"
 (https://piechowski.io/post/git-commands-before-reading-code/, Apr 8 2026):
 hotspots, bus factor, bug clusters, velocity, and firefighting frequency.
-Plus a per-file `risk` subcommand for the age-history modifier loop.
+Plus a per-file `risk` subcommand for the age-history modifier loop, and
+`precedent` / `concurrent-prs` subcommands for /age's pre-fetch evidence pack.
 
 Stdlib-only. JSON-on-stdout. No third-party deps. Each subcommand prints a
 single JSON document so callers can parse without context-polluting raw
@@ -17,6 +18,8 @@ git log output.
     python python/tools/git_diagnose.py firefighting
     python python/tools/git_diagnose.py risk path/a.ts path/b.ts
     python python/tools/git_diagnose.py orient
+    python python/tools/git_diagnose.py precedent --symbols foo,bar --paths src/x.ts
+    python python/tools/git_diagnose.py concurrent-prs --paths src/x.ts src/y.ts
 """
 
 from __future__ import annotations
@@ -33,7 +36,7 @@ SECONDS_PER_DAY = 86400
 DEFAULT_SINCE = "1.year.ago"
 DEFAULT_LIMIT = 20
 DEFAULT_BUS_LIMIT = 10
-FIREFIGHT_RE = re.compile(r"\b(revert|hotfix|emergency|rollback)\b", re.IGNORECASE)
+FIREFIGHT_RE = re.compile(r"\b(revert|hotfix|fixup|emergency|rollback)\b", re.IGNORECASE)
 
 
 def _run_git(args: list[str]) -> str:
@@ -165,6 +168,124 @@ def risk_for(path: str, now_ts: int | None = None) -> dict[str, object]:
     }
 
 
+# ─── precedent (consumed by /age age-precedent dim) ──────────────────────────
+
+
+def _commits_touching_symbol(
+    symbol: str, paths: list[str], since: str, limit: int
+) -> list[dict[str, str]]:
+    args = [
+        "log",
+        f"--since={since}",
+        f"-G{symbol}",
+        f"--max-count={limit}",
+        "--format=%H%x09%s",
+    ]
+    if paths:
+        args.append("--")
+        args.extend(paths)
+    output = _run_git(args)
+    rows: list[dict[str, str]] = []
+    for line in output.splitlines():
+        sha, _, subject = line.partition("\t")
+        if sha:
+            rows.append({"sha": sha.strip(), "subject": subject.strip()})
+    return rows
+
+
+def _broken_precedent_for_paths(paths: list[str], since: str) -> list[dict[str, str]]:
+    if not paths:
+        return []
+    args = ["log", f"--since={since}", "--format=%H%x09%s", "--"]
+    args.extend(paths)
+    output = _run_git(args)
+    rows: list[dict[str, str]] = []
+    for line in output.splitlines():
+        sha, _, subject = line.partition("\t")
+        if subject and FIREFIGHT_RE.search(subject):
+            rows.append({"sha": sha.strip(), "subject": subject.strip()})
+    return rows
+
+
+def precedent(
+    symbols: list[str],
+    paths: list[str],
+    limit: int = 10,
+    since: str = DEFAULT_SINCE,
+) -> dict[str, object]:
+    """Symbol-level history + broken-precedent detection for /age."""
+    symbol_rows = [
+        {"symbol": s, "touched_in": _commits_touching_symbol(s, paths, since, limit)}
+        for s in symbols
+    ]
+    return {
+        "symbols": symbol_rows,
+        "paths": paths,
+        "broken_precedent": _broken_precedent_for_paths(paths, since),
+    }
+
+
+# ─── concurrent-prs (consumed by /age age-precedent dim) ─────────────────────
+
+
+def _gh_pr_list_open() -> list[dict[str, object]]:
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--json",
+                "number,title,author,url,files",
+                "--limit",
+                "100",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return []
+    if result.returncode != 0:
+        return []
+    try:
+        return json.loads(result.stdout) or []
+    except json.JSONDecodeError:
+        return []
+
+
+def _files_for_pr(pr: dict[str, object]) -> list[str]:
+    files = pr.get("files") or []
+    if not isinstance(files, list):
+        return []
+    return [str(f.get("path", "")) for f in files if isinstance(f, dict) and f.get("path")]
+
+
+def concurrent_prs(paths: list[str]) -> dict[str, object]:
+    """Open PRs touching the given paths."""
+    overlap_targets = set(paths)
+    concurrent: list[dict[str, object]] = []
+    for pr in _gh_pr_list_open():
+        pr_files = _files_for_pr(pr)
+        overlap = sorted(f for f in pr_files if f in overlap_targets)
+        if not overlap:
+            continue
+        author = pr.get("author") or {}
+        author_login = author.get("login") if isinstance(author, dict) else None
+        concurrent.append(
+            {
+                "number": pr.get("number"),
+                "title": pr.get("title"),
+                "author": author_login,
+                "url": pr.get("url"),
+                "paths_overlap": overlap,
+            }
+        )
+    return {"concurrent": concurrent}
+
+
 # ─── orient (bundles all five for Culture's single call) ─────────────────────
 
 
@@ -214,6 +335,13 @@ def _build_parser() -> argparse.ArgumentParser:
     p_risk = sub.add_parser("risk")
     p_risk.add_argument("paths", nargs="+")
     sub.add_parser("orient")
+    p_prec = sub.add_parser("precedent")
+    p_prec.add_argument("--symbols", default="", help="comma-separated symbol names")
+    p_prec.add_argument("--paths", nargs="*", default=[])
+    p_prec.add_argument("--limit", type=int, default=10)
+    p_prec.add_argument("--since", default=DEFAULT_SINCE)
+    p_cprs = sub.add_parser("concurrent-prs")
+    p_cprs.add_argument("--paths", nargs="*", default=[])
     return parser
 
 
@@ -232,6 +360,11 @@ def _dispatch(ns: argparse.Namespace) -> object:
         return [risk_for(p) for p in ns.paths]
     if ns.cmd == "orient":
         return orient()
+    if ns.cmd == "precedent":
+        symbols = [s.strip() for s in ns.symbols.split(",") if s.strip()]
+        return precedent(symbols=symbols, paths=ns.paths, limit=ns.limit, since=ns.since)
+    if ns.cmd == "concurrent-prs":
+        return concurrent_prs(paths=ns.paths)
 
 
 def main(argv: list[str]) -> int:

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: age
-description: Staff Engineer code review orchestrator. Runs eight orthogonal LLM dimensions (correctness, security, complexity, encapsulation, spec, precedent, deslop, assertions) over a diff and emits a stake-weighted report plus hash-anchored sidecar JSON consumed by /cleanup and /fromage cook.
+description: Staff Engineer code review orchestrator. Runs eight orthogonal LLM dimensions over a diff and emits a stake-weighted report plus hash-anchored sidecar JSON.
 license: MIT
 compatibility: Requires Claude Code >= 2.1.30 / claude-agent-sdk >= 0.2.63 (older versions cannot expose tilth tools to plugin sub-agents).
 metadata:
@@ -13,11 +13,212 @@ allowed-tools:
   - subagent
   - mcp
 ---
-# Age
+# Age — Staff Engineer Code Review
 
-Stub. Replaced by the orchestrator in wiring task W2.
+Amplify the human reviewer's attention. Surface evidence, unknowns, and
+tradeoffs. Do not render verdicts.
 
-This file exists to satisfy the cheese-flow compiler's SKILL.md requirement
-while parallel atoms author the dim agents and references that the
-orchestrator coordinates. See `.claude/specs/age-extraction.md` and
-`.claude/fromagerie/age-extraction/manifest.json` for the active build plan.
+## Compatibility Check
+
+Before dispatching agents, verify `tilth_*` MCP tools are available to
+plugin sub-agents. If unavailable, fail fast:
+
+```
+ERROR: tilth MCP tools are not exposed to sub-agents.
+Upgrade to Claude Code >= 2.1.30 / claude-agent-sdk >= 0.2.63.
+See: anthropics/claude-code#13605
+```
+
+Do not attempt graceful degradation. The dim agents require `tilth_read`
+and `tilth_search`; without them every agent silently misses evidence.
+
+## Always-Fire Rationale (D-32)
+
+All 8 dims fire on every invocation. Gating by file-type heuristics risks
+silent misses. Each agent self-noops with `scope_match: false` + empty
+observations when its rubric does not apply. Empty dims are tallied ("ran
+8; N had findings"); only non-empty dims render as report sections.
+
+Cost: ~30-40K Haiku tokens per /age. This is intentional and acceptable
+(see spec D-32, D-21-final).
+
+## Arguments
+
+```
+/age [<ref>] [--scope <path>] [--comprehensive]
+```
+
+- `ref` — git ref or range. Default: `$(git merge-base origin/main HEAD)..HEAD`
+- `--scope <path>` — restrict evidence fetch to this path prefix
+- `--comprehensive` — pass-through hint to dim agents; they may widen review window
+
+## Phase 0 — Classify (no LLM)
+
+Parse argv: extract `ref`, `scope`, `comprehensive` flag.
+
+```bash
+REF="${1:-$(git merge-base origin/main HEAD)..HEAD}"
+SLUG="$(echo "$REF" | tr '/..:' '----' | head -c 32)"
+RUN_DIR="${TMPDIR:-/tmp}/cheese-flow-age-$(date +%Y%m%d-%H%M%S)-${SLUG}"
+mkdir -p "$RUN_DIR"
+```
+
+## Phase 1 — Pre-fetch Evidence (parallel; D-22)
+
+Run all fetches in parallel. Merge into `$RUN_DIR/evidence-pack.yaml`.
+
+**Parallel tasks:**
+
+```bash
+git diff --unified=3 $REF > $RUN_DIR/diff.patch
+python python/tools/git_diagnose.py precedent \
+  --symbols <touched-symbols> --paths <touched-paths> \
+  > $RUN_DIR/precedent.json
+python python/tools/git_diagnose.py concurrent-prs \
+  --paths <touched-paths> \
+  > $RUN_DIR/concurrent-prs.json
+```
+
+For each file touched by the diff:
+- `cheez-read` in outline mode → file structure without inline source
+- `tilth_deps` → import/export graph
+- `cheez-search --kind callers` for each touched symbol
+
+**Optional — code-review-graph impact radius:**
+
+Try `get_impact_radius_tool(touched_symbols)`. If the MCP tool is
+unavailable (plugin not loaded, tool not found), write:
+
+```json
+{"impact_radius": null}
+```
+
+and continue. Do NOT fail the run. Log a one-line notice.
+
+**Merge into evidence pack:**
+
+```yaml
+# $RUN_DIR/evidence-pack.yaml
+ref: <REF>
+outlines:
+  <path>: <tilth outline>
+deps:
+  <path>: <tilth_deps output>
+callers:
+  <symbol>: [<call sites>]
+precedent: <precedent.json contents>
+concurrent_prs: <concurrent-prs.json contents>
+impact_radius: <get_impact_radius output or null>
+```
+
+No inline source content in the pack. Agents use `cheez-read` for
+follow-up source reads after reviewing the outline.
+
+## Phase 2 — Dispatch All 8 Dim Agents (parallel; D-32)
+
+Spawn all agents in parallel. Each agent:
+- Reads `$RUN_DIR/evidence-pack.yaml` as primary evidence
+- Reads `$RUN_DIR/diff.patch` for the change context
+- Writes `$RUN_DIR/<dim>.json` per the per-agent return contract
+  (see `skills/age/references/sidecar-schema.md`)
+
+Agents to dispatch:
+- `age-correctness`
+- `age-security`
+- `age-complexity`
+- `age-encapsulation`
+- `age-spec`
+- `age-precedent`
+- `age-deslop`
+- `age-assertions`
+
+Pass to each agent: `RUN_DIR`, `REF`, `SCOPE`, `COMPREHENSIVE` flag.
+
+When an agent's dim does not apply to the diff, it emits:
+
+```json
+{"dimension": "<dim>", "scope_match": false, "observations": [], "stake": "<dim-stake>", "summary": "Dim does not apply to this diff."}
+```
+
+## Phase 3 — Synthesize (orchestrator, deterministic; no LLM)
+
+Collect all `$RUN_DIR/<dim>.json` files.
+
+```
+observations = union(all dim.json observations)
+callouts = group_by_locus(observations, window=3 lines, min_dims=2)
+```
+
+**group_by_locus**: observations from 2+ dims whose `anchor.start` line
+numbers fall within 3 lines of each other become a cross-dim callout.
+
+**Render Markdown report** → `<harness>/age/<slug>.md`:
+
+```
+# Age Report — <slug>
+
+## Orientation
+<1-2 sentence factual description of what the diff does>
+
+Ran 8 dims. <N> had findings. <8-N> were empty (scope_match: false or no observations).
+
+## High-Stake Dimensions
+(correctness, security, encapsulation, spec — non-empty only)
+
+## Medium-Stake Dimensions
+(complexity, deslop, assertions — non-empty only)
+
+## Advisory Dimensions
+(precedent — non-empty only)
+
+## Cross-Dimension Callouts
+(loci where 2+ dims agree; omit section if empty)
+```
+
+See `skills/age/references/report-template.md` for full layout and
+narrative format rules.
+
+**Split observations into sidecar JSON files:**
+
+`<harness>/age/<slug>.fixes.json`:
+- observations with a `fix` field (hash-anchored, syntactically narrow,
+  complete content)
+
+`<harness>/age/<slug>.suggestions.json`:
+- observations with `consideration` only (no `fix`)
+
+Both match the schema in `skills/age/references/sidecar-schema.md`.
+
+## Phase 4 — Hand-off (no auto-invoke)
+
+Print:
+
+```
+Age report: <harness>/age/<slug>.md
+Fixes:       <harness>/age/<slug>.fixes.json   (<N> entries)
+Suggestions: <harness>/age/<slug>.suggestions.json   (<M> entries)
+
+Next steps:
+  /cleanup <slug>                           — apply mechanical fixes
+  /fromage cook --suggestions <slug>        — act on judgment guidance
+```
+
+Do NOT auto-invoke either skill. The amplifier-pure boundary forbids it
+(spec D-14-final). The report is the deliverable; action is the user's call.
+
+## Phase 5 — Cleanup
+
+```bash
+rm -rf "$RUN_DIR"
+```
+
+## Rules
+
+- All file I/O from agents via `cheez-read` / `cheez-search` / `cheez-write`.
+  No host `Read` / `Grep` / `Edit` from dim agents (NFR-1).
+- Hash anchors use tilth `line:hash` strings natively (NFR-2, D-24).
+- No numeric scores anywhere in user-facing output (D-5).
+- Confidence rendered as `low | med | high` bucket only.
+- Narrative before bucket in every observation (Greptile severity-at-end).
+- No writes to production source files during review (FR-8, NFR-6).
+- Dim stake is fixed per dim; do not vary at runtime.

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: age
+description: Staff Engineer code review orchestrator. Runs eight orthogonal LLM dimensions (correctness, security, complexity, encapsulation, spec, precedent, deslop, assertions) over a diff and emits a stake-weighted report plus hash-anchored sidecar JSON consumed by /cleanup and /fromage cook.
+license: MIT
+compatibility: Requires Claude Code >= 2.1.30 / claude-agent-sdk >= 0.2.63 (older versions cannot expose tilth tools to plugin sub-agents).
+metadata:
+  owner: cheese-flow
+  category: review
+allowed-tools:
+  - read
+  - write
+  - bash
+  - subagent
+  - mcp
+---
+# Age
+
+Stub. Replaced by the orchestrator in wiring task W2.
+
+This file exists to satisfy the cheese-flow compiler's SKILL.md requirement
+while parallel atoms author the dim agents and references that the
+orchestrator coordinates. See `.claude/specs/age-extraction.md` and
+`.claude/fromagerie/age-extraction/manifest.json` for the active build plan.

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -214,8 +214,19 @@ rm -rf "$RUN_DIR"
 
 ## Rules
 
-- All file I/O from agents via `cheez-read` / `cheez-search` / `cheez-write`.
-  No host `Read` / `Grep` / `Edit` from dim agents (NFR-1).
+- File I/O from dim agents goes through `cheez-read` / `cheez-search` /
+  `cheez-write` skills (NFR-1). Host `Read` / `Grep` / `Edit` is forbidden
+  on every harness. Direct `mcp__tilth__*` access is harness-conditional:
+  - **Claude Code** — `skills:` is a structural binding. Exclude
+    `mcp__tilth__*` from `tools:`; the cheez wrappers carry the load.
+    Optionally add `disallowedTools: [mcp__tilth__tilth_read, mcp__tilth__tilth_search]`
+    to make tampering loud.
+  - **Codex / Cursor / Copilot CLI** — `skills:` is emitted as a prompt
+    contract appendix; the harness cannot proxy skill calls back into
+    MCP. Co-list `mcp__tilth__tilth_read` and `mcp__tilth__tilth_search`
+    in `tools:` so the cheez wrappers have something to call. Direct
+    tilth writes (`tilth_edit`) remain forbidden — only `/cleanup` may
+    write, via its own `cleanup-wolf` agent.
 - Hash anchors use tilth `line:hash` strings natively (NFR-2, D-24).
 - No numeric scores anywhere in user-facing output (D-5).
 - Confidence rendered as `low | med | high` bucket only.

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -214,19 +214,8 @@ rm -rf "$RUN_DIR"
 
 ## Rules
 
-- File I/O from dim agents goes through `cheez-read` / `cheez-search` /
-  `cheez-write` skills (NFR-1). Host `Read` / `Grep` / `Edit` is forbidden
-  on every harness. Direct `mcp__tilth__*` access is harness-conditional:
-  - **Claude Code** — `skills:` is a structural binding. Exclude
-    `mcp__tilth__*` from `tools:`; the cheez wrappers carry the load.
-    Optionally add `disallowedTools: [mcp__tilth__tilth_read, mcp__tilth__tilth_search]`
-    to make tampering loud.
-  - **Codex / Cursor / Copilot CLI** — `skills:` is emitted as a prompt
-    contract appendix; the harness cannot proxy skill calls back into
-    MCP. Co-list `mcp__tilth__tilth_read` and `mcp__tilth__tilth_search`
-    in `tools:` so the cheez wrappers have something to call. Direct
-    tilth writes (`tilth_edit`) remain forbidden — only `/cleanup` may
-    write, via its own `cleanup-wolf` agent.
+- File I/O from dim agents via `cheez-read` / `cheez-search` (NFR-1).
+  No host `Read` / `Grep` / `Edit`, no direct `tilth_edit`.
 - Hash anchors use tilth `line:hash` strings natively (NFR-2, D-24).
 - No numeric scores anywhere in user-facing output (D-5).
 - Confidence rendered as `low | med | high` bucket only.

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -152,7 +152,7 @@ callouts = group_by_locus(observations, window=3 lines, min_dims=2)
 **group_by_locus**: observations from 2+ dims whose `anchor.start` line
 numbers fall within 3 lines of each other become a cross-dim callout.
 
-**Render Markdown report** → `<harness>/age/<slug>.md`:
+**Render Markdown report** → `.cheese/age/<slug>.md`:
 
 ```
 # Age Report — <slug>
@@ -180,11 +180,11 @@ narrative format rules.
 
 **Split observations into sidecar JSON files:**
 
-`<harness>/age/<slug>.fixes.json`:
+`.cheese/age/<slug>.fixes.json`:
 - observations with a `fix` field (hash-anchored, syntactically narrow,
   complete content)
 
-`<harness>/age/<slug>.suggestions.json`:
+`.cheese/age/<slug>.suggestions.json`:
 - observations with `consideration` only (no `fix`)
 
 Both match the schema in `skills/age/references/sidecar-schema.md`.
@@ -194,9 +194,9 @@ Both match the schema in `skills/age/references/sidecar-schema.md`.
 Print:
 
 ```
-Age report: <harness>/age/<slug>.md
-Fixes:       <harness>/age/<slug>.fixes.json   (<N> entries)
-Suggestions: <harness>/age/<slug>.suggestions.json   (<M> entries)
+Age report: .cheese/age/<slug>.md
+Fixes:       .cheese/age/<slug>.fixes.json   (<N> entries)
+Suggestions: .cheese/age/<slug>.suggestions.json   (<M> entries)
 
 Next steps:
   /cleanup <slug>                           — apply mechanical fixes

--- a/skills/age/references/assertions/go.md
+++ b/skills/age/references/assertions/go.md
@@ -1,0 +1,192 @@
+# Go (testing/testify) Weak Assertion Patterns
+
+Framework-specific patterns the `age-assertions` dim looks for in Go test diffs.
+Read alongside `protocol.md` (cross-framework patterns).
+
+---
+
+## 1. `require.NoError` as Sole Assertion
+
+Error absence is necessary but not sufficient. What did the function return?
+
+```go
+// WEAK — error checked, result ignored
+result, err := service.GetUser(42)
+require.NoError(t, err)
+
+// STRONG — error AND value
+result, err := service.GetUser(42)
+require.NoError(t, err)
+assert.Equal(t, &User{ID: 42, Name: "Alice", Role: "admin"}, result)
+```
+
+---
+
+## 2. `assert.Error` Without Type or Message
+
+Any error passes. Wrong query? Passes. Nil pointer? Passes.
+
+```go
+// WEAK
+_, err := service.GetUser(-1)
+assert.Error(t, err)
+
+// STRONG — specific error type
+var notFoundErr *NotFoundError
+require.ErrorAs(t, err, &notFoundErr)
+assert.Equal(t, 42, notFoundErr.ID)
+
+// STRONG — error message
+require.ErrorContains(t, err, "user -1 not found")
+
+// STRONG — sentinel error
+require.ErrorIs(t, err, ErrNotFound)
+```
+
+---
+
+## 3. Length Check Without Content
+
+```go
+// WEAK
+assert.Equal(t, 2, len(results))
+
+// STRONG
+assert.Equal(t, []User{
+    {ID: 1, Name: "Alice"},
+    {ID: 2, Name: "Bob"},
+}, results)
+```
+
+---
+
+## 4. `t.Fail()` / `t.Error()` Without Message
+
+Go's test output is minimalist. Without context, failures are cryptic.
+
+```go
+// WEAK
+if got != expected {
+    t.Fail()
+}
+
+// STRONG — use testify, consistent format, diff on failure
+assert.Equal(t, expected, got)
+```
+
+---
+
+## 5. `assert.Nil` on Interfaces — the Nil Interface Trap
+
+A non-nil interface holding a nil pointer is not nil. Classic Go gotcha.
+
+```go
+// WEAK — this can fail unexpectedly
+var err error = (*MyError)(nil) // non-nil interface, nil pointer
+assert.Nil(t, err)              // FAILS — err is not nil!
+
+// BETTER — prefer NoError for intent when checking errors
+assert.NoError(t, err)          // but still FAILS for typed-nil errors
+
+// REAL FIX — ensure the code under test returns a truly nil error
+func (s *Service) DoSomething() error {
+    if ok {
+        return nil // correct: returns nil interface
+    }
+    return &MyError{} // correct: returns non-nil interface with non-nil pointer
+}
+```
+
+---
+
+## 6. Missing `t.Helper()` in Test Helpers
+
+Stack traces point to the helper function, not the test that called it.
+
+```go
+// WEAK
+func assertUserEquals(t *testing.T, got, want User) {
+    assert.Equal(t, want, got) // failure points HERE, not the caller
+}
+
+// STRONG
+func assertUserEquals(t *testing.T, got, want User) {
+    t.Helper() // failure points to the calling test
+    assert.Equal(t, want, got)
+}
+```
+
+---
+
+## 7. Sequential Subtests Instead of Table-Driven
+
+AI writes repetitive sequential test cases instead of Go's idiomatic
+table-driven pattern.
+
+```go
+// WEAK — repetitive, hard to add cases
+func TestFormat(t *testing.T) {
+    result1, _ := format(1)
+    assert.Equal(t, "1 item", result1)
+    result2, _ := format(0)
+    assert.Equal(t, "0 items", result2)
+}
+
+// STRONG — table-driven
+func TestFormat(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   int
+        want    string
+        wantErr bool
+    }{
+        {"singular", 1, "1 item", false},
+        {"plural", 0, "0 items", false},
+        {"negative", -1, "", true},
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := format(tt.input)
+            if tt.wantErr {
+                require.Error(t, err)
+                return
+            }
+            require.NoError(t, err)
+            assert.Equal(t, tt.want, got)
+        })
+    }
+}
+```
+
+---
+
+## 8. `fmt.Sprintf("%v")` for Comparison
+
+Comparing string representations instead of structured values.
+
+```go
+// WEAK — Debug repr comparison
+assert.Contains(t, fmt.Sprintf("%v", result), "Alice")
+
+// STRONG — structural equality
+assert.Equal(t, expected, result)
+```
+
+---
+
+## 9. Missing `t.Parallel()`
+
+AI generates serial tests by default. Independent tests should run in parallel.
+
+```go
+// WEAK — serial, slow
+func TestGetUser(t *testing.T) {
+    // ...
+}
+
+// STRONG — parallel where tests are independent
+func TestGetUser(t *testing.T) {
+    t.Parallel()
+    // ...
+}
+```

--- a/skills/age/references/assertions/protocol.md
+++ b/skills/age/references/assertions/protocol.md
@@ -1,0 +1,197 @@
+# Weak Assertion Patterns — Cross-Framework Protocol
+
+Patterns the `age-assertions` dim looks for during `/age` review of test files.
+Applies across all test frameworks; supplement with the language-specific
+reference for the test framework present in the diff.
+
+The dim only applies when the diff contains test files. When no test files are
+touched, emit `{"observations": [], "scope_match": false}`.
+
+---
+
+## 1. Existence Check Instead of Value Equality
+
+The #1 AI testing failure. Asserts something exists without verifying it's correct.
+
+**What to look for:** `assert result is not None`, `expect(result).toBeDefined()`,
+`assert!(result.is_some())`, `assert.NotNil(t, result)` — any assertion that
+only checks presence.
+
+**Fix shape:** Always assert the specific value expected, not just that a value
+exists.
+
+```
+WEAK: assert result is not None
+STRONG: assert result == expected_value
+
+WEAK: expect(result).toBeDefined()
+STRONG: expect(result).toEqual({ id: 1, name: "Alice" })
+
+WEAK: assert!(result.is_some())
+STRONG: assert_eq!(result.unwrap(), expected)
+```
+
+---
+
+## 2. Length Check Without Content Inspection
+
+Verifies the container has items but not what those items are.
+
+**What to look for:** `assert len(results) == 1`, `expect(items).toHaveLength(3)`,
+`assert_eq!(vec.len(), 2)`, `assert.Equal(t, 2, len(results))` — any
+assertion that only checks the count.
+
+**Fix shape:** Check content first. Length-only assertions are acceptable as
+a *final* confirmation after content checks, never as the sole assertion.
+
+```
+WEAK: assert len(results) == 1
+STRONG: assert results[0].name == "Alice"
+
+WEAK: expect(items).toHaveLength(3)
+STRONG: expect(items).toEqual([...expected])
+```
+
+---
+
+## 3. Catch-All Error Assertions
+
+Verifies an error occurred without checking it's the *right* error.
+
+**What to look for:** `pytest.raises(Exception)`, `expect(() => fn()).toThrow()`,
+`assert!(result.is_err())`, `assert.Error(t, err)` — any assertion that
+accepts any error.
+
+**Fix shape:** Assert the specific error type AND message/content.
+
+```
+WEAK: with pytest.raises(Exception):
+STRONG: with pytest.raises(ValueError, match=r"must be positive"):
+
+WEAK: expect(() => fn()).toThrow()
+STRONG: expect(() => fn()).toThrow(ValidationError)
+
+WEAK: assert!(result.is_err())
+STRONG: assert!(matches!(result, Err(MyError::NotFound(_))))
+```
+
+---
+
+## 4. No-Crash-as-Success
+
+Test only asserts the function didn't throw, with no behavioral check.
+
+**What to look for:** Test functions where the only assertion is the absence
+of an error, or test functions with no assertions at all.
+
+**Fix shape:** Every test needs a positive behavioral assertion. "Didn't crash"
+is necessary but never sufficient.
+
+```
+WEAK: run my_command; assert_success  (sole assertion)
+STRONG: run my_command; [[ "$output" == "expected" ]]
+
+WEAK: require.NoError(t, err)  (nothing follows)
+STRONG: require.NoError(t, err); assert.Equal(t, expected, result)
+```
+
+---
+
+## 5. Mock Verification Without Arguments
+
+Verifies a mock was called but not *how* it was called.
+
+**What to look for:** `mock_fn.assert_called()`, `expect(mockFn).toHaveBeenCalled()`,
+`mock.AssertCalled(t, "Send")` — any verification that ignores arguments.
+
+**Fix shape:** Always verify mock call arguments. A mock called with wrong
+arguments is a test that passes while the code is broken.
+
+```
+WEAK: mock_fn.assert_called()
+STRONG: mock_fn.assert_called_once_with(user_id=42, role="admin")
+
+WEAK: expect(mockFn).toHaveBeenCalled()
+STRONG: expect(mockFn).toHaveBeenCalledWith({ to: "alice@example.com" })
+```
+
+---
+
+## 6. Testing the Mock, Not the Code
+
+Asserts that a mock returns what you told it to return — tautological.
+
+**What to look for:** Test code that calls the mock directly and asserts it
+returns its configured `return_value`.
+
+**Fix shape:** The assertion should check the *system under test* which *uses*
+the mock, not the mock itself.
+
+```
+WEAK:
+  mock = Mock(return_value=42)
+  assert mock() == 42  # Tests Mock.__call__, not your code
+
+STRONG:
+  mock_repo = Mock(return_value=42)
+  service = MyService(repo=mock_repo)
+  result = service.do_thing()
+  assert result == expected_output
+```
+
+---
+
+## 7. Boolean Coercion Assertions
+
+Uses truthiness where a value check is possible and more precise.
+
+**What to look for:** `assert bool(result)`, `expect(!!result).toBe(true)`,
+`assert!(some_function())` — assertions that coerce to boolean.
+
+**Fix shape:** If you know what the value should be, assert that. Truthiness
+only when the contract genuinely is "any truthy value."
+
+```
+WEAK: assert bool(result)
+STRONG: assert result == expected_value
+
+WEAK: assert!(some_function())
+STRONG: assert_eq!(some_function(), expected)
+```
+
+---
+
+## 8. Tautological Assertions
+
+Assertions that literally cannot fail. A test that always passes tests nothing.
+
+**What to look for:** `assert True`, `expect(1).toBe(1)`, `assert_eq!(true, true)`,
+`[[ $status -eq 0 || $status -eq 1 ]]`.
+
+**Fix shape:** Delete tautological assertions. If the test needs a placeholder,
+mark it as `@pytest.mark.skip` / `it.todo()` / `#[ignore]` instead.
+
+---
+
+## 9. Approximate Equality When Exact Is Possible
+
+Uses fuzzy matching when the result is deterministic.
+
+**What to look for:** `assertAlmostEqual`, `toBeCloseTo`, epsilon comparisons
+on results of integer arithmetic, string operations, or deterministic
+calculations.
+
+**Fix shape:** Use approximate equality only for floating-point arithmetic
+that genuinely introduces rounding. Integer math and deterministic
+calculations should use exact equality.
+
+```
+WEAK: assert abs(result - 100) < 1      (result IS exactly 100)
+STRONG: assert result == 100
+
+WEAK: expect(result).toBeCloseTo(100)   (when result is integer math)
+STRONG: expect(result).toBe(100)
+```
+
+Reverse is also a smell: using `assert_eq!` on computed float values that
+may legitimately differ by tiny amounts due to rounding.

--- a/skills/age/references/assertions/python.md
+++ b/skills/age/references/assertions/python.md
@@ -1,0 +1,172 @@
+# Python (pytest) Weak Assertion Patterns
+
+Framework-specific patterns the `age-assertions` dim looks for in Python test diffs.
+Read alongside `protocol.md` (cross-framework patterns).
+
+---
+
+## 1. Truthy Instead of Value Equality
+
+The most common AI assertion failure. Any non-empty, non-zero value passes.
+
+```python
+# WEAK — None, 0, "" fail; anything else passes
+assert result
+assert result is not None
+assert bool(result)
+
+# STRONG
+assert result == {"key": "expected_value"}
+assert result == User(id=1, name="Alice")
+assert result == [Item(id=1), Item(id=2)]
+```
+
+---
+
+## 2. `len()` Without Content Check
+
+Knows there are items, doesn't know if they're the right items.
+
+```python
+# WEAK
+assert len(results) == 1
+assert len(d) > 0
+
+# STRONG — content first, length as confirmation
+assert results[0].name == "Alice"
+assert results[0].role == "admin"
+assert len(results) == 1  # OK as final confirmation
+```
+
+---
+
+## 3. `isinstance` Instead of Value Check
+
+Verifies the type but not the data.
+
+```python
+# WEAK
+assert isinstance(result, list)
+assert isinstance(result, User)
+
+# STRONG
+assert result == [1, 2, 3]
+assert result == User(id=1, name="Alice")
+```
+
+---
+
+## 4. `pytest.raises(Exception)` — Catch-All
+
+Any exception passes. Wrong function signature? Passes. Import error? Passes.
+
+```python
+# WEAK
+with pytest.raises(Exception):
+    validate(-1)
+
+with pytest.raises(Exception) as exc_info:
+    do_thing()
+# exc_info never inspected
+
+# STRONG — specific type AND message
+with pytest.raises(ValueError, match=r"must be positive"):
+    validate(-1)
+
+# STRONG — inspect exception details
+with pytest.raises(ValidationError) as exc_info:
+    validate(data)
+assert exc_info.value.field == "email"
+assert "invalid format" in str(exc_info.value)
+```
+
+---
+
+## 5. Mock `.assert_called()` Without Arguments
+
+The function was called — but with what?
+
+```python
+# WEAK
+mock_send.assert_called()
+mock_send.assert_called_once()
+
+# STRONG
+mock_send.assert_called_once_with(
+    to="alice@example.com",
+    subject="Welcome",
+    body=ANY,  # OK to use ANY for non-critical args
+)
+```
+
+---
+
+## 6. `mock.called` Without `assert` — Silent Pass
+
+The real pitfall is referencing `.called` without asserting. It is always
+truthy as a bare expression and silently passes.
+
+```python
+# WEAK — bare expression, always passes, tests nothing
+mock.called
+
+# WEAK — works but only checks "was called", not "with what"
+assert mock.called
+
+# STRONG
+mock.assert_called_once_with(expected_arg)
+```
+
+---
+
+## 7. Testing the Mock Itself
+
+Asserts the mock returns what you configured it to return. Tautological.
+
+```python
+# WEAK — tests unittest.mock, not your code
+mock_repo = Mock()
+mock_repo.find.return_value = User(id=1)
+assert mock_repo.find(1) == User(id=1)
+
+# STRONG — test the system that USES the mock
+mock_repo = Mock()
+mock_repo.find.return_value = User(id=1, name="Alice")
+service = UserService(repo=mock_repo)
+result = service.get_display_name(1)
+assert result == "Alice"
+mock_repo.find.assert_called_once_with(1)
+```
+
+---
+
+## 8. `assert x in y` for Structured Data
+
+Substring matching on structured output hides mismatches.
+
+```python
+# WEAK — "Alice" could appear in error messages, other fields
+assert "Alice" in str(result)
+assert "success" in response.text
+
+# STRONG
+assert result.name == "Alice"
+assert response.json() == {"status": "success", "user_id": 42}
+```
+
+---
+
+## 9. Unordered Check When Order Matters
+
+Using `set()` comparison when the function should return ordered results.
+
+```python
+# WEAK — if sort is broken, this still passes
+assert set(result) == {"a", "b", "c"}
+
+# STRONG — when order is part of the contract
+assert result == ["a", "b", "c"]
+
+# When order genuinely doesn't matter, be explicit
+assert sorted(result) == ["a", "b", "c"]
+```

--- a/skills/age/references/assertions/rust.md
+++ b/skills/age/references/assertions/rust.md
@@ -1,0 +1,128 @@
+# Rust Weak Assertion Patterns
+
+Framework-specific patterns the `age-assertions` dim looks for in Rust test diffs.
+Read alongside `protocol.md` (cross-framework patterns).
+
+---
+
+## 1. `is_ok()` / `is_some()` Without Value Check
+
+AI asserts the `Result`/`Option` variant but never inspects the value inside.
+
+```rust
+// WEAK
+assert!(result.is_ok());
+assert!(result.is_some());
+assert!(!vec.is_empty());
+
+// STRONG
+assert_eq!(result.unwrap(), 42);
+assert_eq!(result.unwrap(), ExpectedStruct { field: "value" });
+assert_eq!(vec, vec!["a", "b", "c"]);
+```
+
+---
+
+## 2. `is_err()` Without Variant or Message Check
+
+Any error passes — wrong error type, wrong message, doesn't matter.
+
+```rust
+// WEAK
+assert!(result.is_err());
+
+// STRONG — specific variant
+assert!(matches!(result, Err(MyError::NotFound(_))));
+
+// STRONG — variant + content
+assert!(matches!(result, Err(MyError::NotFound(msg)) if msg.contains("id=42")));
+
+// STRONG — with assert_eq on error
+let err = result.unwrap_err();
+assert_eq!(err.kind(), ErrorKind::NotFound);
+```
+
+---
+
+## 3. `#[should_panic]` Without `expected`
+
+Any panic passes the test. A refactor that panics at a different point
+still passes.
+
+```rust
+// WEAK
+#[should_panic]
+fn test_overflow() { ... }
+
+// STRONG
+#[should_panic(expected = "index out of bounds")]
+fn test_overflow() { ... }
+```
+
+---
+
+## 4. Debug Format Assertions
+
+Testing `Debug` string representation instead of structural equality.
+
+```rust
+// WEAK — format changes break the test, not behavior changes
+assert!(format!("{:?}", x).contains("Foo"));
+assert_eq!(format!("{}", result), "expected string");
+
+// STRONG — implement PartialEq and compare structurally
+assert_eq!(x, Foo { field: "value" });
+
+// If you need string output, test Display explicitly
+assert_eq!(result.to_string(), "expected string");
+```
+
+---
+
+## 5. `unwrap()` in Tests Without `expect()`
+
+When the test fails, you get "called unwrap on None" with no context.
+
+```rust
+// WEAK — opaque failure message
+let user = repo.find(42).unwrap();
+
+// STRONG — failure tells you what went wrong
+let user = repo.find(42).expect("user 42 should exist in test fixture");
+```
+
+---
+
+## 6. Boolean `assert!` Where `assert_eq!` Applies
+
+`assert!` gives no context on failure. `assert_eq!` shows both values.
+
+```rust
+// WEAK — failure says "assertion failed"
+assert!(result == 42);
+assert!(items.len() == 3);
+
+// STRONG — failure says "left: 41, right: 42"
+assert_eq!(result, 42);
+assert_eq!(items.len(), 3);
+```
+
+---
+
+## 7. Floating-Point `assert_eq!` on Computed Values
+
+Direct equality fails for floating-point arithmetic due to rounding.
+
+```rust
+// WEAK — may fail due to float rounding
+assert_eq!(compute_ratio(1.0, 3.0), 0.333333);
+
+// STRONG — use epsilon comparison
+assert!((compute_ratio(1.0, 3.0) - 0.333333).abs() < 1e-6);
+// Or with approx crate:
+assert_relative_eq!(compute_ratio(1.0, 3.0), 0.333333, epsilon = 1e-6);
+```
+
+Note: the reverse is also a smell — using epsilon comparison when the math
+is exact (integer arithmetic, simple multiplication). Use `assert_eq!` for
+deterministic values.

--- a/skills/age/references/assertions/shell.md
+++ b/skills/age/references/assertions/shell.md
@@ -1,0 +1,190 @@
+# Shell / Bash (bats) Weak Assertion Patterns
+
+Framework-specific patterns the `age-assertions` dim looks for in shell test diffs.
+Read alongside `protocol.md` (cross-framework patterns).
+
+---
+
+## 1. Status-Only Assertion — No Output Check
+
+The command succeeded. But did it produce the right output?
+
+```bash
+# WEAK
+run my_command
+[[ $status -eq 0 ]]
+
+# WEAK — bats helper, same problem
+run my_command
+assert_success
+
+# STRONG — status AND output
+run my_command --flag
+assert_success
+[[ "$output" == "expected output" ]]
+```
+
+---
+
+## 2. Status Catch-All
+
+Accepts multiple exit codes — anything passes.
+
+```bash
+# WEAK — exit 0 (success) and exit 1 (failure) both pass
+run my_command
+[[ $status -eq 0 || $status -eq 1 ]]
+
+# STRONG — assert the specific expected status
+run my_command
+assert_success
+[[ "$output" == "expected output" ]]
+
+# STRONG — for error cases, assert the specific failure
+run my_command --invalid
+assert_failure
+[[ "$output" == *"Unknown option: --invalid"* ]]
+```
+
+---
+
+## 3. Absence-of-Error as Sole Assertion
+
+Checking that a specific error string is absent doesn't verify correct behavior.
+
+```bash
+# WEAK — any output except "parse error" passes
+run parse_config "$input"
+assert_not_contains "parse error"
+
+# STRONG — assert the expected output positively
+run parse_config "$input"
+assert_success
+[[ "$output" == "key=value" ]]
+```
+
+---
+
+## 4. Over-Broad Substring Matching
+
+Matches unrelated strings. `*"s"*` matches almost everything.
+
+```bash
+# WEAK — "s" or "m" appears in nearly every string
+[[ "$output" == *"s"* || "$output" == *"m"* ]]
+
+# WEAK — "error" matches "no_error", "error_count", etc.
+[[ "$output" == *"error"* ]]
+
+# STRONG — specific expected text
+[[ "$output" == "30m" ]]
+[[ "$output" == "Error: file not found" ]]
+```
+
+---
+
+## 5. File Existence Without Content Check
+
+The file was created — is it correct?
+
+```bash
+# WEAK
+run generate_config
+[[ -f result.txt ]]
+
+# STRONG
+run generate_config
+[[ -f result.txt ]]
+[[ "$(cat result.txt)" == "expected content" ]]
+
+# Or for large files, check key content
+run generate_config
+assert_success
+grep -q "^server_name=prod$" result.txt
+grep -q "^port=8080$" result.txt
+```
+
+---
+
+## 6. `grep -q` Without Anchoring
+
+Matches partial lines, leading to false positives.
+
+```bash
+# WEAK — "count" matches "count=0", "discount", "account"
+grep -q "count" output.txt
+
+# STRONG — anchored match
+grep -q "^count=3$" output.txt
+
+# STRONG — exact line match
+[[ "$(grep '^count=' output.txt)" == "count=3" ]]
+```
+
+---
+
+## 7. Comparing Numbers as Strings
+
+Leads to surprising failures with leading zeros or whitespace.
+
+```bash
+# WEAK — string comparison, "03" != "3"
+[[ "$count" == "3" ]]
+
+# STRONG — arithmetic comparison for numbers
+[[ $count -eq 3 ]]
+
+# But for output that should be exact, string comparison IS correct
+[[ "$output" == "3 items found" ]]
+```
+
+---
+
+## 8. Missing Negative Test Cases
+
+AI generates only happy-path tests. Error handling goes untested.
+
+```bash
+# WEAK — only tests success
+@test "parse valid config" {
+    run parse_config valid.yaml
+    assert_success
+}
+
+# STRONG — also test failure modes
+@test "parse valid config" {
+    run parse_config valid.yaml
+    assert_success
+    [[ "$output" == "key=value" ]]
+}
+
+@test "parse invalid config returns error" {
+    run parse_config invalid.yaml
+    assert_failure
+    [[ "$output" == *"syntax error at line 3"* ]]
+}
+
+@test "parse missing file returns error" {
+    run parse_config nonexistent.yaml
+    assert_failure
+    [[ "$output" == *"file not found: nonexistent.yaml"* ]]
+}
+```
+
+---
+
+## 9. Not Using `run` for Testable Commands
+
+Calling commands directly instead of through `run` means bats can't capture
+status and output.
+
+```bash
+# WEAK — if this fails, the whole test aborts (set -e)
+my_command arg1
+[[ -f output.txt ]]
+
+# STRONG — run captures status and output
+run my_command arg1
+assert_success
+[[ "$output" == "expected" ]]
+```

--- a/skills/age/references/assertions/typescript.md
+++ b/skills/age/references/assertions/typescript.md
@@ -1,0 +1,175 @@
+# TypeScript / JavaScript (Jest/Vitest) Weak Assertion Patterns
+
+Framework-specific patterns the `age-assertions` dim looks for in TypeScript/JavaScript
+test diffs. Read alongside `protocol.md` (cross-framework patterns).
+
+---
+
+## 1. `toBeTruthy()` / `toBeDefined()` / `not.toBeNull()`
+
+The truthy trifecta. All three avoid asserting the actual value.
+
+```typescript
+// WEAK — 0, "", false all fail; "wrong answer" passes
+expect(result).toBeTruthy();
+expect(result).toBeDefined();
+expect(result).not.toBeNull();
+expect(result).not.toBeUndefined();
+
+// STRONG
+expect(result).toEqual({ id: 1, name: "Alice", role: "admin" });
+expect(result).toBe(42);
+```
+
+---
+
+## 2. `toHaveLength()` Without Content Check
+
+Knows the array has items, doesn't know what they are.
+
+```typescript
+// WEAK
+expect(items).toHaveLength(3);
+expect(items.length).toBeGreaterThan(0);
+
+// STRONG — full content
+expect(items).toEqual([
+  { id: 1, name: "first" },
+  { id: 2, name: "second" },
+  { id: 3, name: "third" },
+]);
+```
+
+---
+
+## 3. `toThrow()` Without Type or Message
+
+Any thrown value passes — wrong error, wrong message, doesn't matter.
+
+```typescript
+// WEAK
+expect(() => fn()).toThrow();
+await expect(promise).rejects.toBeTruthy();
+
+// STRONG — type AND message
+expect(() => fn()).toThrow(ValidationError);
+expect(() => fn()).toThrow("must be positive");
+await expect(promise).rejects.toThrow(NetworkError);
+
+// STRONG — inspect the error
+try {
+  fn();
+  fail("expected to throw");
+} catch (err) {
+  expect(err).toBeInstanceOf(ValidationError);
+  expect((err as ValidationError).field).toBe("email");
+}
+```
+
+---
+
+## 4. `toHaveBeenCalled()` Without Argument Check
+
+The mock was invoked — with what arguments?
+
+```typescript
+// WEAK
+expect(mockFn).toHaveBeenCalled();
+expect(mockFn).toHaveBeenCalledTimes(1);
+
+// STRONG
+expect(mockSend).toHaveBeenCalledWith({
+  to: "alice@example.com",
+  subject: "Welcome",
+});
+expect(mockSend).toHaveBeenCalledTimes(1); // OK after argument check
+```
+
+---
+
+## 5. `typeof` Check — The `null` Trap
+
+`typeof null === "object"` in JavaScript. This classic gotcha catches AI regularly.
+
+```typescript
+// WEAK — null passes as "object"!
+expect(typeof result).toBe("object");
+expect(Array.isArray(result)).toBe(true); // empty array passes
+
+// STRONG
+expect(result).toEqual({ key: "value" });
+expect(result).toEqual(["a", "b", "c"]);
+```
+
+---
+
+## 6. `toMatchSnapshot()` as First Resort
+
+Snapshots are fragile, hard to review, and drift over time. They test
+formatting, not behavior.
+
+```typescript
+// WEAK — snapshot drift, opaque failures
+expect(result).toMatchSnapshot();
+expect(JSON.stringify(result)).toMatchSnapshot();
+
+// STRONG — explicit structural check
+expect(result).toEqual({
+  id: expect.any(Number),
+  name: "Alice",
+  createdAt: expect.any(Date),
+});
+```
+
+Use snapshots only for large output where manually writing the expected value
+is impractical (rendered HTML, complex serialized formats).
+
+---
+
+## 7. Testing the Mock, Not the Code
+
+Asserts that `jest.fn()` works as configured. Tautological.
+
+```typescript
+// WEAK
+const mock = jest.fn().mockReturnValue(42);
+expect(mock()).toBe(42); // Tests jest, not your code
+
+// STRONG — test the system under test
+const mockRepo = { findUser: jest.fn().mockReturnValue(user) };
+const service = new UserService(mockRepo);
+expect(service.getDisplayName(1)).toBe("Alice");
+expect(mockRepo.findUser).toHaveBeenCalledWith(1);
+```
+
+---
+
+## 8. Missing `await` on Async Assertions
+
+The assertion never executes. The test passes silently.
+
+```typescript
+// WEAK — promise is never awaited, assertion doesn't run!
+expect(fetchUser(42)).resolves.toEqual(user);
+expect(fetchUser(-1)).rejects.toThrow();
+
+// STRONG — always await
+await expect(fetchUser(42)).resolves.toEqual(user);
+await expect(fetchUser(-1)).rejects.toThrow(NotFoundError);
+```
+
+---
+
+## 9. `toContain()` for Structured Data
+
+Substring matching on strings or loose `includes` on arrays.
+
+```typescript
+// WEAK — "error" might match "error_code", "no_error", etc.
+expect(message).toContain("error");
+expect(items).toContain(expected); // reference equality trap
+
+// STRONG — exact match or toMatchObject for partials
+expect(message).toBe("Validation error: email is required");
+expect(items).toContainEqual({ id: 1, name: "Alice" }); // deep equality
+```

--- a/skills/age/references/deslop/go.md
+++ b/skills/age/references/deslop/go.md
@@ -1,0 +1,203 @@
+# Go De-slop Patterns
+
+Language-specific patterns the `age-deslop` dim looks for in Go diffs.
+Read alongside `protocol.md` (cross-language patterns).
+
+---
+
+## 1. Error String Conventions
+
+Go errors are lowercase, no trailing punctuation, and wrap with `%w`.
+
+**What to look for:** Capitalized error strings; trailing periods; use of `%v`
+(breaks error chain) where `%w` is appropriate.
+
+```go
+// SLOP
+return fmt.Errorf("Failed to open file: %s", err)
+return errors.New("User not found.")
+
+// CLEAN
+return fmt.Errorf("open file: %w", err)
+return errors.New("user not found")
+```
+
+The `%w` verb wraps the error so callers can use `errors.Is`/`errors.As`.
+Use `%v` only when you intentionally want to break the error chain.
+
+---
+
+## 2. Named Returns With Bare `return`
+
+AI loves named returns. They obscure which values are being returned.
+
+**What to look for:** Functions with named return variables that use bare
+`return` statements in non-`defer` contexts.
+
+```go
+// SLOP
+func getUser(id int) (user *User, err error) {
+    user = db.Find(id)
+    if user == nil {
+        err = errors.New("not found")
+        return
+    }
+    return
+}
+
+// CLEAN
+func getUser(id int) (*User, error) {
+    user := db.Find(id)
+    if user == nil {
+        return nil, errors.New("user not found")
+    }
+    return user, nil
+}
+```
+
+Named returns are acceptable only in `defer` recovery patterns.
+
+---
+
+## 3. `context.TODO()` Permanently
+
+AI scaffolds with `context.TODO()` and never replaces it.
+
+**What to look for:** `context.TODO()` in request handlers or service methods
+that already have an incoming context available.
+
+```go
+// SLOP
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+    ctx := context.TODO()
+    result, err := db.Query(ctx, query)
+}
+
+// CLEAN — use the context you already have
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+    result, err := db.Query(r.Context(), query)
+}
+```
+
+`context.TODO()` means "I haven't decided which context to use yet."
+In production code, you should always have decided.
+
+---
+
+## 4. Pointer to Interface
+
+Almost never correct. Interfaces are already reference types.
+
+**What to look for:** Parameters typed as `*SomeInterface` where `SomeInterface`
+is an interface (not a concrete struct).
+
+```go
+// SLOP
+func NewService(repo *Repository) *Service { ... }
+// where Repository is an interface
+
+// CLEAN
+func NewService(repo Repository) *Service { ... }
+```
+
+---
+
+## 5. Goroutine Leaks
+
+AI spawns goroutines without cancellation paths.
+
+**What to look for:** Goroutines with infinite loops and no `ctx.Done()` select
+case; goroutines spawned without any way to signal them to stop.
+
+```go
+// SLOP — runs forever, no way to stop it
+go func() {
+    for {
+        doWork()
+        time.Sleep(time.Second)
+    }
+}()
+
+// CLEAN — respects context cancellation
+go func(ctx context.Context) {
+    ticker := time.NewTicker(time.Second)
+    defer ticker.Stop()
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        case <-ticker.C:
+            doWork()
+        }
+    }
+}(ctx)
+```
+
+---
+
+## 6. `fmt.Sprintf` for String Concatenation in Loops
+
+O(n²) string building.
+
+**What to look for:** `fmt.Sprintf("%s%s", result, s)` inside a loop;
+repeated `result +=` string concatenation.
+
+```go
+// SLOP
+var result string
+for _, s := range items {
+    result = fmt.Sprintf("%s%s", result, s)
+}
+
+// CLEAN
+var b strings.Builder
+for _, s := range items {
+    b.WriteString(s)
+}
+result := b.String()
+```
+
+---
+
+## 7. Stuttering Package Names
+
+**What to look for:** Type names that repeat the package name:
+`user.UserService`, `user.UserModel`.
+
+```go
+// SLOP — user.UserService, user.UserModel
+package user
+type UserService struct{}
+type UserModel struct{}
+
+// CLEAN — user.Service, user.Model
+package user
+type Service struct{}
+type Model struct{}
+```
+
+---
+
+## 8. `init()` for Non-Trivial Setup
+
+AI puts complex initialization in `init()` which can't return errors
+and runs at import time with no control.
+
+**What to look for:** Database connections, network clients, or file I/O
+inside `init()` functions; `log.Fatal` inside `init()`.
+
+```go
+// SLOP
+func init() {
+    db, err := sql.Open("postgres", os.Getenv("DATABASE_URL"))
+    if err != nil {
+        log.Fatal(err)  // Kills the process at import time
+    }
+    globalDB = db
+}
+
+// CLEAN — explicit initialization the caller controls
+func NewDB(dsn string) (*sql.DB, error) {
+    return sql.Open("postgres", dsn)
+}
+```

--- a/skills/age/references/deslop/protocol.md
+++ b/skills/age/references/deslop/protocol.md
@@ -1,0 +1,151 @@
+# De-slop Patterns — Cross-Language Protocol
+
+Patterns the `age-deslop` dim looks for during `/age` review. Applies to
+all languages; supplement with the language-specific reference for the
+languages present in the diff.
+
+---
+
+## 1. Comment Pollution
+
+AI explains *what* code does instead of *why*. Every function gets a docstring.
+Every line gets a narration comment.
+
+**What to look for:** Comments that restate the code verbatim; docstrings that
+repeat the function name; inline narration of obvious operations.
+
+**Fix shape:** Delete comments that restate the code. Keep only comments that
+explain non-obvious intent, business rules, or "why not the obvious approach."
+
+---
+
+## 2. Defensive Error Handling Everywhere
+
+Try/catch wrapping every operation, swallowing errors silently, returning
+empty defaults instead of propagating failures.
+
+**What to look for:** Catch blocks with `pass`/`return {}`/`return null`; errors
+consumed without logging or re-raise; functions that return sentinel values
+on failure where the caller has no way to distinguish success from silent error.
+
+**Fix shape:** Let errors propagate to where they can be handled meaningfully.
+A function that returns `{}` on failure is worse than one that throws — the
+caller silently gets corrupted data.
+
+---
+
+## 3. Over-Abstraction
+
+Abstract base classes, interfaces, factory functions, and plugin systems for
+problems with exactly one concrete implementation.
+
+**What to look for:** Single-implementor interfaces; factory functions that
+create exactly one type; abstract classes with one subclass; plugin registries
+with one plugin.
+
+**Fix shape:** Delete the abstraction. Write the concrete implementation directly.
+Three similar lines of code is better than a premature abstraction. Extract
+only when there are 3+ real consumers.
+
+---
+
+## 4. Verbose Names That Describe Types, Not Domain
+
+`user_data_dictionary`, `list_of_user_objects`, `current_item_being_processed`.
+These names couple to the data structure and add noise.
+
+**What to look for:** Names that embed their container type (`_list`, `_dict`,
+`_array`, `_map`, `_slice`); names with `current_` or `_being_processed` scaffolding.
+
+**Fix shape:** Name after the domain concept: `users`, `items`, `user`.
+A name should tell you what the thing *represents*, not what container it lives in.
+
+---
+
+## 5. Unnecessary Type Annotations
+
+Annotating local variables where the type is immediately obvious from the
+right-hand side. Function signatures deserve annotations; `const x: number = 5` doesn't.
+
+**What to look for:** Type annotations on variables initialized with literals,
+constructor calls, or typed function return values where inference is unambiguous.
+
+**Fix shape:** Remove annotations where inference handles it. Keep them on
+function signatures (they're the public contract) and where the inferred type
+would be unclear. Empty collection declarations are an exception — inference
+can't know the element type.
+
+---
+
+## 6. Dead Code and Unused Imports
+
+AI imports entire module sets "just in case" and leaves commented-out
+alternative implementations.
+
+**What to look for:** Unused imports (any language); commented-out alternative
+implementations; functions defined but never called; variables assigned but
+never read.
+
+**Fix shape:** Delete unused imports and dead code. No `// Alternative approach:`
+blocks. If it's not called, it's not code.
+
+---
+
+## 7. Cargo-Cult Boilerplate
+
+Patterns copied without understanding: `if __name__ == "__main__":` in every
+Python file, `"use strict"` in TypeScript, `context.TODO()` in non-concurrent
+Go paths.
+
+**What to look for:** Boilerplate that appears in every file regardless of
+whether it's needed; patterns applied out of habit without the condition they guard.
+
+**Fix shape:** Remove boilerplate that serves no purpose in context. Apply
+patterns only where they're needed.
+
+---
+
+## 8. Test Bloat
+
+AI generates many shallow tests covering the same code path with slightly
+different inputs — all testing the same behavior, none adding new coverage.
+
+**What to look for:** Multiple test functions with minor input variations testing
+the same logic path; test suite size dramatically exceeding implementation size;
+no tests for error paths or edge cases despite many happy-path tests.
+
+**Fix shape:** Consolidate into parameterized/table-driven tests. One test per
+behavior, not one test per input variation. Focus tests on actual edge cases
+and error paths.
+
+---
+
+## 9. Lint Suppression as Band-Aid
+
+AI silences compiler/linter warnings with suppression comments instead of fixing
+the underlying issue: `#[allow(dead_code)]`, `# noqa`, `// @ts-ignore`,
+`//nolint`, `// eslint-disable`.
+
+**High-confidence smells (almost always slop):**
+- Rust: `#[allow(clippy::unwrap_used)]`, `#[allow(clippy::dbg_macro)]`, `#[allow(clippy::print_stdout)]`, `#[allow(clippy::panic)]`, `#[allow(clippy::todo)]`
+- Python: `# noqa: E501`, `# pylint: disable=missing-docstring`
+- TypeScript: `// @ts-ignore` (without `@ts-expect-error`)
+- Go: `//nolint` without specific lint name
+- Shell: broad `# shellcheck disable=SCxxxx`
+
+**Fix shape:** Remove the suppression, read the warning, fix the root cause.
+If suppression is truly needed, scope it narrowly and add a comment explaining why.
+See language references for per-language taxonomy (Rust has the deepest).
+
+---
+
+## 10. Partial Strict Mode in Shell Scripts
+
+AI writes `set -e` but omits `-u` (undefined variables) and `-o pipefail`
+(pipeline error propagation). Failures in the left side of pipes are silently ignored.
+
+**What to look for:** Shell scripts with `set -e` only; scripts with no `set`
+at all; pipes through `jq`/`yq`/`grep` without `pipefail`.
+
+**Fix shape:** Always `set -euo pipefail`. All three flags together.
+`set -e` alone is a half-measure.

--- a/skills/age/references/deslop/python.md
+++ b/skills/age/references/deslop/python.md
@@ -1,0 +1,161 @@
+# Python De-slop Patterns
+
+Language-specific patterns the `age-deslop` dim looks for in Python diffs.
+Read alongside `protocol.md` (cross-language patterns).
+
+---
+
+## 1. `range(len())` Instead of `enumerate`
+
+AI defaults to C-style index loops.
+
+**What to look for:** `for i in range(len(items))` when the loop body uses
+both `i` and `items[i]`.
+
+```python
+# SLOP
+for i in range(len(items)):
+    print(i, items[i])
+
+# CLEAN
+for i, item in enumerate(items):
+    print(i, item)
+```
+
+When the index is not needed, iterate directly:
+
+```python
+for item in items:
+    process(item)
+```
+
+---
+
+## 2. Manual `None` Checks Instead of Truthiness
+
+**What to look for:** `if user is not None and user.name is not None and len(user.name) > 0`.
+
+```python
+# SLOP
+if user is not None and user.name is not None and len(user.name) > 0:
+    greet(user.name)
+
+# CLEAN
+if user and user.name:
+    greet(user.name)
+```
+
+---
+
+## 3. Old-Style String Formatting
+
+AI mixes `%`, `.format()`, and f-strings inconsistently.
+
+**What to look for:** `%` formatting or `.format()` in code that otherwise
+uses f-strings (Python 3.6+).
+
+```python
+# SLOP
+message = "Hello, %s! You have %d messages." % (name, count)
+message = "Hello, {}!".format(name)
+
+# CLEAN — f-strings everywhere (Python 3.6+)
+message = f"Hello, {name}! You have {count} messages."
+```
+
+---
+
+## 4. Silent `except: pass`
+
+Swallowing exceptions without handling is the #1 debugging time-sink.
+
+**What to look for:** `except Exception: pass`, `except: pass`, catch blocks
+that return empty defaults without logging.
+
+```python
+# SLOP
+try:
+    risky_operation()
+except Exception:
+    pass  # Silent failure
+
+# CLEAN — either handle it meaningfully or don't catch it
+# If you truly need to ignore: except SpecificError as e: logger.debug(...)
+```
+
+---
+
+## 5. Raw Dicts for Structured Data
+
+AI returns `{"id": 1, "name": "Alice"}` where a dataclass gives type safety,
+IDE support, and self-documenting code.
+
+**What to look for:** Functions returning raw dicts with fixed keys that are
+always the same shape; callers using string keys to access struct-like data.
+
+```python
+# SLOP
+def get_user():
+    return {"id": 1, "name": "Alice", "email": "alice@example.com"}
+
+# CLEAN
+@dataclass
+class User:
+    id: int
+    name: str
+    email: str
+```
+
+---
+
+## 6. `open()` Without Context Manager
+
+**What to look for:** `f = open(...)` not inside a `with` block; manual
+`f.close()` calls.
+
+```python
+# SLOP
+f = open("file.txt")
+data = f.read()
+f.close()  # Never reached if f.read() throws
+
+# CLEAN
+with open("file.txt") as f:
+    data = f.read()
+```
+
+---
+
+## 7. Overzealous Type Hints on Obvious Locals
+
+**What to look for:** Type annotations on variables initialized with literals
+or unambiguous constructor calls.
+
+```python
+# SLOP
+name: str = "Alice"
+count: int = 0
+active: bool = True
+
+# CLEAN — type hints on function signatures, not obvious assignments
+name = "Alice"
+count = 0
+items: list[str] = []  # Empty collection annotation is fine (inference can't know element type)
+active = True
+```
+
+---
+
+## 8. List Comprehension Where a Generator Suffices
+
+**What to look for:** `sum([x for x in ...])`, `any([x for x in ...])`,
+`max([x for x in ...])` — functions that consume iterables building a full
+list in memory first.
+
+```python
+# SLOP — builds entire list in memory just to iterate
+total = sum([x * x for x in range(1_000_000)])
+
+# CLEAN — generator expression, lazy evaluation
+total = sum(x * x for x in range(1_000_000))
+```

--- a/skills/age/references/deslop/rust.md
+++ b/skills/age/references/deslop/rust.md
@@ -1,0 +1,346 @@
+# Rust De-slop Patterns
+
+Language-specific patterns the `age-deslop` dim looks for in Rust diffs.
+Read alongside `protocol.md` (cross-language patterns).
+
+---
+
+## 1. Excessive `.clone()` to Silence the Borrow Checker
+
+LLMs reach for `.clone()` as a universal fix for ownership errors.
+
+**What to look for:** `.clone()` on a value that is immediately passed to
+a function that could accept a borrow; repeated `.clone()` chains.
+
+**Fix shape:**
+- Use borrowing (`&` and `&mut`) instead
+- Take `&str` instead of `String` in function parameters
+- Use `.as_ref()` on `Option`/`Result` instead of cloning to unwrap
+- Rule: `.clone()` is suspect unless you can explain why you need owned data
+
+```rust
+// SLOP
+fn greet(name: String) { println!("Hello, {name}"); }
+let msg = my_string.clone();
+greet(msg);
+
+// CLEAN
+fn greet(name: &str) { println!("Hello, {name}"); }
+greet(&my_string);
+```
+
+---
+
+## 2. `.unwrap()` Everywhere
+
+Creates runtime panics scattered throughout the codebase.
+
+**What to look for:** `.unwrap()` outside of test code or compile-time-guaranteed
+constants; `.unwrap()` on I/O operations, network calls, or user input.
+
+**Fix shape:**
+- Use `?` operator for error propagation
+- Use `anyhow` or `thiserror` for structured errors
+- Use `if let Some(x)` or `match` for `Option` types
+- `.unwrap()` only for compile-time guarantees (hardcoded regex, constants)
+
+```rust
+// SLOP
+let file = File::open("config.toml").unwrap();
+let config: Config = toml::from_str(&contents).unwrap();
+
+// CLEAN
+let file = File::open("config.toml")?;
+let config: Config = toml::from_str(&contents)?;
+```
+
+---
+
+## 3. Treating Everything as `String`
+
+Losing type safety and adding unnecessary allocations.
+
+**What to look for:** Functions accepting `String` parameters where `&str`
+would work; no newtypes for domain identifiers.
+
+**Fix shape:**
+- Accept `&str` or `impl AsRef<str>` in function parameters
+- Use `Cow<'_, str>` when sometimes owned, sometimes borrowed
+- Create newtypes for domain concepts: `struct UserId(String)`
+
+```rust
+// SLOP
+fn find_user(id: String, name: String) -> String { ... }
+
+// CLEAN
+fn find_user(id: &UserId, name: &str) -> Result<User> { ... }
+```
+
+---
+
+## 4. Index-Based Loops Instead of Iterators
+
+C-style `for i in 0..vec.len()` misses safety and optimization.
+
+**What to look for:** `for i in 0..items.len()` with `items[i]` indexing;
+index arithmetic that could be `.enumerate()` or `.zip()`.
+
+**Fix shape:**
+- Use `.iter()`, `.map()`, `.filter()`, `.enumerate()`, `.collect()`
+- Use slice patterns: `match vec.as_slice() { [first, ..] => ... }`
+
+```rust
+// SLOP
+for i in 0..items.len() {
+    process(i, &items[i]);
+}
+
+// CLEAN
+for (i, item) in items.iter().enumerate() {
+    process(i, item);
+}
+```
+
+---
+
+## 5. Fighting Lifetimes with `Rc<RefCell<T>>`
+
+When ownership gets complex, AI reaches for interior mutability or `unsafe`.
+
+**What to look for:** `Rc<RefCell<T>>` for data that doesn't need shared
+ownership; `unsafe` blocks in application code (not FFI).
+
+**Fix shape:**
+- Reduce borrow lifetimes so they don't overlap
+- Design structs to own their data
+- Pass short-lived borrows as method parameters
+- Restructure to avoid holding long-lived references
+
+---
+
+## 6. Weak Assertions in Test Code
+
+`assert!(result.is_ok())` and `assert!(result.is_err())` swallow the actual
+error/value on failure, printing only `false`.
+
+**What to look for:** `assert!(x.is_ok())`, `assert!(x.is_some())`, bare
+`assert_eq!` without failure messages on non-obvious operands.
+
+**Fix shape:**
+- Propagate with `.expect("context")` or `?` to see the real error
+- Check actual values, not just existence
+- For errors, verify the specific variant with `matches!` or check the message
+- Every `assert_eq!`/`assert!` with non-obvious operands needs a failure message
+
+```rust
+// SLOP
+assert!(result.is_ok());
+assert_eq!(count, 3);  // no context on failure
+
+// CLEAN
+let value = result.expect("scan_worktree should succeed");
+assert_eq!(value.label, "Ready");
+assert_eq!(count, 3, "expected 3 active workers after spawn");
+```
+
+---
+
+## 7. `is_none()` / `is_some()` Without Value Context
+
+`assert!(x.is_none())` prints `assertion failed: false`. `assert_eq!` shows
+what was actually there.
+
+**What to look for:** `assert!(x.is_none())` or `assert!(x.is_some())` as
+sole assertions without extracting the inner value.
+
+**Fix shape:**
+- Use `assert_eq!(x, None)` for better failure messages
+- For `is_some()`, extract and check the inner value
+
+```rust
+// SLOP
+assert!(x.is_none());
+assert!(ping["result"]["host_type"].as_str().is_some());
+
+// CLEAN
+assert_eq!(x, None);
+assert_eq!(ping["result"]["host_type"].as_str(), Some("daemon"));
+```
+
+---
+
+## 8. Async Timing Slop
+
+Raw `tokio::time::sleep` before assertions is fragile — passes on fast
+machines, flakes in CI.
+
+**What to look for:** `sleep(Duration::from_millis(N))` immediately before
+an assertion that checks state changed by a concurrent task.
+
+**Fix shape:**
+- Use a `wait_until_async` polling pattern with timeout
+- Sleep-then-assert is only acceptable for testing actual timing behavior
+
+```rust
+// SLOP
+tokio::time::sleep(Duration::from_millis(500)).await;
+assert_eq!(state.status(), "ready");
+
+// CLEAN — poll with timeout
+wait_until_async(Duration::from_secs(2), || async {
+    state.status() == "ready"
+}).await.expect("status should reach ready");
+```
+
+---
+
+## 9. `#[should_panic]` Without `expected`
+
+A bare `#[should_panic]` passes on *any* panic — including unrelated ones
+from refactoring. Always pin the expected message.
+
+**What to look for:** `#[should_panic]` without an `expected = "..."` argument.
+
+**Fix shape:**
+
+```rust
+// SLOP
+#[test]
+#[should_panic]
+fn rejects_empty_input() {
+    parse("");
+}
+
+// CLEAN
+#[test]
+#[should_panic(expected = "input must not be empty")]
+fn rejects_empty_input() {
+    parse("");
+}
+```
+
+---
+
+## 10. No-Crash-Is-Success Tests
+
+Tests with zero assertions only prove the code doesn't panic — not that it works.
+
+**What to look for:** Test functions with no `assert*!` macros and no `?`
+returning a value; test functions that call a function and return nothing.
+
+**Fix shape:**
+- Add assertions on return values or side effects
+- If intentionally testing "no panic", add an explicit comment documenting why
+
+```rust
+// SLOP
+#[test]
+fn stamp_activity_nonexistent_is_noop() {
+    tracker.stamp_activity("ghost-id");
+}
+
+// CLEAN — document the intent
+#[test]
+fn stamp_activity_nonexistent_is_noop() {
+    // No assertion needed: verifying no panic on missing ID
+    tracker.stamp_activity("ghost-id");
+}
+```
+
+---
+
+## 11. Lint Suppression as Band-Aid (`#[allow(...)]`)
+
+AI sprinkles `#[allow(...)]` to silence warnings instead of fixing root causes.
+
+### Crate-Level Nuclear Options (flag immediately)
+
+```rust
+// SLOP — nuclear options
+#![allow(warnings)]
+#![allow(clippy::all)]
+
+// SLOP — scaffold dump (3+ together = AI signature)
+#![allow(dead_code)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+```
+
+### The AI Scaffold Cluster
+
+| Attribute | AI Excuse | Real Fix |
+|-----------|-----------|----------|
+| `allow(dead_code)` | "I'll wire it up later" | Delete unconnected code |
+| `allow(unused_imports)` | Copied from examples | Remove unused `use` statements |
+| `allow(unused_variables)` | Bound "just in case" | Prefix with `_` or remove |
+| `allow(unused_mut)` | Added `mut` preemptively | Remove unnecessary `mut` |
+| `allow(unused_assignments)` | Assign then overwrite | Remove dead assignment |
+
+### Clippy Suppression Smells
+
+**Red Flag (almost always slop):**
+
+```rust
+// Hiding panic risks
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::expect_used)]
+#[allow(clippy::indexing_slicing)]
+#[allow(clippy::panic)]
+
+// Incomplete code in CI
+#[allow(clippy::todo)]
+#[allow(clippy::unimplemented)]
+#[allow(clippy::dbg_macro)]
+
+// Logging-aware code ignored
+#[allow(clippy::print_stdout)]
+#[allow(clippy::print_stderr)]
+
+// Weak error handling
+#[allow(clippy::result_unit_err)]
+```
+
+**Yellow Flag (context-dependent):**
+
+```rust
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)]
+#[allow(clippy::cognitive_complexity)]
+```
+
+### Tier System
+
+| Category | Philosophy | Suppression OK? |
+|----------|-----------|-----------------|
+| **restriction** | "Don't do this" | Almost never |
+| **correctness** | "This is likely wrong" | Almost never |
+| **complexity** | "This is confusing" | With justification |
+| **perf** | "This is slow" | Document why |
+| **style** | "Use X instead" | Preference |
+| **pedantic** | "Extra strict" | Usually OK |
+
+### Legitimate Uses (do not flag)
+
+- `#[allow(clippy::unwrap_used)]` in test code (idiomatic)
+- `#[allow(non_snake_case)]` in FFI modules matching C signatures
+- `#[allow(dead_code)]` on test utility functions
+- `#[allow(clippy::cognitive_complexity)]` on legitimate state machines
+
+### Scope Rule
+
+The further an allow reaches, the worse it smells. Crate-level > module-level
+> function-level > statement-level. If you must allow, scope it narrowly and
+add a comment explaining why.
+
+---
+
+## 12. Hallucinated APIs and Deprecated Syntax
+
+AI generates functions that don't exist or uses outdated API patterns
+(e.g., `clap` `App::new` instead of derive macros).
+
+**What to look for:** Method calls that don't exist in the current crate version;
+API patterns from 2+ major versions ago.
+
+**Fix shape:** Run `cargo check` immediately after generating code. Pin specific
+crate versions. Use Clippy. When in doubt, check docs.

--- a/skills/age/references/deslop/shell.md
+++ b/skills/age/references/deslop/shell.md
@@ -1,0 +1,197 @@
+# Shell / Bash De-slop Patterns
+
+Language-specific patterns the `age-deslop` dim looks for in shell script diffs.
+Read alongside `protocol.md` (cross-language patterns).
+
+---
+
+## 1. Unquoted Variables
+
+The #1 shell bug. Breaks on spaces, globs, and empty values.
+
+**What to look for:** `$var` or `$array` without quotes in contexts where
+word splitting or glob expansion would occur.
+
+```bash
+# SLOP
+for file in $files; do
+    rm $file
+done
+
+# CLEAN
+for file in "${files[@]}"; do
+    rm -- "$file"
+done
+```
+
+Quote every variable expansion: `"$var"`, `"${array[@]}"`, `"$(command)"`.
+The `--` stops option parsing (protects against filenames starting with `-`).
+
+---
+
+## 2. Missing or Incomplete `set -euo pipefail`
+
+AI scripts either omit strict mode entirely or use partial `set -e` without
+`-u` and `-o pipefail`.
+
+**What to look for:** Scripts with `set -e` only; scripts with no `set` at
+all; pipes through `jq`/`yq`/`grep` without `pipefail`.
+
+```bash
+# SLOP — no strict mode
+#!/bin/bash
+cd /some/directory    # Might fail silently
+rm -rf build/         # Now you're deleting in the wrong place
+
+# SLOP — partial strict mode (common AI output)
+#!/bin/bash
+set -e
+yq '.items[]' file.yaml | while read -r item; do  # yq failure silently ignored
+    process "$item"
+done
+
+# CLEAN
+#!/bin/bash
+set -euo pipefail
+cd /some/directory
+rm -rf build/
+```
+
+- `-e`: Exit on error
+- `-u`: Error on undefined variables (catches typos like `$UESR`)
+- `-o pipefail`: Pipeline fails if any command fails
+
+All three flags together. `set -e` alone is a half-measure.
+
+---
+
+## 3. Parsing `ls` Output
+
+`ls` output is not machine-readable. Filenames with spaces, newlines,
+or special characters break everything.
+
+**What to look for:** `for file in $(ls *.txt)` or similar.
+
+```bash
+# SLOP
+for file in $(ls *.txt); do
+    process "$file"
+done
+
+# CLEAN — glob directly
+for file in *.txt; do
+    [[ -f "$file" ]] && process "$file"
+done
+```
+
+---
+
+## 4. Useless Use of `cat`
+
+**What to look for:** `cat file | grep`, `cat file | wc -l` — piping into
+commands that accept file arguments directly.
+
+```bash
+# SLOP
+cat file.txt | grep "pattern"
+cat file.txt | wc -l
+
+# CLEAN
+grep "pattern" file.txt
+wc -l < file.txt
+```
+
+---
+
+## 5. Backticks Instead of `$()`
+
+Backticks don't nest and are harder to read.
+
+**What to look for:** Backtick command substitution in new code.
+
+```bash
+# SLOP
+result=`command`
+nested=`echo \`date\``
+
+# CLEAN
+result=$(command)
+nested=$(echo "$(date)")
+```
+
+---
+
+## 6. `[ ]` Instead of `[[ ]]`
+
+`[[ ]]` is safer: no word splitting, supports regex, no quoting surprises.
+
+**What to look for:** Single-bracket test expressions in bash scripts.
+
+```bash
+# SLOP
+if [ $var = "value" ]; then
+if [ -z $maybe_empty ]; then
+
+# CLEAN
+if [[ "$var" == "value" ]]; then
+if [[ -z "${maybe_empty:-}" ]]; then
+```
+
+---
+
+## 7. Hardcoded Paths
+
+AI writes absolute paths or assumes CWD.
+
+**What to look for:** Absolute paths to the author's home directory; relative
+paths that assume the script runs from a specific directory.
+
+```bash
+# SLOP
+source /home/user/project/lib/utils.sh
+config_file=./config.yaml
+
+# CLEAN
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/utils.sh"
+config_file="${SCRIPT_DIR}/config.yaml"
+```
+
+---
+
+## 8. Not Using `readonly` for Constants
+
+**What to look for:** Constants assigned with `=` that could be accidentally
+overwritten later in the script.
+
+```bash
+# SLOP
+MAX_RETRIES=3
+BASE_URL="https://api.example.com"
+
+# CLEAN
+readonly MAX_RETRIES=3
+readonly BASE_URL="https://api.example.com"
+```
+
+---
+
+## 9. Using `echo` for Error Messages
+
+Errors go to stderr, not stdout.
+
+**What to look for:** `echo "Error: ..."` followed by `exit 1` in error paths.
+
+```bash
+# SLOP
+echo "Error: file not found"
+exit 1
+
+# CLEAN
+echo >&2 "Error: file not found"
+exit 1
+
+# Or with a helper
+die() { echo >&2 "$@"; exit 1; }
+die "file not found"
+```

--- a/skills/age/references/deslop/typescript.md
+++ b/skills/age/references/deslop/typescript.md
@@ -1,0 +1,170 @@
+# TypeScript / JavaScript De-slop Patterns
+
+Language-specific patterns the `age-deslop` dim looks for in TypeScript/JavaScript diffs.
+Read alongside `protocol.md` (cross-language patterns).
+
+---
+
+## 1. `any` as Escape Hatch
+
+When types get complex, AI gives up and uses `any`, throwing away everything
+TypeScript provides.
+
+**What to look for:** Function parameters typed as `any`; return types of `any`;
+`data: any` in API handlers or utility functions.
+
+```typescript
+// SLOP
+function processData(data: any): any {
+  return data.value;
+}
+
+// CLEAN
+function processData<T extends { value: unknown }>(data: T): T['value'] {
+  return data.value;
+}
+
+// Or if you genuinely don't know the shape:
+function processData(data: unknown): unknown {
+  if (hasValue(data)) return data.value;
+  throw new Error("missing value field");
+}
+```
+
+---
+
+## 2. `.then()` Chains Instead of `async/await`
+
+AI mixes paradigms or uses promise chains where async/await is cleaner.
+
+**What to look for:** `.then().then().catch()` chains in new code where
+`async/await` is available.
+
+```typescript
+// SLOP
+function fetchUser(id: string) {
+  return fetch(`/api/users/${id}`)
+    .then(res => res.json())
+    .then(data => data.user)
+    .catch(err => console.error(err));
+}
+
+// CLEAN
+async function fetchUser(id: string): Promise<User> {
+  const res = await fetch(`/api/users/${id}`);
+  return (await res.json()).user;
+}
+```
+
+---
+
+## 3. `console.log` Debugging Left In
+
+AI adds debug logging that never gets removed.
+
+**What to look for:** `console.log(...)`, `console.log("Fetching...", ...)`,
+debug-flavored log strings in non-test code.
+
+**Fix shape:** Delete all `console.log` debug statements. Use a proper logger
+if observability is needed, or remove entirely if the code is self-evident.
+
+---
+
+## 4. `Array.forEach` With Async Callbacks
+
+`forEach` doesn't await — async callbacks fire and are silently dropped.
+
+**What to look for:** `items.forEach(async (item) => { await ... })`.
+
+```typescript
+// SLOP — these await calls do nothing useful
+items.forEach(async (item) => {
+  await processItem(item);
+});
+
+// CLEAN — sequential
+for (const item of items) {
+  await processItem(item);
+}
+
+// CLEAN — concurrent with control
+await Promise.all(items.map(item => processItem(item)));
+```
+
+---
+
+## 5. Redundant Null Checks TypeScript Already Handles
+
+With `strictNullChecks`, the compiler enforces null safety.
+
+**What to look for:** `=== null || === undefined` checks on values the type
+system already guarantees are non-null; double-null-checks on typed fields.
+
+```typescript
+// SLOP — name can't be undefined here, the type says string | null
+function greet(name: string | null): string {
+  if (name === null || name === undefined) {
+    return "Hello, stranger";
+  }
+  return `Hello, ${name}`;
+}
+
+// CLEAN
+function greet(name: string | null): string {
+  return name ? `Hello, ${name}` : "Hello, stranger";
+}
+```
+
+---
+
+## 6. `JSON.parse(JSON.stringify())` for Deep Cloning
+
+**What to look for:** `JSON.parse(JSON.stringify(x))` used where `structuredClone`
+is available (all modern runtimes).
+
+```typescript
+// SLOP
+const cloned = JSON.parse(JSON.stringify(user));
+
+// CLEAN
+const cloned = structuredClone(user);
+```
+
+---
+
+## 7. Redundant Type Annotations on Initialized Variables
+
+**What to look for:** Type annotations on variables whose type is unambiguous
+from the initializer (literals, constructor calls, typed function returns).
+
+```typescript
+// SLOP
+const count: number = 0;
+const name: string = user.name;
+const isActive: boolean = true;
+const users: User[] = getUsers();
+
+// CLEAN — inference handles these
+const count = 0;
+const name = user.name;
+const isActive = true;
+const users = getUsers();
+
+// Keep annotations on empty collections or ambiguous initializers
+const users: User[] = [];
+```
+
+---
+
+## 8. Over-Importing from Barrel Files
+
+**What to look for:** Import statements that pull 4+ named exports from a
+single module when only 1-2 are used.
+
+```typescript
+// SLOP — grabs everything, bloats bundle
+import { UserService, UserModel, UserDTO, UserMapper, UserValidator } from "./users";
+
+// CLEAN — import only what you use
+import { UserService } from "./users";
+```

--- a/skills/age/references/fixture-protocol.md
+++ b/skills/age/references/fixture-protocol.md
@@ -63,24 +63,28 @@ fail the gate.
 
 ## How `just test-age-fixtures` works
 
-```justfile
-test-age-fixtures:
-    python python/tools/age_fixture_diff.py tests/age-fixtures/
+The `justfile` loops each dim directory and calls the comparator with two
+explicit file arguments:
+
+```bash
+python python/tools/age_fixture_diff.py <dim>/actual.json <dim>/expected.json
 ```
 
 The comparator:
-1. Scans `tests/age-fixtures/` for `<dim>/` subdirectories.
-2. For each dim, reads `expected.json` and locates `actual.json` (written by
-   the dim agent during the test run).
-3. Compares per the tolerances above.
-4. Exits non-zero if any observation fails; prints a diff for each failure.
+1. Receives `actual.json` (written by the dim agent) and `expected.json`
+   (the checked-in fixture).
+2. Verifies the `dimension` field matches.
+3. Matches observations by `id` first (exact), then falls back to fuzzy
+   scoring. Each actual observation is consumed at most once (one-to-one).
+4. Exits non-zero if any expected observation is unmatched; prints a
+   JSON summary with `misses` for each failure.
 
 ---
 
 ## Failure modes
 
-**orphan match** -- `expected.json` references an observation id that has no
-counterpart in `actual.json`. Fail with: `orphan: <id> not found in actual`.
+**missing id** -- `expected.json` references an observation `id` that is
+absent from `actual.json` and no fuzzy match succeeds. Reported in `misses`.
 
 **missing actual.json** -- the dim agent did not write output. Fail with:
 `missing: tests/age-fixtures/<dim>/actual.json`.

--- a/skills/age/references/fixture-protocol.md
+++ b/skills/age/references/fixture-protocol.md
@@ -1,0 +1,108 @@
+# Fixture Protocol
+
+L2 quality gate for `/age`. One fixture per dim under `tests/age-fixtures/<dim>/`.
+Runnable via `just test-age-fixtures`.
+
+---
+
+## Directory layout
+
+```
+tests/age-fixtures/
+  <dim>/
+    diff.patch      -- real-file-shaped unified diff (input to the dim agent)
+    expected.json   -- subset of the per-agent return contract
+```
+
+One directory per dim: `correctness`, `security`, `complexity`, `encapsulation`,
+`spec`, `precedent`, `deslop`, `assertions`.
+
+---
+
+## `expected.json` schema
+
+A subset of the per-agent return contract (`sidecar-schema.md`). Only fields
+used by the comparator need to be present:
+
+```json
+{
+  "dimension": "<dim>",
+  "observations": [
+    {
+      "id": "<dim>-1",
+      "bucket": "high",
+      "narrative": "...",
+      "anchor": {"start": "42:a3f"}
+    }
+  ]
+}
+```
+
+Required fields per observation: `id`, `bucket`, `narrative`, `anchor.start`.
+All other fields (`evidence`, `consideration`, `fix`, etc.) are optional in
+`expected.json` and ignored by the comparator.
+
+---
+
+## Comparison tolerances
+
+`python/tools/age_fixture_diff.py` enforces:
+
+| Field | Rule |
+|---|---|
+| `dimension` | Exact match |
+| `bucket` | Exact match (`low`, `med`, or `high`) |
+| `narrative` | Levenshtein ratio >= 0.6 via `difflib.SequenceMatcher` |
+| `anchor.start` (line number) | Within +/- 1 of expected (hash ignored) |
+
+Any observation failing one of these four rules fails the L2 gate.
+Other fields are informational only; their mismatches are logged but do not
+fail the gate.
+
+---
+
+## How `just test-age-fixtures` works
+
+```justfile
+test-age-fixtures:
+    python python/tools/age_fixture_diff.py tests/age-fixtures/
+```
+
+The comparator:
+1. Scans `tests/age-fixtures/` for `<dim>/` subdirectories.
+2. For each dim, reads `expected.json` and locates `actual.json` (written by
+   the dim agent during the test run).
+3. Compares per the tolerances above.
+4. Exits non-zero if any observation fails; prints a diff for each failure.
+
+---
+
+## Failure modes
+
+**orphan match** -- `expected.json` references an observation id that has no
+counterpart in `actual.json`. Fail with: `orphan: <id> not found in actual`.
+
+**missing actual.json** -- the dim agent did not write output. Fail with:
+`missing: tests/age-fixtures/<dim>/actual.json`.
+
+**bucket mismatch** -- actual bucket differs from expected. Exact match
+required; no fuzzy logic.
+
+**narrative drift** -- Levenshtein ratio below 0.6. Printed as:
+`narrative ratio <actual_ratio> < 0.60 for <id>`. Update `expected.json`
+when the narrative intentionally changes.
+
+---
+
+## Adding a new fixture
+
+1. Add a new directory: `tests/age-fixtures/<new-dim>/`.
+2. Add `diff.patch`: a real-file-shaped unified diff that exercises the dim's
+   rubric. Use an actual file from the repo, not synthetic content.
+3. Run the dim agent against the patch to generate `actual.json`.
+4. Copy `actual.json` to `expected.json` and trim to only the fields required
+   by the comparator schema above.
+5. Run `just test-age-fixtures` to confirm the fixture passes baseline.
+6. Commit both `diff.patch` and `expected.json`.
+
+New dims require a fixture before merging (D-19).

--- a/skills/age/references/report-template.md
+++ b/skills/age/references/report-template.md
@@ -1,0 +1,90 @@
+# /age Report Template
+
+The orchestrator's Phase 3 fills in every `<!-- placeholder -->` comment.
+Do NOT include numeric scores anywhere in the rendered output.
+
+---
+
+## Review: <!-- placeholder: slug, e.g. "my-feature-abc123" -->
+
+<!-- placeholder: orientation paragraph -- 2-4 factual sentences built by the
+orchestrator from the correctness and precedent agents' summaries. State what
+changed, what patterns are present, and any prior-art signals. Not evaluative.
+Example: "This diff adds a new cache layer to the payments module (3 files,
++187/-42). The correctness agent found one null-dereference path in the happy
+route. Precedent shows the same pattern was reverted in commit a1b2c3 six
+months ago." -->
+
+Ran <!-- placeholder: N --> dims; <!-- placeholder: N --> had findings
+(`<!-- placeholder: dim-names with findings, comma-separated -->`).
+<!-- placeholder: dims with scope_match: false, if any -->
+
+---
+
+## High-stakes findings
+
+<!-- placeholder: one section per high-stake dim (correctness, security,
+encapsulation, spec) with observations. Omit dim section entirely if empty --
+it is counted in the tally above. -->
+
+### <!-- placeholder: dim name, e.g. "correctness" -->
+
+<!-- placeholder: per-observation block -- repeat for each observation.
+
+<narrative text>
+
+bucket: low|med|high
+
+**Evidence**
+- <evidence[0]>
+- <evidence[1]>
+
+**Consideration** (omit if fix is set)
+<consideration text>
+
+**Fix available** (omit if fix is absent)
+Category: <fix.category>
+
+-->
+
+---
+
+## Medium-stakes findings
+
+<!-- placeholder: one section per medium-stake dim (complexity, deslop,
+assertions) with observations. Same per-observation format as above. -->
+
+### <!-- placeholder: dim name -->
+
+<!-- placeholder: per-observation blocks -->
+
+---
+
+## Advisory findings
+
+<!-- placeholder: one section for the precedent dim if it has observations.
+Same per-observation format. -->
+
+### precedent
+
+<!-- placeholder: per-observation blocks -->
+
+---
+
+## Cross-dimension callouts
+
+<!-- placeholder: panel appears only when group_by_locus() finds observations
+from >= 2 dims within a 3-line window. Omit entirely if no cross-dim overlap.
+
+Format per callout:
+
+**<file>:<approx-line>** -- agreement across: <dim1>, <dim2>
+- <dim1>: <observation narrative, one line>
+- <dim2>: <observation narrative, one line>
+
+-->
+
+---
+
+*Report written to `<harness>/age/<slug>.md`. Fixes: <!-- placeholder: N -->. Suggestions: <!-- placeholder: N -->.*
+*To apply fixes: `/cleanup <slug>` -- To act on suggestions: `/fromage cook --suggestions <slug>`*

--- a/skills/age/references/report-template.md
+++ b/skills/age/references/report-template.md
@@ -86,5 +86,5 @@ Format per callout:
 
 ---
 
-*Report written to `<harness>/age/<slug>.md`. Fixes: <!-- placeholder: N -->. Suggestions: <!-- placeholder: N -->.*
+*Report written to `.cheese/age/<slug>.md`. Fixes: <!-- placeholder: N -->. Suggestions: <!-- placeholder: N -->.*
 *To apply fixes: `/cleanup <slug>` -- To act on suggestions: `/fromage cook --suggestions <slug>`*

--- a/skills/age/references/sidecar-schema.md
+++ b/skills/age/references/sidecar-schema.md
@@ -111,6 +111,7 @@ Written by the orchestrator after Phase 3 synthesis. Consumed by
     {
       "id": "deslop-1",
       "dimension": "deslop",
+      "operation": "tilth_edit",
       "file": "src/bar.ts",
       "anchor": {"start": "88:b2c", "end": "90:e1d"},
       "content": "...",
@@ -123,8 +124,8 @@ Written by the orchestrator after Phase 3 synthesis. Consumed by
 
 ### Rules
 
-- `operation` enum is closed and singular: `tilth_edit`. Do not add
-  alternatives without revising this schema.
+- `operation` is always `"tilth_edit"`. The enum is closed and singular;
+  do not add alternatives without revising this schema.
 - `id` matches the originating observation's `id`.
 - `anchor` and `content` map 1:1 to `tilth_edit`'s `start`, `end`,
   `content` arguments. The cleanup skill calls `tilth_edit` with no

--- a/skills/age/references/sidecar-schema.md
+++ b/skills/age/references/sidecar-schema.md
@@ -1,0 +1,178 @@
+# Sidecar schema
+
+The contract every `/age` dim agent emits and every downstream consumer
+(`/cleanup`, `/fromage cook`, `age_fixture_diff.py`) reads.
+
+Three artifacts are defined here:
+
+1. **Per-agent return contract** — one `<dim>.json` per dim, emitted into
+   `$RUN_DIR` by every dim agent.
+2. **`<slug>.fixes.json`** — sidecar of mechanically-applicable fixes,
+   consumed by `/cleanup`.
+3. **`<slug>.suggestions.json`** — sidecar of narrative-shaped guidance,
+   consumed by `/fromage cook`.
+
+## Anchor format
+
+All anchors are tilth `line:hash` strings — `"<line>:<hash>"` where the
+hash is FNV-1a 12-bit over the source line content. Example: `"42:a3f"`.
+
+`tilth_edit` validates these natively. A hash mismatch on apply means the
+file moved underneath the anchor — the cleanup skill routes to its
+`cleanup-wolf` sub-agent.
+
+## Per-agent return contract
+
+Every dim agent writes exactly one file:
+
+```
+$RUN_DIR/<dim>.json
+```
+
+Shape:
+
+```json
+{
+  "dimension": "<dim>",
+  "summary": "1-2 sentences",
+  "stake": "<high|medium|advisory>",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "<dim>-1",
+      "file": "src/foo.ts",
+      "anchor": {"start": "42:a3f", "end": "45:b1c"},
+      "bucket": "high",
+      "narrative": "...",
+      "evidence": [
+        "src/foo.ts:42 imports from src/bar/internal/baz.ts"
+      ],
+      "consideration": "Going through bar/index.ts requires bar to expose `frob()`",
+      "fix": {
+        "category": "deslop.swallowed_catch",
+        "content": "try { ... } catch (e) { logger.error(e); throw }"
+      }
+    }
+  ],
+  "manual_review_concerns": [
+    {
+      "topic": "data-flow",
+      "summary": "...",
+      "files": ["src/auth.ts:12"]
+    }
+  ]
+}
+```
+
+### Field rules
+
+- **`dimension`** — must match the dim name (`correctness`, `security`,
+  `complexity`, `encapsulation`, `spec`, `precedent`, `deslop`,
+  `assertions`).
+- **`stake`** — fixed per dim. Do not vary at runtime.
+  - high: `correctness`, `security`, `encapsulation`, `spec`
+  - medium: `complexity`, `deslop`, `assertions`
+  - advisory: `precedent`
+- **`scope_match`** — `false` when the dim's rubric does not apply to
+  this diff. Pair with `observations: []`.
+- **`bucket`** — exactly one of `low | med | high`. **No numeric scores
+  anywhere.**
+- **`narrative`** comes BEFORE the bucket value in any rendered report
+  (Greptile severity-at-end pattern). The agent need not enforce render
+  order; it just emits the field.
+- **`evidence`** — at least one entry per observation. Each entry is a
+  verifiable fact: `file:line`, prior commit sha, output of a tool, etc.
+  An observation without evidence is a verdict, not amplification.
+- **`consideration`** — narrative-shaped guidance; required when `fix`
+  is unset.
+- **`fix`** — set ONLY when all three hold:
+  1. Hash-anchored (the `anchor` field is filled with valid `line:hash`
+     strings).
+  2. Syntactically narrow (replaces a contiguous block; no whole-file
+     rewrites).
+  3. Complete `content` (the replacement is ready to apply verbatim;
+     no `...` placeholders).
+
+  Otherwise leave `fix` unset and write a `consideration`.
+- **`manual_review_concerns`** — for shapes the dim cannot adjudicate
+  but the reviewer should examine (e.g. taint, data-flow). Surfaced as
+  `manual_review_concerns`, not as observations with verdicts.
+
+## `<slug>.fixes.json`
+
+Written by the orchestrator after Phase 3 synthesis. Consumed by
+`/cleanup`. Entries are direct `tilth_edit` calls:
+
+```json
+{
+  "schema_version": 1,
+  "ref": "HEAD~3..HEAD",
+  "fixes": [
+    {
+      "id": "deslop-1",
+      "dimension": "deslop",
+      "file": "src/bar.ts",
+      "anchor": {"start": "88:b2c", "end": "90:e1d"},
+      "content": "...",
+      "rationale": "Silent failure pattern (deslop.swallowed_catch)",
+      "category": "deslop.swallowed_catch"
+    }
+  ]
+}
+```
+
+### Rules
+
+- `operation` enum is closed and singular: `tilth_edit`. Do not add
+  alternatives without revising this schema.
+- `id` matches the originating observation's `id`.
+- `anchor` and `content` map 1:1 to `tilth_edit`'s `start`, `end`,
+  `content` arguments. The cleanup skill calls `tilth_edit` with no
+  translation layer.
+- A fix entry is invalid if any of `id`, `dimension`, `file`, `anchor`,
+  `content`, `rationale`, `category` are missing.
+
+## `<slug>.suggestions.json`
+
+Written by the orchestrator after Phase 3. Consumed by `/fromage cook`
+when the user asks it to act on judgment-shaped guidance:
+
+```json
+{
+  "schema_version": 1,
+  "ref": "HEAD~3..HEAD",
+  "suggestions": [
+    {
+      "id": "encap-1",
+      "dimension": "encapsulation",
+      "file": "src/foo.ts",
+      "outline_ref": "44-89",
+      "narrative": "Cross-slice import bypasses index",
+      "agent_brief_for_cook": "Re-route src/foo.ts:42 through src/bar/index.ts."
+    }
+  ]
+}
+```
+
+### Rules
+
+- `outline_ref` is a line range, not a hash anchor. Suggestions are not
+  mechanically-applicable.
+- `agent_brief_for_cook` is a one-sentence imperative an LLM agent can
+  act on. Keep it concrete and bounded.
+- `narrative` repeats the originating observation's narrative (so the
+  consumer doesn't need to load the dim's full report).
+
+## Validation
+
+`age_fixture_diff.py` validates `<dim>.json` outputs against per-fixture
+`expected.json` files using:
+
+- **`dimension`** — exact match required.
+- **`bucket`** — exact match required.
+- **`narrative`** — Levenshtein similarity ≥ 0.6.
+- **`anchor.start`** — line number within ±1 of expected (hash ignored
+  for fixture comparison; hash drift across edits is normal).
+
+Any other field comparison is informational only; failures on the four
+above fail the L2 gate.

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -71,7 +71,7 @@ except HashMismatch:
     current_file     — cheez-read(fix.file, section containing anchor lines)
     rationale        — fix.rationale
 
-  record outcome from wolf: applied | skipped(reason)
+  record wolf result: {id, status: "applied"|"skip"|"already_applied", ...}
 ```
 
 Hash mismatch is the ONLY trigger for `cleanup-wolf`. Every other path is
@@ -82,10 +82,12 @@ any other condition.
 
 The wolf receives the fix entry and the current file state at the
 affected region. It attempts to re-anchor via `cheez-search` narrative
-match and applies with `tilth_edit`. Returns:
+match and applies with `tilth_edit`. Returns one of:
 
 ```json
-{"outcome": "applied" | "skipped", "reason": "<if skipped>"}
+{"id": "<fix.id>", "status": "applied", "new_anchor": {...}, "file": "..."}
+{"id": "<fix.id>", "status": "skip", "reason": "<reason>"}
+{"id": "<fix.id>", "status": "already_applied"}
 ```
 
 ## Phase 3 — Emit Report

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: cleanup
+description: Mechanical apply of /age's hash-anchored sidecar fixes via tilth_edit. The cleanup-wolf sub-agent is the only LLM in the path, fired per anchor mismatch.
+license: MIT
+compatibility: Requires Claude Code >= 2.1.30 / claude-agent-sdk >= 0.2.63 (tilth_edit must be exposed to plugin sub-agents).
+metadata:
+  owner: cheese-flow
+  category: cleanup
+allowed-tools:
+  - read
+  - write
+  - bash
+  - subagent
+  - mcp
+---
+# Cleanup — Mechanical Fix Apply
+
+Apply `/age` sidecar fixes mechanically via `tilth_edit`. No LLM in the
+happy path. The `cleanup-wolf` sub-agent fires only on hash mismatch.
+
+## Arguments
+
+```
+/cleanup <slug>
+```
+
+`slug` is the same slug produced by `/age`. Resolves to:
+
+```
+<harness>/age/<slug>.fixes.json
+```
+
+`<harness>` is `.claude` for Claude Code, `.codex` for Codex.
+
+## Phase 1 — Load
+
+Load `<harness>/age/<slug>.fixes.json`.
+
+Validate schema: every entry must have all of
+`id`, `dimension`, `file`, `anchor`, `content`, `rationale`, `category`.
+
+If any entry fails validation, abort with a structured error listing the
+invalid `id` values. Do not apply any fixes from a malformed file.
+
+If the file does not exist, fail fast:
+
+```
+ERROR: <harness>/age/<slug>.fixes.json not found.
+Run /age first to generate the fixes sidecar.
+```
+
+## Phase 2 — Apply Each Fix
+
+For each fix in `fixes`:
+
+```
+try:
+  tilth_edit(
+    path=fix.file,
+    edits=[{
+      start: fix.anchor.start,
+      end:   fix.anchor.end,
+      content: fix.content
+    }]
+  )
+  record: applied fix.id
+
+except HashMismatch:
+  spawn cleanup-wolf sub-agent with:
+    fix              — the original fix entry
+    current_file     — cheez-read(fix.file, section containing anchor lines)
+    rationale        — fix.rationale
+
+  record outcome from wolf: applied | skipped(reason)
+```
+
+Hash mismatch is the ONLY trigger for `cleanup-wolf`. Every other path is
+mechanical. Do not spawn the wolf for schema errors, missing files, or
+any other condition.
+
+**cleanup-wolf contract** (see `skills/cleanup/references/wolf-protocol.md`):
+
+The wolf receives the fix entry and the current file state at the
+affected region. It attempts to re-anchor via `cheez-search` narrative
+match and applies with `tilth_edit`. Returns:
+
+```json
+{"outcome": "applied" | "skipped", "reason": "<if skipped>"}
+```
+
+## Phase 3 — Emit Report
+
+Write `<harness>/age/<slug>.cleanup-report.md`:
+
+```markdown
+# Cleanup Report — <slug>
+
+Applied:      <N> fixes
+Wolf-rescued: <M> (hash mismatch, re-anchored and applied)
+Skipped:      <K> (hash mismatch, wolf could not re-anchor)
+
+## Skipped Details
+<id> — <reason>
+```
+
+If all fixes were applied cleanly (zero wolf invocations), omit the
+Wolf-rescued and Skipped rows.
+
+Print the report path to the caller.
+
+## Rules
+
+- `cleanup-wolf` is the only LLM in this skill. The happy path has zero
+  agent spawns.
+- Do not modify `<slug>.fixes.json` or `<slug>.suggestions.json`.
+- Do not apply suggestions. `/cleanup` is fixes-only; suggestions flow to
+  `/fromage cook`.
+- `tilth_edit` hash validation is the source of truth for anchor
+  correctness. Do not second-guess it.
+- Each fix is applied independently. A wolf failure on one fix does not
+  block the remaining fixes.

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -27,14 +27,14 @@ happy path. The `cleanup-wolf` sub-agent fires only on hash mismatch.
 `slug` is the same slug produced by `/age`. Resolves to:
 
 ```
-<harness>/age/<slug>.fixes.json
+.cheese/age/<slug>.fixes.json
 ```
 
-`<harness>` is `.claude` for Claude Code, `.codex` for Codex.
+All harnesses share the project-root `.cheese/` runtime directory.
 
 ## Phase 1 — Load
 
-Load `<harness>/age/<slug>.fixes.json`.
+Load `.cheese/age/<slug>.fixes.json`.
 
 Validate schema: every entry must have all of
 `id`, `dimension`, `file`, `anchor`, `content`, `rationale`, `category`.
@@ -45,7 +45,7 @@ invalid `id` values. Do not apply any fixes from a malformed file.
 If the file does not exist, fail fast:
 
 ```
-ERROR: <harness>/age/<slug>.fixes.json not found.
+ERROR: .cheese/age/<slug>.fixes.json not found.
 Run /age first to generate the fixes sidecar.
 ```
 
@@ -90,7 +90,7 @@ match and applies with `tilth_edit`. Returns:
 
 ## Phase 3 — Emit Report
 
-Write `<harness>/age/<slug>.cleanup-report.md`:
+Write `.cheese/age/<slug>.cleanup-report.md`:
 
 ```markdown
 # Cleanup Report — <slug>

--- a/skills/cleanup/references/wolf-protocol.md
+++ b/skills/cleanup/references/wolf-protocol.md
@@ -1,0 +1,79 @@
+# Wolf Protocol
+
+Wolf is the cleaner of last resort in the `/cleanup` path (named after the
+fixer in Pulp Fiction). It is the ONLY LLM agent in the cleanup skill.
+Wolf fires exactly when `tilth_edit` returns a hash mismatch for a fix entry.
+
+---
+
+## When Wolf fires
+
+The cleanup skill applies each fix mechanically via `tilth_edit`. If the anchor
+hash no longer matches the current file state, the skill cannot apply without
+human judgment. That is the only trigger for Wolf.
+
+Wolf does NOT fire on: missing files, permission errors, schema validation
+failures. Those are hard errors -- fail fast and surface to the caller.
+
+---
+
+## Inputs
+
+Wolf receives exactly three inputs:
+
+1. **`fix`** -- the original fix entry from `<slug>.fixes.json`:
+   `{id, dimension, file, anchor: {start, end}, content, rationale, category}`
+2. **`current_file_state`** -- the full current content of `fix.file`, read
+   via `cheez-read` immediately before Wolf is spawned.
+3. **`original_narrative`** -- the observation narrative from the dim agent
+   that produced the fix (used as the search signal).
+
+---
+
+## Re-anchor algorithm
+
+1. **Extract tier-1 tokens** from `original_narrative`: function name, class
+   name, or type name if present. These are the most stable identifiers.
+2. **cheez-search** for the original block using the tier-1 token as query,
+   scoped to `fix.file`.
+3. **Evaluate matches**:
+   - If exactly one match is found at a plausible location, re-anchor:
+     set `new_anchor.start` and `new_anchor.end` to the match's line:hash
+     values from `cheez-search` output.
+   - If zero or multiple matches are found, return skip with reason.
+4. **Apply** via `tilth_edit` using the new anchor.
+5. **Return** the result object (see Output below).
+
+Wolf MUST NOT make semantic changes. The `content` field is applied verbatim.
+Re-anchoring only; the replacement content is unchanged from the original fix.
+
+---
+
+## Output
+
+On success:
+```json
+{"applied": true, "new_anchor": {"start": "<line:hash>", "end": "<line:hash>"}}
+```
+
+On skip:
+```json
+{"skipped": "<reason>"}
+```
+
+Reasons for skip: `"no_match"`, `"ambiguous_match: N candidates"`,
+`"narrative_too_generic"`.
+
+Wolf returns one of these two shapes and nothing else. No partial applies,
+no semantic rewrites, no suggestions.
+
+---
+
+## What Wolf defers (v1 non-goals)
+
+- Multi-anchor merge (applying when the block was split across lines)
+- Semantic auto-fix (rewriting content to match new context)
+- Cross-file re-anchor (the fix moved to a different file)
+
+If any of these are needed, Wolf skips with reason and the cleanup report
+records it as `wolf_skipped`. The user decides next steps.

--- a/skills/cleanup/references/wolf-protocol.md
+++ b/skills/cleanup/references/wolf-protocol.md
@@ -53,16 +53,33 @@ Re-anchoring only; the replacement content is unchanged from the original fix.
 
 On success:
 ```json
-{"applied": true, "new_anchor": {"start": "<line:hash>", "end": "<line:hash>"}}
+{
+  "id": "<fix.id>",
+  "status": "applied",
+  "new_anchor": {"start": "<line:hash>", "end": "<line:hash>"},
+  "file": "<fix.file>"
+}
 ```
 
 On skip:
 ```json
-{"skipped": "<reason>"}
+{
+  "id": "<fix.id>",
+  "status": "skip",
+  "reason": "<reason>"
+}
+```
+
+On already-applied (block already contains the fix content):
+```json
+{
+  "id": "<fix.id>",
+  "status": "already_applied"
+}
 ```
 
 Reasons for skip: `"no_match"`, `"ambiguous_match: N candidates"`,
-`"narrative_too_generic"`.
+`"narrative_too_generic"`, `"semantic_change_required"`.
 
 Wolf returns one of these two shapes and nothing else. No partial applies,
 no semantic rewrites, no suggestions.

--- a/tests/age-fixtures/assertions/diff.patch
+++ b/tests/age-fixtures/assertions/diff.patch
@@ -1,0 +1,20 @@
+--- a/tests/pricing/price-calculator.test.ts
++++ b/tests/pricing/price-calculator.test.ts
+@@ -1,12 +1,20 @@
+ import { PriceCalculator } from "../../src/pricing";
+
+ describe("PriceCalculator", () => {
+-  it("applies 10% discount for bulk orders", () => {
+-    const result = PriceCalculator.calculate([{ sku: "A", qty: 100, unitPrice: 10 }]);
+-    expect(result.total).toBe(900);
++  it("applies discount for bulk orders", () => {
++    const result = PriceCalculator.calculate([{ sku: "A", qty: 100, unitPrice: 10 }]);
++    expect(result.total).toBeTruthy();
++    expect(result.discountApplied).toBeTruthy();
+   });
++
++  it("calculates tax correctly", () => {
++    const result = PriceCalculator.calculate([{ sku: "B", qty: 1, unitPrice: 50 }]);
++    expect(result.tax).toBeTruthy();
++  });
+ });

--- a/tests/age-fixtures/assertions/expected.json
+++ b/tests/age-fixtures/assertions/expected.json
@@ -1,0 +1,17 @@
+{
+  "dimension": "assertions",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "assertions-1",
+      "file": "tests/pricing/price-calculator.test.ts",
+      "anchor": { "start": "8:000", "end": "9:000" },
+      "bucket": "high",
+      "narrative": "toBeTruthy() on result.total passes for any non-zero value and cannot catch an off-by-one; toBe(900) is the exact equality check this test needs.",
+      "evidence": [
+        "tests/pricing/price-calculator.test.ts:8 expect(result.total).toBeTruthy() — truthy check where exact value equality is required"
+      ]
+    }
+  ]
+}

--- a/tests/age-fixtures/complexity/diff.patch
+++ b/tests/age-fixtures/complexity/diff.patch
@@ -1,0 +1,57 @@
+--- a/src/orders/fulfillment.ts
++++ b/src/orders/fulfillment.ts
+@@ -1,8 +1,50 @@
+ import { Order } from "./order";
+ import { db } from "../db/client";
++import { mailer } from "../notifications/mailer";
++import { inventory } from "../inventory/client";
+
+-export async function fulfill(order: Order): Promise<void> {
+-  await db.orders.update(order.id, { status: "fulfilled" });
++export async function fulfillOrder(
++  orderId: string,
++  warehouseId: string,
++  carrierId: string,
++  notifyEmail: string,
++  priority: "standard" | "express",
++): Promise<void> {
++  const order = await db.orders.find(orderId);
++  if (!order) throw new Error(`Order ${orderId} not found`);
++
++  const stock = await inventory.check(warehouseId, order.items);
++  if (!stock.available) {
++    throw new Error("Insufficient stock");
++  }
++
++  await inventory.reserve(warehouseId, order.items);
++
++  const shipment = await db.shipments.create({
++    orderId,
++    warehouseId,
++    carrierId,
++    priority,
++  });
++
++  await db.orders.update(orderId, {
++    status: "fulfilled",
++    shipmentId: shipment.id,
++  });
++
++  const label = await db.shippingLabels.generate(shipment.id);
++
++  if (priority === "express") {
++    await db.expressQueue.enqueue(shipment.id);
++  }
++
++  await mailer.send({
++    to: notifyEmail,
++    subject: `Order ${orderId} shipped`,
++    body: `Your order has been fulfilled. Tracking: ${label.trackingNumber}`,
++  });
++
++  await db.auditLog.append({
++    event: "order.fulfilled",
++    orderId,
++    shipmentId: shipment.id,
++  });
+ }

--- a/tests/age-fixtures/complexity/expected.json
+++ b/tests/age-fixtures/complexity/expected.json
@@ -1,0 +1,17 @@
+{
+  "dimension": "complexity",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "complexity-1",
+      "file": "src/orders/fulfillment.ts",
+      "anchor": { "start": "6:000", "end": "10:000" },
+      "bucket": "high",
+      "narrative": "fulfillOrder takes 5 parameters, exceeding the 4-param budget, and its body runs 44 lines past the 40-line ceiling.",
+      "evidence": [
+        "src/orders/fulfillment.ts:6 fulfillOrder(orderId, warehouseId, carrierId, notifyEmail, priority) — 5 params"
+      ]
+    }
+  ]
+}

--- a/tests/age-fixtures/correctness/diff.patch
+++ b/tests/age-fixtures/correctness/diff.patch
@@ -1,0 +1,17 @@
+--- a/src/users/handler.ts
++++ b/src/users/handler.ts
+@@ -8,10 +8,14 @@ import { db } from "../db/client";
+ import { User } from "./user";
+
+ export async function fetchUser(id: string): Promise<User | null> {
+-  return await db.users.find(id);
++  try {
++    return await db.users.find(id);
++  } catch (e) {
++    return null;
++  }
+ }
+
+ export async function deleteUser(id: string): Promise<void> {
+   await db.users.delete(id);
+ }

--- a/tests/age-fixtures/correctness/expected.json
+++ b/tests/age-fixtures/correctness/expected.json
@@ -1,0 +1,17 @@
+{
+  "dimension": "correctness",
+  "stake": "high",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "correctness-1",
+      "file": "src/users/handler.ts",
+      "anchor": { "start": "13:000", "end": "14:000" },
+      "bucket": "high",
+      "narrative": "Catch block swallows the db error and returns null, hiding fetch failures from all callers.",
+      "evidence": [
+        "src/users/handler.ts:13 catch (e) { return null; } swallows db.users.find rejection"
+      ]
+    }
+  ]
+}

--- a/tests/age-fixtures/deslop/diff.patch
+++ b/tests/age-fixtures/deslop/diff.patch
@@ -1,0 +1,13 @@
+--- a/src/notifications/email-sender.ts
++++ b/src/notifications/email-sender.ts
+@@ -5,9 +5,15 @@ import { mailer } from "./mailer-client";
+ import { logger } from "../common/logger";
+
+ export async function sendWelcomeEmail(userId: string, email: string): Promise<void> {
+-  await mailer.send({ to: email, template: "welcome", context: { userId } });
++  try {
++    await mailer.send({ to: email, template: "welcome", context: { userId } });
++  } catch (e) {
++    /* ignore */
++  }
+ }

--- a/tests/age-fixtures/deslop/expected.json
+++ b/tests/age-fixtures/deslop/expected.json
@@ -1,0 +1,17 @@
+{
+  "dimension": "deslop",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "deslop-1",
+      "file": "src/notifications/email-sender.ts",
+      "anchor": { "start": "10:000", "end": "11:000" },
+      "bucket": "high",
+      "narrative": "Catch block with bare comment swallows mailer errors silently, matching the swallowed_catch tier-1 deslop pattern.",
+      "evidence": [
+        "src/notifications/email-sender.ts:10 catch (e) { /* ignore */ } — swallowed_catch pattern"
+      ]
+    }
+  ]
+}

--- a/tests/age-fixtures/encapsulation/diff.patch
+++ b/tests/age-fixtures/encapsulation/diff.patch
@@ -1,0 +1,15 @@
+--- a/src/orders/order-service.ts
++++ b/src/orders/order-service.ts
+@@ -1,7 +1,10 @@
+ import { db } from "../db/client";
+-import { PricingEngine } from "../pricing";
++import { PricingEngine } from "../pricing/internal/pricing-engine";
++import { DiscountTable } from "../pricing/internal/discount-table";
+ import { Order } from "./order";
+
+ export async function createOrder(items: string[]): Promise<Order> {
+-  const price = PricingEngine.calculate(items);
++  const discounts = DiscountTable.load();
++  const price = PricingEngine.calculate(items, discounts);
+   return db.orders.create({ items, price });
+ }

--- a/tests/age-fixtures/encapsulation/expected.json
+++ b/tests/age-fixtures/encapsulation/expected.json
@@ -1,0 +1,17 @@
+{
+  "dimension": "encapsulation",
+  "stake": "high",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "encapsulation-1",
+      "file": "src/orders/order-service.ts",
+      "anchor": { "start": "2:000", "end": "3:000" },
+      "bucket": "high",
+      "narrative": "Imports reach into pricing/internal/ directly, bypassing the pricing slice's public index and coupling orders to internal implementation details.",
+      "evidence": [
+        "src/orders/order-service.ts:2 import from ../pricing/internal/pricing-engine — bypasses ../pricing/index"
+      ]
+    }
+  ]
+}

--- a/tests/age-fixtures/precedent/diff.patch
+++ b/tests/age-fixtures/precedent/diff.patch
@@ -1,0 +1,11 @@
+--- a/src/sessions/session-store.ts
++++ b/src/sessions/session-store.ts
+@@ -12,6 +12,10 @@ export class SessionStore {
+   async get(sessionId: string): Promise<Session | null> {
+     return this.cache.get(sessionId) ?? null;
+   }
++
++  async invalidateAll(): Promise<void> {
++    this.cache.clear();
++  }
+ }

--- a/tests/age-fixtures/precedent/expected.json
+++ b/tests/age-fixtures/precedent/expected.json
@@ -1,0 +1,17 @@
+{
+  "dimension": "precedent",
+  "stake": "advisory",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "precedent-1",
+      "file": "src/sessions/session-store.ts",
+      "anchor": { "start": "15:000", "end": "17:000" },
+      "bucket": "med",
+      "narrative": "Path src/sessions/session-store.ts carries 3 firefight commits (revert, hotfix, hotfix) suggesting cache-clearing logic has previously caused incidents.",
+      "evidence": [
+        "src/sessions/session-store.ts: 3 firefight commits found in path history (revert/hotfix pattern)"
+      ]
+    }
+  ]
+}

--- a/tests/age-fixtures/security/diff.patch
+++ b/tests/age-fixtures/security/diff.patch
@@ -1,0 +1,17 @@
+--- a/src/auth/middleware.ts
++++ b/src/auth/middleware.ts
+@@ -1,8 +1,14 @@
+ import { Request, Response, NextFunction } from "express";
++import { db } from "../db/client";
+
++const ADMIN_API_KEY = "sk-prod-8f2a91bc4d7e3051fa6c";
++
+ export function requireAdmin(req: Request, res: Response, next: NextFunction): void {
+-  if (!req.user?.isAdmin) {
++  const key = req.headers["x-api-key"];
++  if (key === ADMIN_API_KEY || req.user?.isAdmin) {
+     next();
++  } else {
++    res.status(403).end();
+   }
+ }

--- a/tests/age-fixtures/security/expected.json
+++ b/tests/age-fixtures/security/expected.json
@@ -1,0 +1,17 @@
+{
+  "dimension": "security",
+  "stake": "high",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "security-1",
+      "file": "src/auth/middleware.ts",
+      "anchor": { "start": "4:000", "end": "4:000" },
+      "bucket": "high",
+      "narrative": "Hardcoded production API key on the added line grants permanent admin bypass without rotation or audit trail.",
+      "evidence": [
+        "src/auth/middleware.ts:4 ADMIN_API_KEY = \"sk-prod-8f2a91bc4d7e3051fa6c\" literal secret in diff hunk"
+      ]
+    }
+  ]
+}

--- a/tests/age-fixtures/spec/diff.patch
+++ b/tests/age-fixtures/spec/diff.patch
@@ -1,0 +1,19 @@
+--- a/specs/payments.md
++++ b/specs/payments.md
+@@ -4,6 +4,7 @@ title: Payment Processing
+ ## Functional Requirements
+
+ - FR-1: All payment amounts must be rounded to 2 decimal places before storage.
++- FR-2: Refund amounts must never exceed the original charge amount.
+ - FR-3: Failed charges must be retried at most 3 times before marking as failed.
+--- a/src/payments/refund-handler.ts
++++ b/src/payments/refund-handler.ts
+@@ -8,6 +8,10 @@ import { db } from "../db/client";
+ import { stripe } from "./stripe-client";
+
+ export async function issueRefund(chargeId: string, amount: number): Promise<void> {
++  // Allow partial over-refund for goodwill gestures
++  const refundAmount = Math.max(amount, 0);
++  await stripe.refunds.create({ charge: chargeId, amount: refundAmount });
++  await db.charges.update(chargeId, { refunded: true });
+ }

--- a/tests/age-fixtures/spec/expected.json
+++ b/tests/age-fixtures/spec/expected.json
@@ -1,0 +1,17 @@
+{
+  "dimension": "spec",
+  "stake": "high",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "spec-1",
+      "file": "src/payments/refund-handler.ts",
+      "anchor": { "start": "11:000", "end": "12:000" },
+      "bucket": "high",
+      "narrative": "issueRefund applies no upper bound on refundAmount, directly contradicting FR-2 which forbids refunds exceeding the original charge.",
+      "evidence": [
+        "src/payments/refund-handler.ts:11 Math.max(amount, 0) permits over-refund; specs/payments.md FR-2 forbids it"
+      ]
+    }
+  ]
+}

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -255,8 +255,17 @@ describe("installHarnessArtifacts", () => {
     ) as { agents: string[]; skills: string[]; commands: string[] };
 
     expect(manifest.agents).toEqual([
+      "age-assertions.md",
+      "age-complexity.md",
+      "age-correctness.md",
+      "age-deslop.md",
+      "age-encapsulation.md",
+      "age-precedent.md",
+      "age-security.md",
+      "age-spec.md",
       "assertion-review.md",
       "basic-agent.md",
+      "cleanup-wolf.md",
       "cook.md",
       "cut.md",
       "milknado-executor.md",
@@ -264,10 +273,12 @@ describe("installHarnessArtifacts", () => {
       "press.md",
     ]);
     expect(manifest.skills).toEqual([
+      "age",
       "basic-skill",
       "cheez-read",
       "cheez-search",
       "cheez-write",
+      "cleanup",
       "gh",
       "merge-resolve",
       "milknado-execute",


### PR DESCRIPTION
## Summary

Replaces the stub `commands/age.md` with a working multi-dimensional code reviewer redesigned around cheese-flow's north star: amplify reviewer attention, do not render verdicts.

- **8 LLM dim agents** — `correctness`, `security`, `complexity`, `encapsulation`, `spec`, `precedent`, `deslop`, `assertions`. Each fires on every invocation (D-32) and emits hash-anchored observations with bucketed confidence (`low | med | high`). No numeric scores anywhere in user-facing output (D-5).
- **Shared evidence pack** (`$RUN_DIR/evidence-pack.yaml`) so dim agents do not duplicate cheez-read / cheez-search work (D-22).
- **`skills/cleanup/`** sibling skill consumes `<slug>.fixes.json` mechanically via `tilth_edit`; `cleanup-wolf` is the only LLM in the apply path, fired per anchor mismatch (D-14-final).
- **`python/tools/git_diagnose.py`** extended with `precedent` and `concurrent-prs` subcommands so agents never compose `git log` pipelines (D-23).
- **L2 quality gate** — `python/tools/age_fixture_diff.py` + `tests/age-fixtures/<dim>/{diff.patch,expected.json}` + `just test-age-fixtures` (D-19). Tolerances: `dimension`/`bucket` exact, `narrative` Levenshtein ≥ 0.6 (`difflib.SequenceMatcher`), `anchor.start` ±1.

All file I/O from agents flows through `cheez-read` / `cheez-search` / `cheez-write` (NFR-1). Anchors use tilth `line:hash` strings natively (NFR-2, D-24). Compatibility gate: Claude Code ≥ 2.1.30 / `claude-agent-sdk` ≥ 0.2.63 (D-28).

Spec: `.claude/specs/age-extraction.md` (sketches_locked, confidence 75).

## Test plan

- [x] `just build` — passing (TS lint, typecheck, tests 99.32% coverage; ruff format/check; pytest 150 tests)
- [x] `tests/compiler.test.ts` updated to register the 9 new agents and 2 new skills
- [ ] Manual smoke: invoke `/age` against this PR's own diff once landed in a session with tilth MCP exposed; confirm the report renders Orientation paragraph + stake-weighted dim sections + sidecar JSON files
- [ ] `just test-age-fixtures` — fixtures are in place; full gate requires running `/age` against each fixture diff and producing `actual.json` per dim, then comparing. Runtime gate, not CI gate.

## Out of scope (deferred per spec §Non-Goals / §Decisions)

- Tilth historical-read (`tilth_read --ref <sha>`) — D-26
- Data-flow / taint analysis — surfaced as `manual_review_concerns` only
- `/skill-improver` extraction — separate spec
- `code-review-graph` MCP wiring — orchestrator's `get_impact_radius_tool` call is optional (try/skip)
- Auto-applying fixes from inside `/age` — D-14-final amplifier-pure