### PR TITLE
fix(compiler): preserve user state at harness output root

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ install:
 
 # Full build with autofix: format -> lint -> typecheck -> build -> tests (for devs before PRs)
 build:
-    rm -rf dist coverage .claude .codex .cursor .copilot
+    rm -rf dist coverage
     npm install
     npm run format
     npm run lint:fix
@@ -27,7 +27,7 @@ build:
 
 # Full build no autofix: format check -> lint check -> typecheck -> build -> tests (for CI)
 build-ci:
-    rm -rf dist coverage .claude .codex .cursor .copilot
+    rm -rf dist coverage
     npm ci
     npm run format:check
     npm run lint:check
@@ -50,7 +50,7 @@ test-py *args:
 
 # Clean build artifacts and caches
 clean:
-    rm -rf dist coverage .claude .codex .cursor .copilot
+    rm -rf dist coverage
     rm -rf .pytest_cache .ruff_cache htmlcov .coverage node_modules/.cache
     find . -type d -name __pycache__ -prune -exec rm -rf {} +
     find . -type f -name "*.pyc" -delete

--- a/src/lib/compiler.ts
+++ b/src/lib/compiler.ts
@@ -138,7 +138,10 @@ async function cleanGeneratedArtifacts(
     generatedDirectories.push("rules", "commands");
   }
 
-  const generatedFiles = [adapter.mcpFileName, "manifest.json", "hooks.json"];
+  const generatedFiles = [adapter.mcpFileName, "manifest.json"];
+  if (adapter.buildHookConfig({}) !== null) {
+    generatedFiles.push("hooks.json");
+  }
 
   await Promise.all([
     ...generatedDirectories.map((entry) =>

--- a/src/lib/compiler.ts
+++ b/src/lib/compiler.ts
@@ -120,13 +120,43 @@ export async function installHarnessArtifacts(
   return outputs;
 }
 
+// Removes only the paths this build re-emits, so user-managed files at the
+// harness output root (settings.local.json, personal CLAUDE.md, etc.) are not
+// destroyed when contributors run `npm run build`.
+async function cleanGeneratedArtifacts(
+  adapter: HarnessAdapter,
+  outputRoot: string,
+): Promise<void> {
+  const generatedDirectories = [
+    adapter.agentDirectory,
+    adapter.skillDirectory,
+    adapter.commandDirectory,
+    adapter.manifestDir,
+  ].filter((entry): entry is string => entry !== undefined);
+
+  if (adapter.emitSurface !== undefined) {
+    generatedDirectories.push("rules", "commands");
+  }
+
+  const generatedFiles = [adapter.mcpFileName, "manifest.json", "hooks.json"];
+
+  await Promise.all([
+    ...generatedDirectories.map((entry) =>
+      rm(path.join(outputRoot, entry), { recursive: true, force: true }),
+    ),
+    ...generatedFiles.map((entry) =>
+      rm(path.join(outputRoot, entry), { force: true }),
+    ),
+  ]);
+}
+
 async function processHarness(context: ProcessHarnessContext): Promise<string> {
   const adapter = harnessAdapters[context.harnessName];
   const outputRoot = path.join(context.projectRoot, adapter.outputRoot);
   const agentOutputDirectory = path.join(outputRoot, adapter.agentDirectory);
   const skillOutputDirectory = path.join(outputRoot, adapter.skillDirectory);
 
-  await rm(outputRoot, { recursive: true, force: true });
+  await cleanGeneratedArtifacts(adapter, outputRoot);
   await mkdir(agentOutputDirectory, { recursive: true });
   await mkdir(skillOutputDirectory, { recursive: true });
 

--- a/src/lib/compiler.ts
+++ b/src/lib/compiler.ts
@@ -120,9 +120,9 @@ export async function installHarnessArtifacts(
   return outputs;
 }
 
-// Removes only the paths this build re-emits, so user-managed files at the
-// harness output root (settings.local.json, personal CLAUDE.md, etc.) are not
-// destroyed when contributors run `npm run build`.
+// Removes only the paths this install step re-emits, so user-managed files at
+// the harness output root (settings.local.json, personal CLAUDE.md, etc.) are
+// not destroyed when contributors run `cheese install` / `npm run install:<harness>`.
 async function cleanGeneratedArtifacts(
   adapter: HarnessAdapter,
   outputRoot: string,

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -509,6 +509,71 @@ describe("installHarnessArtifacts", () => {
     ).rejects.toThrow();
   });
 
+  it("preserves user-managed files at the harness output root across rebuilds", async () => {
+    const projectRoot = await mkdtemp(
+      path.join(os.tmpdir(), "cheese-flow-preserve-"),
+    );
+    createdDirectories.push(projectRoot);
+    await cp(path.resolve("agents"), path.join(projectRoot, "agents"), {
+      recursive: true,
+    });
+    await cp(path.resolve("skills"), path.join(projectRoot, "skills"), {
+      recursive: true,
+    });
+
+    const claudeRoot = path.join(projectRoot, ".claude");
+    await mkdir(claudeRoot, { recursive: true });
+    const userSettingsPath = path.join(claudeRoot, "settings.local.json");
+    const userClaudeMdPath = path.join(claudeRoot, "CLAUDE.md");
+    await writeFile(userSettingsPath, '{"theme":"dark"}\n', "utf8");
+    await writeFile(userClaudeMdPath, "# user notes\n", "utf8");
+
+    await installHarnessArtifacts({
+      projectRoot,
+      harnesses: ["claude-code"],
+    });
+    await installHarnessArtifacts({
+      projectRoot,
+      harnesses: ["claude-code"],
+    });
+
+    expect(await readFile(userSettingsPath, "utf8")).toBe('{"theme":"dark"}\n');
+    expect(await readFile(userClaudeMdPath, "utf8")).toBe("# user notes\n");
+  });
+
+  it("removes stale generated agents on rebuild", async () => {
+    const projectRoot = await mkdtemp(
+      path.join(os.tmpdir(), "cheese-flow-stale-"),
+    );
+    createdDirectories.push(projectRoot);
+    await cp(path.resolve("agents"), path.join(projectRoot, "agents"), {
+      recursive: true,
+    });
+    await cp(path.resolve("skills"), path.join(projectRoot, "skills"), {
+      recursive: true,
+    });
+
+    await installHarnessArtifacts({
+      projectRoot,
+      harnesses: ["claude-code"],
+    });
+
+    const staleAgentPath = path.join(
+      projectRoot,
+      ".claude",
+      "agents",
+      "renamed-away.md",
+    );
+    await writeFile(staleAgentPath, "stale\n", "utf8");
+
+    await installHarnessArtifacts({
+      projectRoot,
+      harnesses: ["claude-code"],
+    });
+
+    await expect(readFile(staleAgentPath, "utf8")).rejects.toThrow();
+  });
+
   it("keeps help on -h and uses -H for harness selection", async () => {
     const { stdout } = await execFileAsync(
       "npx",


### PR DESCRIPTION
## Summary

Fixes a critical bug where the build process deleted user-managed files at harness output roots. Contributors running `just build`, `just build-ci`, or `just clean` could lose their personal `settings.local.json`, `CLAUDE.md`, and other local state.

## Root Cause

The compiler's `processHarness()` was doing `rm -rf $outputRoot` on every build, treating `.claude/`, `.codex/`, `.cursor/`, and `.copilot/` as purely generated directories. But these roots also hold user state in Claude Code projects.

## Solution

- **Compiler**: Introduced `cleanGeneratedArtifacts()` that removes only the paths this build re-emits (`agents/`, `skills/`, `commands/`, `rules/`, `manifestDir`, and the generated files `manifest.json`, `hooks.json`, `mcp*.json`)
- **Justfile**: Removed `.claude .codex .cursor .copilot` from `rm -rf` lines in `build`, `build-ci`, and `clean` recipes since the compiler now manages targeted cleanup
- **Tests**: Added two regression tests to prevent re-introduction:
  1. User-managed files at the harness root survive across rebuilds
  2. Stale generated artifacts (e.g., renamed agents) still get cleaned

## Test Plan

- ✅ Full build passes: `just build` (99.33% coverage, 150 tests)
- ✅ No lint or formatting issues
- ✅ New regression tests pass

🧀 Generated with [Claude Code](https://claude.com/claude-code)
