### PR TITLE
Portable model selection: aliases + manifest + tier rebalance

### DIFF
--- a/agents/age-assertions.md.eta
+++ b/agents/age-assertions.md.eta
@@ -2,9 +2,9 @@
 name: age-assertions
 description: Assertions reviewer in /age — detects weak test assertions in changed test files using the assertions protocol and language refs.
 models:
-  default: claude-haiku-4-5
-  claude-code: claude-haiku-4-5-20251001
-  codex: gpt-5.1-codex
+  default: sonnet
+  claude-code: sonnet
+  codex: gpt-5-codex
 tools:
   - mcp__tilth__tilth_read
   - mcp__tilth__tilth_search

--- a/agents/age-complexity.md.eta
+++ b/agents/age-complexity.md.eta
@@ -2,9 +2,9 @@
 name: age-complexity
 description: Complexity reviewer in /age — flags functions >40 lines, files >300 lines, params >4, and nesting >3 in the diff.
 models:
-  default: claude-haiku-4-5
-  claude-code: claude-haiku-4-5-20251001
-  codex: gpt-5.1-codex
+  default: haiku
+  claude-code: haiku
+  codex: gpt-5-codex
 tools:
   - mcp__tilth__tilth_read
   - mcp__tilth__tilth_search

--- a/agents/age-correctness.md.eta
+++ b/agents/age-correctness.md.eta
@@ -2,9 +2,9 @@
 name: age-correctness
 description: Correctness reviewer in /age — surfaces silent failures, null misuse, off-by-ones, and ordering bugs in the diff.
 models:
-  default: claude-haiku-4-5
-  claude-code: claude-haiku-4-5-20251001
-  codex: gpt-5.1-codex
+  default: sonnet
+  claude-code: sonnet
+  codex: gpt-5-codex
 tools:
   - mcp__tilth__tilth_read
   - mcp__tilth__tilth_search

--- a/agents/age-deslop.md.eta
+++ b/agents/age-deslop.md.eta
@@ -2,9 +2,9 @@
 name: age-deslop
 description: Deslop reviewer in /age — detects AI-generated anti-patterns using the deslop protocol and language-specific references.
 models:
-  default: claude-haiku-4-5
-  claude-code: claude-haiku-4-5-20251001
-  codex: gpt-5.1-codex
+  default: sonnet
+  claude-code: sonnet
+  codex: gpt-5-codex
 tools:
   - mcp__tilth__tilth_read
   - mcp__tilth__tilth_search

--- a/agents/age-encapsulation.md.eta
+++ b/agents/age-encapsulation.md.eta
@@ -2,9 +2,9 @@
 name: age-encapsulation
 description: Encapsulation reviewer in /age — enforces Sliced Bread compliance, cross-slice imports, public-API width, and model purity.
 models:
-  default: claude-haiku-4-5
-  claude-code: claude-haiku-4-5-20251001
-  codex: gpt-5.1-codex
+  default: sonnet
+  claude-code: sonnet
+  codex: gpt-5-codex
 tools:
   - mcp__tilth__tilth_read
   - mcp__tilth__tilth_search

--- a/agents/age-precedent.md.eta
+++ b/agents/age-precedent.md.eta
@@ -2,9 +2,9 @@
 name: age-precedent
 description: Precedent reviewer in /age — surfaces historical patterns and concurrent-PR context as narratives for the reviewer to interpret.
 models:
-  default: claude-haiku-4-5
-  claude-code: claude-haiku-4-5-20251001
-  codex: gpt-5.1-codex
+  default: haiku
+  claude-code: haiku
+  codex: gpt-5-codex
 tools:
   - mcp__tilth__tilth_read
   - mcp__tilth__tilth_search

--- a/agents/age-security.md.eta
+++ b/agents/age-security.md.eta
@@ -2,9 +2,9 @@
 name: age-security
 description: Security reviewer in /age — diff-scoped auth bypass, secrets, and taint-shaped concerns in changed code only.
 models:
-  default: claude-haiku-4-5
-  claude-code: claude-haiku-4-5-20251001
-  codex: gpt-5.1-codex
+  default: sonnet
+  claude-code: sonnet
+  codex: gpt-5-codex
 tools:
   - mcp__tilth__tilth_read
   - mcp__tilth__tilth_search

--- a/agents/age-spec.md.eta
+++ b/agents/age-spec.md.eta
@@ -2,9 +2,9 @@
 name: age-spec
 description: Spec-drift reviewer in /age — surfaces divergence between touched code and the harness spec file(s) that govern it.
 models:
-  default: claude-haiku-4-5
-  claude-code: claude-haiku-4-5-20251001
-  codex: gpt-5.1-codex
+  default: sonnet
+  claude-code: sonnet
+  codex: gpt-5-codex
 tools:
   - mcp__tilth__tilth_read
   - mcp__tilth__tilth_search

--- a/agents/assertion-review.md.eta
+++ b/agents/assertion-review.md.eta
@@ -2,9 +2,9 @@
 name: assertion-review
 description: Spec-drift detection via assertion review. Reads the spec, the cut tests, and the cooked implementation, then rates how well each assertion actually verifies a spec requirement.
 models:
-  default: gpt-5.1-codex
-  claude-code: claude-sonnet-4-5
-  codex: gpt-5.1-codex
+  default: sonnet
+  claude-code: sonnet
+  codex: gpt-5-codex
 tools:
   - mcp__tilth__tilth_read
   - mcp__tilth__tilth_search

--- a/agents/basic-agent.md.eta
+++ b/agents/basic-agent.md.eta
@@ -2,9 +2,9 @@
 name: basic-agent
 description: A starter portable agent definition compiled into harness-specific markdown.
 models:
-  default: gpt-5.1-codex
-  claude-code: claude-sonnet-4-5
-  codex: gpt-5.1-codex
+  default: sonnet
+  claude-code: sonnet
+  codex: gpt-5-codex
 tools:
   - read
   - write

--- a/agents/cleanup-wolf.md.eta
+++ b/agents/cleanup-wolf.md.eta
@@ -2,9 +2,9 @@
 name: cleanup-wolf
 description: Re-anchors a /cleanup fix when the original tilth_edit hash mismatches; applies via tilth_edit or returns explicit skip.
 models:
-  default: claude-haiku-4-5
-  claude-code: claude-haiku-4-5-20251001
-  codex: gpt-5.1-codex
+  default: haiku
+  claude-code: haiku
+  codex: gpt-5-codex
 tools:
   - mcp__tilth__tilth_read
   - mcp__tilth__tilth_search

--- a/agents/cook.md.eta
+++ b/agents/cook.md.eta
@@ -2,9 +2,9 @@
 name: cook
 description: Implementation agent for the /cook flow. Makes failing tests pass with minimal, spec-scoped production changes.
 models:
-  default: gpt-5.1-codex
-  claude-code: claude-sonnet-4-5
-  codex: gpt-5.1-codex
+  default: sonnet
+  claude-code: sonnet
+  codex: gpt-5-codex
 tools:
   - mcp__tilth__tilth_read
   - mcp__tilth__tilth_search

--- a/agents/cut.md.eta
+++ b/agents/cut.md.eta
@@ -2,9 +2,9 @@
 name: cut
 description: Test-slicing agent for the /cook flow. Converts an approved spec into failing behavioral tests before implementation starts.
 models:
-  default: gpt-5.1-codex
-  claude-code: claude-sonnet-4-5
-  codex: gpt-5.1-codex
+  default: sonnet
+  claude-code: sonnet
+  codex: gpt-5-codex
 tools:
   - mcp__tilth__tilth_read
   - mcp__tilth__tilth_search

--- a/agents/milknado-executor.md.eta
+++ b/agents/milknado-executor.md.eta
@@ -2,9 +2,9 @@
 name: milknado-executor
 description: Executes a single ready Milknado node — applies file changes, runs quality gates, and reports completion status.
 models:
-  default: gpt-5.1-codex
-  claude-code: claude-sonnet-4-5
-  codex: gpt-5.1-codex
+  default: sonnet
+  claude-code: sonnet
+  codex: gpt-5-codex
 tools:
   - read
   - write

--- a/agents/milknado-planner.md.eta
+++ b/agents/milknado-planner.md.eta
@@ -2,9 +2,9 @@
 name: milknado-planner
 description: Decomposes a goal into a Mikado-style change manifest and populates the Milknado graph via MCP tools.
 models:
-  default: gpt-5.1-codex
-  claude-code: claude-sonnet-4-5
-  codex: gpt-5.1-codex
+  default: opus
+  claude-code: opus
+  codex: gpt-5-codex
 tools:
   - read
   - mcp__milknado__milknado_graph_summary

--- a/agents/press.md.eta
+++ b/agents/press.md.eta
@@ -2,9 +2,9 @@
 name: press
 description: Hardening agent for the /cook flow. Strengthens tests, presses boundaries, and completes adversarial self-evaluation after cook.
 models:
-  default: gpt-5.1-codex
-  claude-code: claude-sonnet-4-5
-  codex: gpt-5.1-codex
+  default: sonnet
+  claude-code: sonnet
+  codex: gpt-5-codex
 tools:
   - mcp__tilth__tilth_read
   - mcp__tilth__tilth_search

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -20,7 +20,7 @@ export const claudeCodeAdapter: HarnessAdapter = {
   agentDirectory: "agents",
   skillDirectory: "skills",
   commandDirectory: "commands",
-  defaultModel: "claude-sonnet-4-5",
+  defaultModel: "sonnet",
   notes: [
     "Use concise markdown headings and explicit tool guidance.",
     "Prefer Claude model identifiers in agent metadata and output.",

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -12,7 +12,7 @@ export const codexAdapter: HarnessAdapter = {
   agentDirectory: "agents",
   skillDirectory: "skills",
   commandDirectory: "commands",
-  defaultModel: "gpt-5.1-codex",
+  defaultModel: "gpt-5-codex",
   notes: [
     "Bias instructions toward patch-oriented execution and explicit constraints.",
     "Prefer Codex model identifiers in agent metadata and output.",

--- a/src/lib/compiler.ts
+++ b/src/lib/compiler.ts
@@ -15,6 +15,11 @@ import {
 import { emitHooks, emitMcpConfig, emitPluginManifest } from "./emit.js";
 import { parseFrontmatter } from "./frontmatter.js";
 import {
+  applyModelManifest,
+  type ModelManifest,
+  readModelManifest,
+} from "./model-manifest.js";
+import {
   type AgentFrontmatter,
   parseAgentFrontmatter,
   parseCommandFrontmatter,
@@ -97,12 +102,14 @@ type ProcessHarnessContext = {
   pluginMetadata: PluginMetadata;
   hooksSource: HooksSource;
   skillSourceDirectory: string;
+  modelManifest: ModelManifest | null;
 };
 
 export async function installHarnessArtifacts(
   options: InstallOptions,
 ): Promise<string[]> {
   const pluginMetadata = await readPluginMetadata(options.projectRoot);
+  const modelManifest = await readModelManifest(options.projectRoot);
   const hooksSource = await readHooksSource(options.projectRoot);
   const skillSourceDirectory = path.join(options.projectRoot, "skills");
   const outputs: string[] = [];
@@ -114,6 +121,7 @@ export async function installHarnessArtifacts(
         pluginMetadata,
         hooksSource,
         skillSourceDirectory,
+        modelManifest,
       }),
     );
   }
@@ -167,6 +175,7 @@ async function processHarness(context: ProcessHarnessContext): Promise<string> {
     projectRoot: context.projectRoot,
     harness: context.harnessName,
     agentOutputDirectory,
+    modelManifest: context.modelManifest,
   });
   const skills = await copySkills({
     projectRoot: context.projectRoot,
@@ -231,6 +240,7 @@ type CompileAgentsOptions = {
   projectRoot: string;
   harness: HarnessName;
   agentOutputDirectory: string;
+  modelManifest: ModelManifest | null;
 };
 
 async function compileAgents(options: CompileAgentsOptions): Promise<string[]> {
@@ -251,7 +261,13 @@ async function compileAgents(options: CompileAgentsOptions): Promise<string[]> {
     const frontmatter = parseAgentFrontmatter(parsed.data);
     const adapter = harnessAdapters[options.harness];
     const outputFile = `${frontmatter.name}.md`;
-    const resolvedModel = resolveModel(frontmatter.models, options.harness);
+    const baseModel = resolveModel(frontmatter.models, options.harness);
+    const resolvedModel = applyModelManifest({
+      model: baseModel,
+      agentName: frontmatter.name,
+      harness: options.harness,
+      manifest: options.modelManifest,
+    });
     const rendered = eta.renderString(parsed.body, {
       agent: { ...frontmatter, model: resolvedModel },
       harness: adapter,
@@ -381,11 +397,16 @@ export async function previewAgent(
   const source = await readFile(sourcePath, "utf8");
   const parsed = parseFrontmatter<unknown>(source);
   const frontmatter: AgentFrontmatter = parseAgentFrontmatter(parsed.data);
+  const manifest = await readModelManifest(projectRoot);
+  const baseModel = resolveModel(frontmatter.models, harness);
+  const resolvedModel = applyModelManifest({
+    model: baseModel,
+    agentName: frontmatter.name,
+    harness,
+    manifest,
+  });
   const rendered = eta.renderString(parsed.body, {
-    agent: {
-      ...frontmatter,
-      model: resolveModel(frontmatter.models, harness),
-    },
+    agent: { ...frontmatter, model: resolvedModel },
     harness: harnessAdapters[harness],
   }) as string;
 

--- a/src/lib/model-manifest.ts
+++ b/src/lib/model-manifest.ts
@@ -27,7 +27,9 @@ const overrideEntrySchema = z
 const modelManifestSchema = z
   .object({
     pins: pinsByHarnessSchema.optional(),
-    overrides: z.record(z.string().min(1), overrideEntrySchema).optional(),
+    overrides: z
+      .record(z.string().regex(/^[a-z][a-z0-9-]*$/), overrideEntrySchema)
+      .optional(),
   })
   .strict();
 
@@ -46,8 +48,16 @@ export async function readModelManifest(
     if (isFileNotFound(error)) return null;
     throw error;
   }
-  const parsed = parseYaml(raw) ?? {};
-  return modelManifestSchema.parse(parsed);
+  try {
+    const parsed = parseYaml(raw) ?? {};
+    return modelManifestSchema.parse(parsed);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown parse/validation error";
+    throw new Error(`Invalid models.yaml at ${manifestPath}: ${message}`, {
+      cause: error,
+    });
+  }
 }
 
 export function applyModelManifest(input: {

--- a/src/lib/model-manifest.ts
+++ b/src/lib/model-manifest.ts
@@ -1,0 +1,74 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+import type { HarnessName } from "../domain/harness.js";
+
+const harnessPinSchema = z.record(z.string().min(1), z.string().min(1));
+
+const pinsByHarnessSchema = z
+  .object({
+    "claude-code": harnessPinSchema.optional(),
+    codex: harnessPinSchema.optional(),
+    cursor: harnessPinSchema.optional(),
+    "copilot-cli": harnessPinSchema.optional(),
+  })
+  .strict();
+
+const overrideEntrySchema = z
+  .object({
+    "claude-code": z.string().min(1).optional(),
+    codex: z.string().min(1).optional(),
+    cursor: z.string().min(1).optional(),
+    "copilot-cli": z.string().min(1).optional(),
+  })
+  .strict();
+
+const modelManifestSchema = z
+  .object({
+    pins: pinsByHarnessSchema.optional(),
+    overrides: z.record(z.string().min(1), overrideEntrySchema).optional(),
+  })
+  .strict();
+
+export type ModelManifest = z.infer<typeof modelManifestSchema>;
+
+export const MODEL_MANIFEST_FILE = "models.yaml";
+
+export async function readModelManifest(
+  projectRoot: string,
+): Promise<ModelManifest | null> {
+  const manifestPath = path.join(projectRoot, MODEL_MANIFEST_FILE);
+  let raw: string;
+  try {
+    raw = await readFile(manifestPath, "utf8");
+  } catch (error) {
+    if (isFileNotFound(error)) return null;
+    throw error;
+  }
+  const parsed = parseYaml(raw) ?? {};
+  return modelManifestSchema.parse(parsed);
+}
+
+export function applyModelManifest(input: {
+  model: string;
+  agentName: string;
+  harness: HarnessName;
+  manifest: ModelManifest | null;
+}): string {
+  const { model, agentName, harness, manifest } = input;
+  if (manifest === null) return model;
+  const override = manifest.overrides?.[agentName]?.[harness];
+  if (override !== undefined) return override;
+  const pin = manifest.pins?.[harness]?.[model];
+  if (pin !== undefined) return pin;
+  return model;
+}
+
+function isFileNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: unknown }).code === "ENOENT"
+  );
+}

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -54,8 +54,12 @@ describe("installHarnessArtifacts", () => {
       "utf8",
     );
 
-    expect(claudeAgent).toContain("sonnet");
-    expect(codexAgent).toContain("gpt-5-codex");
+    expect(parseFrontmatter<{ model: string }>(claudeAgent).data.model).toBe(
+      "sonnet",
+    );
+    expect(parseFrontmatter<{ model: string }>(codexAgent).data.model).toBe(
+      "gpt-5-codex",
+    );
 
     // New emitters: plugin manifest + mcp config appear for both harnesses
     const claudePlugin = JSON.parse(

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -54,8 +54,8 @@ describe("installHarnessArtifacts", () => {
       "utf8",
     );
 
-    expect(claudeAgent).toContain("claude-sonnet-4-5");
-    expect(codexAgent).toContain("gpt-5.1-codex");
+    expect(claudeAgent).toContain("sonnet");
+    expect(codexAgent).toContain("gpt-5-codex");
 
     // New emitters: plugin manifest + mcp config appear for both harnesses
     const claudePlugin = JSON.parse(
@@ -120,7 +120,7 @@ describe("installHarnessArtifacts", () => {
       permissionMode: string;
     }>(cookAgent);
     expect(data.name).toBe("cook");
-    expect(data.model).toBe("claude-sonnet-4-5");
+    expect(data.model).toBe("sonnet");
     expect(data.skills).toEqual(["cheez-read", "cheez-search", "cheez-write"]);
     expect(data.color).toBe("blue");
     expect(data.permissionMode).toBe("acceptEdits");
@@ -158,7 +158,7 @@ describe("installHarnessArtifacts", () => {
       permissionMode?: string;
     }>(cookAgent);
     expect(data.name).toBe("cook");
-    expect(data.model).toBe("gpt-5.1-codex");
+    expect(data.model).toBe("gpt-5-codex");
     expect(data.skills).toBeUndefined();
     expect(data.color).toBeUndefined();
     expect(data.permissionMode).toBeUndefined();
@@ -166,6 +166,51 @@ describe("installHarnessArtifacts", () => {
     expect(cookAgent).toContain("- cheez-read");
     expect(cookAgent).toContain("- cheez-search");
     expect(cookAgent).toContain("- cheez-write");
+  });
+
+  it("applies models.yaml pins and overrides during install", async () => {
+    const projectRoot = await mkdtemp(
+      path.join(os.tmpdir(), "cheese-flow-manifest-install-"),
+    );
+    createdDirectories.push(projectRoot);
+    await cp(path.resolve("agents"), path.join(projectRoot, "agents"), {
+      recursive: true,
+    });
+    await cp(path.resolve("skills"), path.join(projectRoot, "skills"), {
+      recursive: true,
+    });
+    await writeFile(
+      path.join(projectRoot, "models.yaml"),
+      [
+        "pins:",
+        "  claude-code:",
+        "    sonnet: claude-sonnet-4-6",
+        "overrides:",
+        "  basic-agent:",
+        "    claude-code: claude-opus-4-7",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await installHarnessArtifacts({
+      projectRoot,
+      harnesses: ["claude-code"],
+    });
+
+    const cookAgent = await readFile(
+      path.join(projectRoot, ".claude", "agents", "cook.md"),
+      "utf8",
+    );
+    const cook = parseFrontmatter<{ model: string }>(cookAgent);
+    expect(cook.data.model).toBe("claude-sonnet-4-6");
+
+    const basicAgent = await readFile(
+      path.join(projectRoot, ".claude", "agents", "basic-agent.md"),
+      "utf8",
+    );
+    const basic = parseFrontmatter<{ model: string }>(basicAgent);
+    expect(basic.data.model).toBe("claude-opus-4-7");
   });
 
   it("validates the shipped skill metadata", async () => {

--- a/tests/model-manifest.test.ts
+++ b/tests/model-manifest.test.ts
@@ -1,0 +1,139 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  applyModelManifest,
+  type ModelManifest,
+  readModelManifest,
+} from "../src/lib/model-manifest.js";
+
+const created: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    created.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+async function makeProjectRoot(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "cheese-flow-manifest-"));
+  created.push(dir);
+  return dir;
+}
+
+describe("readModelManifest", () => {
+  it("returns null when models.yaml is absent", async () => {
+    const root = await makeProjectRoot();
+    expect(await readModelManifest(root)).toBeNull();
+  });
+
+  it("parses pins and overrides", async () => {
+    const root = await makeProjectRoot();
+    await writeFile(
+      path.join(root, "models.yaml"),
+      [
+        "pins:",
+        "  claude-code:",
+        "    sonnet: claude-sonnet-4-6",
+        "    opus: claude-opus-4-7",
+        "  codex:",
+        "    gpt-5-codex: gpt-5.3-codex",
+        "overrides:",
+        "  age-correctness:",
+        "    claude-code: claude-opus-4-7",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const manifest = await readModelManifest(root);
+    expect(manifest).toEqual({
+      pins: {
+        "claude-code": {
+          sonnet: "claude-sonnet-4-6",
+          opus: "claude-opus-4-7",
+        },
+        codex: { "gpt-5-codex": "gpt-5.3-codex" },
+      },
+      overrides: {
+        "age-correctness": { "claude-code": "claude-opus-4-7" },
+      },
+    });
+  });
+
+  it("rejects unknown harness keys via strict schema", async () => {
+    const root = await makeProjectRoot();
+    await writeFile(
+      path.join(root, "models.yaml"),
+      "pins:\n  qwen-code:\n    sonnet: foo\n",
+      "utf8",
+    );
+    await expect(readModelManifest(root)).rejects.toThrow();
+  });
+
+  it("treats an empty file as an empty manifest", async () => {
+    const root = await makeProjectRoot();
+    await writeFile(path.join(root, "models.yaml"), "", "utf8");
+    expect(await readModelManifest(root)).toEqual({});
+  });
+
+  it("propagates non-ENOENT read errors", async () => {
+    const root = await makeProjectRoot();
+    await mkdir(path.join(root, "models.yaml"), { recursive: true });
+    await expect(readModelManifest(root)).rejects.toThrow();
+  });
+});
+
+describe("applyModelManifest", () => {
+  const baseInput = {
+    model: "sonnet",
+    agentName: "age-correctness",
+    harness: "claude-code" as const,
+  };
+
+  it("returns the input model when manifest is null", () => {
+    expect(applyModelManifest({ ...baseInput, manifest: null })).toBe("sonnet");
+  });
+
+  it("returns the input model when no pin or override matches", () => {
+    const manifest: ModelManifest = {
+      pins: { codex: { "gpt-5-codex": "gpt-5.3-codex" } },
+    };
+    expect(applyModelManifest({ ...baseInput, manifest })).toBe("sonnet");
+  });
+
+  it("substitutes a pinned version when the alias matches the harness pin", () => {
+    const manifest: ModelManifest = {
+      pins: { "claude-code": { sonnet: "claude-sonnet-4-6" } },
+    };
+    expect(applyModelManifest({ ...baseInput, manifest })).toBe(
+      "claude-sonnet-4-6",
+    );
+  });
+
+  it("uses an override that supersedes any matching pin", () => {
+    const manifest: ModelManifest = {
+      pins: { "claude-code": { sonnet: "claude-sonnet-4-6" } },
+      overrides: {
+        "age-correctness": { "claude-code": "claude-opus-4-7" },
+      },
+    };
+    expect(applyModelManifest({ ...baseInput, manifest })).toBe(
+      "claude-opus-4-7",
+    );
+  });
+
+  it("ignores overrides for a different agent", () => {
+    const manifest: ModelManifest = {
+      overrides: { "age-security": { "claude-code": "claude-opus-4-7" } },
+    };
+    expect(applyModelManifest({ ...baseInput, manifest })).toBe("sonnet");
+  });
+
+  it("ignores pins for a different harness", () => {
+    const manifest: ModelManifest = {
+      pins: { codex: { sonnet: "gpt-5.5" } },
+    };
+    expect(applyModelManifest({ ...baseInput, manifest })).toBe("sonnet");
+  });
+});


### PR DESCRIPTION
## Summary

Implements portable model selection across cheese-flow with three key components: (1) **Alias migration** — replaces versioned IDs (e.g., `claude-sonnet-4-6`) with short tier aliases (`sonnet`, `haiku`, `opus`) in 16 agent templates and 2 adapter defaults, enabling models to survive version bumps without code changes; (2) **Tier rebalancing** — promotes 6 high-stakes age-* review dimensions from haiku to sonnet for better judgment quality, and elevates milknado-planner from sonnet to opus for orchestration; (3) **Optional manifest** — introduces `models.yaml` at repo root with `pins:` (global alias→version mapping) and `overrides:` (per-agent, per-harness surgical pins) for surgical version control without touching agent files.

All tests pass (30 compiler + 11 manifest manifest tests).

## Manifest Schema

Pins map aliases to full model IDs; overrides allow per-agent, per-harness overrides. Both are optional and isolated from agent definitions.

## Changes

- **16 agent templates** — Updated model frontmatter to use aliases
- **2 adapter defaults** — Switched to alias values
- **Compiler** — Integrated manifest reading and application
- **Tests** — 41 passing (new manifest test suite covers read/apply lifecycle)

Ready for review.