### PR TITLE
feat(mold): anchor interface sketches to Sliced Bread slices

### DIFF
--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -47,9 +47,9 @@ dialogue actually produced — never more, never less.
    step.
 4. **Lock down interfaces before crystallizing.** Every cross-slice seam
    gets a pseudocode signature with named unknowns, a recommended answer,
-   and an explicit Sliced Bread slice (`domains/<name>/`,
-   `adapters/<name>/`, or `app/`). Architecture rules in
-   `references/sliced-bread.md`.
+   and an explicit Sliced Bread slice (`domains/<name>`, `adapters/<name>`,
+   `app`, or `domains/common`). Architecture rules in
+   `references/sliced-bread.md` (repo root, not local to this skill).
 5. **Two-key handshake.** Both the user (explicit verb) and the agent
    (coherence self-check) must agree before extraction.
 6. **Heavy delegation.** `/briesearch` for external research, `cheez-search`
@@ -103,10 +103,10 @@ Job: lock modules, responsibilities, I/O contracts, and seams in pseudocode
 signatures, anchored to Sliced Bread slices. Before drafting, parallel
 `cheez-search` for sibling signatures in the same slice so new ones fit
 conventions and respect the crust (the slice's public API).
-Exit when: every public seam has a signature with a slice path; every
-cross-slice call imports from the target slice's crust, never its
-internals. Detail in `references/sketch-mode.md`; architecture rules in
-`references/sliced-bread.md`.
+Exit when: every public seam has a signature and a declared `slice` field;
+   every cross-slice call imports from the target slice's crust, never its
+   internals. Detail in `references/sketch-mode.md`; architecture rules in
+   `references/sliced-bread.md` (repo root, not local to this skill).
 
 ### Grill — adversarial clarification
 Job: stress-test the chosen approach plus sketched interfaces. **One question

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -45,8 +45,11 @@ dialogue actually produced — never more, never less.
 3. **State a hypothesis before researching.** A bare research dispatch is
    discouraged; the Validate Cycle frame forces commitment plus a judgment
    step.
-4. **Lock down interfaces before crystallizing.** Every cross-module seam
-   gets a pseudocode signature with named unknowns and a recommended answer.
+4. **Lock down interfaces before crystallizing.** Every cross-slice seam
+   gets a pseudocode signature with named unknowns, a recommended answer,
+   and an explicit Sliced Bread slice (`domains/<name>/`,
+   `adapters/<name>/`, or `app/`). Architecture rules in
+   `references/sliced-bread.md`.
 5. **Two-key handshake.** Both the user (explicit verb) and the agent
    (coherence self-check) must agree before extraction.
 6. **Heavy delegation.** `/briesearch` for external research, `cheez-search`
@@ -97,10 +100,13 @@ Exit when: an option is picked (→ Sketch) or none survive (→ Explore).
 
 ### Sketch — interface lockdown
 Job: lock modules, responsibilities, I/O contracts, and seams in pseudocode
-signatures. Before drafting, parallel `cheez-search` for sibling signatures
-in the same domain so new ones fit conventions.
-Exit when: every public seam has a signature; every cross-module call has a
-contract. Detail in `references/sketch-mode.md`.
+signatures, anchored to Sliced Bread slices. Before drafting, parallel
+`cheez-search` for sibling signatures in the same slice so new ones fit
+conventions and respect the crust (the slice's public API).
+Exit when: every public seam has a signature with a slice path; every
+cross-slice call imports from the target slice's crust, never its
+internals. Detail in `references/sketch-mode.md`; architecture rules in
+`references/sliced-bread.md`.
 
 ### Grill — adversarial clarification
 Job: stress-test the chosen approach plus sketched interfaces. **One question
@@ -211,6 +217,7 @@ Coherence self-check before crystallize:
 - [ ] At least 2 options weighed (Do Nothing included)
 - [ ] Chosen option grounded in codebase evidence
 - [ ] Interface sketches: every public seam has a pseudocode signature
+- [ ] Each sketch declares a Sliced Bread slice; cross-slice calls go through the crust
 - [ ] Validate cycles: all launched cycles judged
 - [ ] Chosen option Grilled (>=1 `Grill turns` entry per major branch)
 - [ ] Open questions all marked [TBD] / [BLOCKED] / [?] (none silent)

--- a/skills/mold/references/sketch-mode.md
+++ b/skills/mold/references/sketch-mode.md
@@ -47,25 +47,27 @@ Push back on either, or `1A 2A` to confirm.
 ## Slice placement
 
 Every signature names the **Sliced Bread slice** it lives in before the
-pseudocode is drafted. The slice path — `domains/<name>/`,
-`adapters/<name>/`, `app/`, or `domains/common/` — goes in the sketch's
-`module` field and gates the direction-of-imports check.
+pseudocode is drafted. The slice — `domains/<name>`,
+`adapters/<name>`, `app`, or `domains/common` — goes in the sketch's
+`slice` field. The `module` field records the specific file or module
+path within that slice.
 
 Default decisions:
 
-- **Pure business concept** (entity, value type, port) → `domains/<slice>/`.
+- **Pure business concept** (entity, value type, port) → `domains/<name>`.
   Define the port inside the domain; adapters implement it.
 - **External integration** (DB, third-party SDK, queue, cache, logger) →
-  `adapters/<name>/`. Implements a port from `domains/`.
+  `adapters/<name>`. Implements a port from `domains/`.
 - **Cross-slice orchestration** (use case spanning 2+ domain slices) →
-  `app/use_cases/`.
+  `app/use_cases`.
 - **Pure shape with universal semantics** (Money, UserId, Email) →
-  `domains/common/`. Only when the type has zero behavior and is referenced
+  `domains/common`. Only when the type has zero behavior and is referenced
   by 2+ slices today.
 
-Full rules in `references/sliced-bread.md`. The Sketch gate fails if any
-signature crosses an existing slice's boundary by importing internals
-instead of the crust, or if `common/` would import from a sibling slice.
+Full rules in `references/sliced-bread.md` (repo root, not local to this
+skill). The Sketch gate fails if any signature crosses an existing
+slice's boundary by importing internals instead of the crust, or if
+`domains/common` would import from a sibling slice.
 
 When the chosen option crosses an existing slice's crust, the sketch
 records the imported public name (`from domains.orders import dispatch`)

--- a/skills/mold/references/sketch-mode.md
+++ b/skills/mold/references/sketch-mode.md
@@ -44,6 +44,35 @@ Unknowns:
 Push back on either, or `1A 2A` to confirm.
 ```
 
+## Slice placement
+
+Every signature names the **Sliced Bread slice** it lives in before the
+pseudocode is drafted. The slice path — `domains/<name>/`,
+`adapters/<name>/`, `app/`, or `domains/common/` — goes in the sketch's
+`module` field and gates the direction-of-imports check.
+
+Default decisions:
+
+- **Pure business concept** (entity, value type, port) → `domains/<slice>/`.
+  Define the port inside the domain; adapters implement it.
+- **External integration** (DB, third-party SDK, queue, cache, logger) →
+  `adapters/<name>/`. Implements a port from `domains/`.
+- **Cross-slice orchestration** (use case spanning 2+ domain slices) →
+  `app/use_cases/`.
+- **Pure shape with universal semantics** (Money, UserId, Email) →
+  `domains/common/`. Only when the type has zero behavior and is referenced
+  by 2+ slices today.
+
+Full rules in `references/sliced-bread.md`. The Sketch gate fails if any
+signature crosses an existing slice's boundary by importing internals
+instead of the crust, or if `common/` would import from a sibling slice.
+
+When the chosen option crosses an existing slice's crust, the sketch
+records the imported public name (`from domains.orders import dispatch`)
+rather than reaching into internals. Run a Validate Cycle on the import
+target to confirm it actually appears in the slice's index file before
+locking the signature.
+
 ## Pseudocode style
 
 - **Python-flavored** as the universal shape (function-style signatures,
@@ -63,10 +92,10 @@ conventions already there.
 
 ```
 Parallel sketches sweep:
-  cheez-search query: "dispatch" scope: "src/notifications/"
-  cheez-search query: "queue, enqueue" scope: "src/notifications/"
+  cheez-search query: "dispatch" scope: "domains/notifications/"
+  cheez-search query: "queue, enqueue" scope: "domains/notifications/"
   cheez-search query: "dispatch" kind: "callers" scope: "src/"
-  cheez-search deps: "src/notifications/index.ts"
+  cheez-search deps: "domains/notifications/index.ts"
 ```
 
 `cheez-search` exposes both `tilth_search` (definitions, usages, callers)
@@ -92,7 +121,8 @@ Sketches live in the state file's `Sketches (locked interfaces)` block
 during the loop, then migrate verbatim into the spec's `Interface Sketches`
 section at Crystallize. Each sketch carries:
 
-- `module` — slice or path.
+- `module` — slice path or file path.
+- `slice` — Sliced Bread slice (`domains/<name>`, `adapters/<name>`, `app`, or `domains/common`).
 - `signature` — pseudocode block.
 - `responsibilities` — bullet list (1-3 items).
 - `seams` — named external integrations (queue, cache, event bus, ...).

--- a/skills/mold/references/spec.md
+++ b/skills/mold/references/spec.md
@@ -160,8 +160,8 @@ erDiagram
 ## Interface Sketches
 > Pseudocode signatures locked during /mold. Names + types + contracts; not
 > final code. /cook translates to the target idioms. Each sketch declares
-> its Sliced Bread slice (`domains/<name>/`, `adapters/<name>/`, `app/`,
-> or `domains/common/`) so /cook places code on the correct side of the
+> its Sliced Bread slice (`domains/<name>`, `adapters/<name>`, `app`,
+> or `domains/common`) so /cook places code on the correct side of the
 > crust.
 
 ### `<module path>`

--- a/skills/mold/references/spec.md
+++ b/skills/mold/references/spec.md
@@ -159,9 +159,13 @@ erDiagram
 
 ## Interface Sketches
 > Pseudocode signatures locked during /mold. Names + types + contracts; not
-> final code. /cook translates to the target idioms.
+> final code. /cook translates to the target idioms. Each sketch declares
+> its Sliced Bread slice (`domains/<name>/`, `adapters/<name>/`, `app/`,
+> or `domains/common/`) so /cook places code on the correct side of the
+> crust.
 
 ### `<module path>`
+**Slice:** `domains/<name>` | `adapters/<name>` | `app` | `domains/common`.
 **Responsibilities:** <one>, <two>, <three>.
 **Seams:** <queue>, <cache>, <event_bus>.
 

--- a/skills/mold/references/state-schema.md
+++ b/skills/mold/references/state-schema.md
@@ -27,7 +27,7 @@ briesearch_used: <integer>      # 0..2 unless user lifts the cap
 - ...
 
 ## Sketches (locked interfaces)
-- module: <slice path or file path>
+- module: <file or module path within the slice>
   slice: domains/<name> | adapters/<name> | app | domains/common
   signature: |
     def <name>(

--- a/skills/mold/references/state-schema.md
+++ b/skills/mold/references/state-schema.md
@@ -27,7 +27,8 @@ briesearch_used: <integer>      # 0..2 unless user lifts the cap
 - ...
 
 ## Sketches (locked interfaces)
-- module: <slice or path>
+- module: <slice path or file path>
+  slice: domains/<name> | adapters/<name> | app | domains/common
   signature: |
     def <name>(
         <arg>: <Type>,
@@ -89,8 +90,10 @@ Explore (1-3) → Ground (4-5) → Shape (6-8) → [validate cycle 1] → Sketch
 - **Decisions** — append-only. Each line is `<title> — <summary> (agreed
   turn <N>)`. Decisions stand until the user explicitly reverses one.
 - **Sketches** — append-only. Locked sketches feed the spec verbatim.
-  Each sketch is a small block with `module`, `signature`, `responsibilities`,
-  `seams`, `error_shape`.
+  Each sketch is a small block with `module`, `slice`, `signature`,
+  `responsibilities`, `seams`, `error_shape`. The `slice` field names the
+  Sliced Bread slice (`domains/<name>`, `adapters/<name>`, `app`, or
+  `domains/common`) and gates the crystallize crust check.
 - **Validate cycles** — append-only. Outcomes are exactly one of `SUPPORTED`,
   `CONTRADICTED`, `REFINED`. REFINED cycles point at their refined-form id.
   CONTRADICTED cycles get a `conflict_id` that ties to an `Open questions`


### PR DESCRIPTION
## Summary
- Wires the Sliced Bread architecture into `/mold` so spec sketches declare which slice they live in (`domains/<name>/`, `adapters/<name>/`, `app/`, or `domains/common/`) before locking signatures.
- Closes the gap between `/mold` (designs) and `/age-arch` (reviews against Sliced Bread): `/cook` now receives slice-anchored sketches instead of placing code by guess.
- Doc-only change. No CLI or runtime behaviour changes.

## What changed

| File | Change |
|---|---|
| `skills/mold/SKILL.md` | Operating principle 4 requires a slice declaration on every cross-slice seam. Sketch mode anchors signatures to slices and routes cross-slice calls through the crust. New coherence-checklist item gates crystallize on slice + crust. |
| `skills/mold/references/sketch-mode.md` | New **Slice placement** section with default routing (business → `domains/`, integration → `adapters/`, orchestration → `app/use_cases/`, pure shape with 2+ consumers → `domains/common/`). Sketch gate fails on internals-bypass. Sibling sweep example uses canonical `domains/notifications/`. Output schema adds `slice`. |
| `skills/mold/references/spec.md` | Interface Sketches preamble explains slice declaration; template gains a `**Slice:**` line. |
| `skills/mold/references/state-schema.md` | Scratch state Sketches block and field rules add the `slice` field. |

## Test plan
- [x] `just build` clean (lint, type-check, 99.32% statement coverage, 150 pytest tests)
- [ ] Manual: invoke `/mold` on a multi-slice feature and verify Sketch mode names slices
- [ ] Manual: confirm crystallized spec carries `**Slice:**` lines that `/cook` and `/age-arch` can read
