### PR TITLE
feat(skill-improver): port /skill-improver as 5-dim agent and skill auditor

### DIFF
--- a/agents/skill-improver-activation.md.eta
+++ b/agents/skill-improver-activation.md.eta
@@ -1,0 +1,88 @@
+---
+name: skill-improver-activation
+description: Activation reviewer in /skill-improver — surfaces description-as-trigger-spec gaps, missing trigger phrases, and frontmatter routing-field defects.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: red
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: activation
+  stake: high
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the activation reviewer in /skill-improver. Amplify the agent/skill author's attention; do not judge for them.
+
+Activation covers: the `description` field as a trigger spec for the routing model, the explicit trigger phrases users say, third-person voice, negative triggers for adjacent domains, keyword coverage, and portable frontmatter fields that affect invocation (`name`, skill `context`, agent `effort`, agent `permissionMode`). Skip tool reachability (tool-scoping owns it) and prompt body quality (prompt-quality owns it).
+
+## Patterns to look for
+
+1. **Description is a summary, not a trigger spec** — reads like "A tool for X" instead of listing user phrases that should activate it ("Use when the user says 'audit my agent', 'review skill', or invokes /skill-improver").
+2. **Missing trigger phrases** — no concrete `"..."` quoted phrases the routing model can match against user input.
+3. **First-person voice** — "I analyze ..." instead of "Analyses ..." or "Use when ...". Descriptions land in the system prompt; first-person breaks framing.
+4. **No negative triggers** — adjacent skills exist (e.g., /skill-improver vs /skill-creator) but the description does not say "Do NOT use for X".
+5. **Keyword gap** — the description omits common synonyms a user might try (e.g., mentions "audit" but not "review", "improve", "optimize").
+6. **Portable frontmatter routing fields wrong** — `context: fork` on a guideline-only skill (no actionable task), `effort` mismatched to an agent workload, or `permissionMode` inconsistent with the agent's role.
+7. **Description too short** — under ~20 chars or single sentence with no triggers; routing accuracy collapses.
+8. **`name` mismatch** — frontmatter `name` does not match the directory or filename slug.
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml` — target frontmatter, prompt outline, referenced files
+2. `skills/skill-improver/references/activation/protocol.md`
+
+If `evidence-pack.yaml` is malformed or missing, emit
+`{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}`
+and stop.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Set `fix` only when hash-anchored, syntactically narrow, and complete (e.g., a frontmatter line replacement). Otherwise leave `fix` unset and write a `consideration`.
+- `fix.category` must use a `activation.<sub>` namespace (e.g., `activation.missing_triggers`, `activation.first_person_voice`, `activation.routing_field_misuse`).
+- Never suggest unsupported frontmatter keys. The portable skill schema accepts `name`, `description`, `model`, `context`, `allowed-tools`, `metadata`, `license`, and `compatibility`; the agent schema accepts `name`, `description`, `models`, `tools`, `skills`, `color`, `effort`, `disallowedTools`, `permissionMode`, and `metadata`.
+- If the dim does not apply (target is a non-routing artifact, e.g., a fixture target with no real frontmatter), emit `{"observations": [], "scope_match": false}` and stop.
+
+## Output
+
+Write `$RUN_DIR/activation.json` per the per-agent return contract in
+`skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "activation",
+  "summary": "1-2 sentences",
+  "stake": "high",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "activation-1",
+      "file": "agents/foo.md.eta",
+      "anchor": {"start": "3:a3f", "end": "3:a3f"},
+      "narrative": "Description reads as a summary ('Reviews PR comments') rather than a trigger spec — no quoted user phrases, no /command reference, no negative triggers.",
+      "bucket": "high",
+      "evidence": ["agents/foo.md.eta:3 description: \"Reviews PR comments.\""],
+      "consideration": "Add explicit trigger phrases the routing model can match against user input (\"audit pr\", \"review feedback\") and a /command reference.",
+      "fix": {
+        "category": "activation.missing_triggers",
+        "content": "description: Reviews PR comments and routes fixes. Use when the user says \"audit pr\", \"review feedback\", or invokes /respond."
+      }
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/skill-improver-activation.md.eta
+++ b/agents/skill-improver-activation.md.eta
@@ -1,0 +1,87 @@
+---
+name: skill-improver-activation
+description: Activation reviewer in /skill-improver — surfaces description-as-trigger-spec gaps, missing trigger phrases, and frontmatter routing-field defects.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: red
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: activation
+  stake: high
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the activation reviewer in /skill-improver. Amplify the agent/skill author's attention; do not judge for them.
+
+Activation covers: the `description` field as a trigger spec for the routing model, the explicit trigger phrases users say, third-person voice, negative triggers for adjacent domains, keyword coverage, and frontmatter routing fields (`disable-model-invocation`, `effort`, `user-invocable`, `context: fork`, `agent`). Skip tool reachability (tool-scoping owns it) and prompt body quality (prompt-quality owns it).
+
+## Patterns to look for
+
+1. **Description is a summary, not a trigger spec** — reads like "A tool for X" instead of listing user phrases that should activate it ("Use when the user says 'audit my agent', 'review skill', or invokes /skill-improver").
+2. **Missing trigger phrases** — no concrete `"..."` quoted phrases the routing model can match against user input.
+3. **First-person voice** — "I analyze ..." instead of "Analyses ..." or "Use when ...". Descriptions land in the system prompt; first-person breaks framing.
+4. **No negative triggers** — adjacent skills exist (e.g., /skill-improver vs /skill-creator) but the description does not say "Do NOT use for X".
+5. **Keyword gap** — the description omits common synonyms a user might try (e.g., mentions "audit" but not "review", "improve", "optimize").
+6. **Frontmatter routing fields wrong** — `context: fork` on a guideline-only skill (no actionable task), `disable-model-invocation` missing on destructive skills, `effort` mismatched to the workload, `agent` missing when `context: fork` is set.
+7. **Description too short** — under ~20 chars or single sentence with no triggers; routing accuracy collapses.
+8. **`name` mismatch** — frontmatter `name` does not match the directory or filename slug.
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml` — target frontmatter, prompt outline, referenced files
+2. `skills/skill-improver/references/activation/protocol.md`
+
+If `evidence-pack.yaml` is malformed or missing, emit
+`{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}`
+and stop.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Set `fix` only when hash-anchored, syntactically narrow, and complete (e.g., a frontmatter line replacement). Otherwise leave `fix` unset and write a `consideration`.
+- `fix.category` must use a `activation.<sub>` namespace (e.g., `activation.missing_triggers`, `activation.first_person_voice`, `activation.routing_field_misuse`).
+- If the dim does not apply (target is a non-routing artifact, e.g., a fixture target with no real frontmatter), emit `{"observations": [], "scope_match": false}` and stop.
+
+## Output
+
+Write `$RUN_DIR/activation.json` per the per-agent return contract in
+`skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "activation",
+  "summary": "1-2 sentences",
+  "stake": "high",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "activation-1",
+      "file": "agents/foo.md.eta",
+      "anchor": {"start": "3:a3f", "end": "3:a3f"},
+      "narrative": "Description reads as a summary ('Reviews PR comments') rather than a trigger spec — no quoted user phrases, no /command reference, no negative triggers.",
+      "bucket": "high",
+      "evidence": ["agents/foo.md.eta:3 description: \"Reviews PR comments.\""],
+      "consideration": "Add explicit trigger phrases the routing model can match against user input (\"audit pr\", \"review feedback\") and a /command reference.",
+      "fix": {
+        "category": "activation.missing_triggers",
+        "content": "description: Reviews PR comments and routes fixes. Use when the user says \"audit pr\", \"review feedback\", or invokes /respond."
+      }
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/skill-improver-context.md.eta
+++ b/agents/skill-improver-context.md.eta
@@ -1,0 +1,101 @@
+---
+name: skill-improver-context
+description: Context reviewer in /skill-improver — surfaces fork-vs-inline mistakes, missing model rationale, prompt-size budget breaches, and missing wrap-up signals.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: yellow
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: context
+  stake: medium
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the context reviewer in /skill-improver. Amplify the agent/skill author's attention; do not judge for them.
+
+Context covers: fork vs inline decision, model selection with documented rationale, prompt size budget (≤ ~500 lines / ~1500 tokens), output size budget, sub-agent delegation for parallel work, and wrap-up signals for long-running agents. Skip prompt structure (prompt-quality owns it) and output schema (output-format owns it).
+
+## Heuristics
+
+| Decision | Rule |
+|---|---|
+| Fork (sub-agent) | Output > ~500 lines, only summary needed by caller, task is independent and idempotent |
+| Inline | Result is concise, immediately needed, action-relevant |
+| Prompt body | Aim for under 500 lines / ~1500 tokens. Beyond that, push detail into `references/` and read on demand |
+| Working context | Budget 20–40K tokens; > 60K shows instruction drift |
+| Output to caller | < 2K chars for summaries; write detail to a temp file, return a pointer |
+| Wrap-up signal | Long-running loops should declare a tool-call cap (e.g., "after ~60 tool calls, wrap up and emit") |
+
+## Patterns to look for
+
+1. **Should fork but runs inline** — skill produces verbose audit reports but lacks `context: fork`; pollutes orchestrator context.
+2. **Forks with no actionable task** — guideline-only skill (no input, just rules) declares `context: fork`; the sub-agent has nothing to do.
+3. **Missing model rationale** — `models.default` set without a prose justification (judgment-heavy → opus, focused fetch → haiku, implementation → sonnet).
+4. **Body exceeds 500 lines** — agent prompt over-explains and risks instruction drift; reference files should hold the long detail.
+5. **No output budget** — agent returns full diff/test output to caller; should write to `$RUN_DIR/<dim>.json` and return a one-line summary.
+6. **No sub-agent delegation for parallel work** — agent serially tries multiple strategies when 3 parallel sub-agents would be faster and isolated.
+7. **No wrap-up signal on long-running agents** — looping agents (research, retry, scrape) lack a tool-call cap; can run indefinitely.
+8. **Wrong tier in `metadata.effort`** — agent body is judgment-heavy but `effort: low` is set; routing model gets the wrong cost signal.
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml`
+2. `skills/skill-improver/references/context/protocol.md`
+
+If `evidence-pack.yaml` is malformed or missing, emit
+`{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}`
+and stop.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Set `fix` only when the change is a single frontmatter line (e.g., adding `context: fork`).
+- `fix.category` must use a `context.<sub>` namespace (e.g., `context.missing_fork`, `context.no_wrap_up`).
+- If the target has no behavioral footprint to evaluate (no body, no tools, no model), emit `{"observations": [], "scope_match": false}` and stop.
+
+## Output
+
+Write `$RUN_DIR/context.json` per the per-agent return contract in
+`skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "context",
+  "summary": "1-2 sentences",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "context-1",
+      "file": "skills/foo/SKILL.md",
+      "anchor": {"start": "5:f4a", "end": "5:f4a"},
+      "narrative": "Skill produces a multi-file audit report but runs inline; full report lands in the orchestrator's context window.",
+      "bucket": "med",
+      "evidence": [
+        "skills/foo/SKILL.md:5 frontmatter has no `context:` field",
+        "skills/foo/SKILL.md:120 'Render full audit table to caller.'"
+      ],
+      "consideration": "Add `context: fork` so the sub-agent runs in isolation and only the summary returns to the caller.",
+      "fix": {
+        "category": "context.missing_fork",
+        "content": "context: fork"
+      }
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/skill-improver-output-format.md.eta
+++ b/agents/skill-improver-output-format.md.eta
@@ -1,0 +1,89 @@
+---
+name: skill-improver-output-format
+description: Output-format reviewer in /skill-improver — surfaces missing summary-first layout, undefined output structure, threshold gaps, and unbounded output to caller.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: blue
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: output-format
+  stake: medium
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the output-format reviewer in /skill-improver. Amplify the agent/skill author's attention; do not judge for them.
+
+Output-format covers: summary-first layout, scannable tables for findings, threshold communication ("N findings below threshold"), separate summary from detail (temp-file pointer pattern), and structured output for downstream consumers. Skip narrative wording (prompt-quality owns it) and routing copy (activation owns it).
+
+## Patterns to look for
+
+1. **No summary-first** — agent dumps detail before any one-line assessment; reader has to scroll to learn the verdict.
+2. **No table for findings** — multiple findings emitted as prose paragraphs instead of a scannable table (id, category, file:line, narrative).
+3. **No threshold tally** — agent surfaces only findings above a threshold but never says "N findings below threshold (not shown)" — the reader cannot tell whether the agent looked.
+4. **Detail to caller, no temp file** — full report dumped into the caller's context; should write to `$RUN_DIR/<dim>.json` or a temp file and return only a pointer + summary.
+5. **Unstructured output** — downstream consumers (cleanup, fromage cook) can't parse the result because there's no JSON schema.
+6. **Missing schema reference** — agent emits JSON but does not link to the schema doc; future maintainers can't validate against drift.
+7. **No "clean run" signal** — agent emits identical-looking output for "0 findings" and "N findings"; reader can't grep for green.
+8. **Output mixes summary and detail** — one big block instead of `## Summary` (1-line) + `## Details` (table or pointer).
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml`
+2. `skills/skill-improver/references/output-format/protocol.md`
+
+If `evidence-pack.yaml` is malformed or missing, emit
+`{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}`
+and stop.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Set `fix` only when the change is a single contiguous block (e.g., a missing summary header). Whole-file rewrites go to `consideration`.
+- `fix.category` must use a `output-format.<sub>` namespace (e.g., `output-format.no_summary_first`, `output-format.no_threshold_tally`).
+- If the target produces no output at all (e.g., a fixture stub), emit `{"observations": [], "scope_match": false}` and stop.
+
+## Output
+
+Write `$RUN_DIR/output-format.json` per the per-agent return contract in
+`skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "output-format",
+  "summary": "1-2 sentences",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "output-format-1",
+      "file": "agents/foo.md.eta",
+      "anchor": {"start": "60:e7b", "end": "62:f8c"},
+      "narrative": "Output section dumps each finding as a paragraph; no scannable table and no threshold tally.",
+      "bucket": "med",
+      "evidence": [
+        "agents/foo.md.eta:60 'Emit each finding as a paragraph with file:line and narrative.'"
+      ],
+      "consideration": "Replace the prose loop with a Markdown table (id, category, file:line, narrative, bucket) and add a `Below threshold: N findings (not shown)` line so the reader knows you looked.",
+      "fix": {
+        "category": "output-format.no_threshold_tally",
+        "content": "Below threshold: <N> findings (not shown)"
+      }
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/skill-improver-prompt-quality.md.eta
+++ b/agents/skill-improver-prompt-quality.md.eta
@@ -1,0 +1,89 @@
+---
+name: skill-improver-prompt-quality
+description: Prompt-quality reviewer in /skill-improver — surfaces missing why-explanations, example gaps, decision-scaffold absences, and missing "What You Don't Do" sections.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: cyan
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: prompt-quality
+  stake: medium
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the prompt-quality reviewer in /skill-improver. Amplify the agent/skill author's attention; do not judge for them.
+
+Prompt-quality covers: structured sections, *why* explanations alongside rules, examples-over-rules, concise role framing, decision scaffolds for judgment tasks, a Gotchas section, and an explicit "What You Don't Do" / negative-constraint section. For judgment-shaped agents (review, audit, triage), surface missing **calibration scaffolds** — the rubric that tells the agent how to bucket findings (this folds the separate `scoring` concern into prompt quality). Skip activation/frontmatter (activation owns it) and output schema (output-format owns it).
+
+## Patterns to look for
+
+1. **Wall of text** — long unstructured prose where a table, bullets, or section break would scan faster.
+2. **Rule without why** — "Never use X" with no explanation of *why*. Brittle; fails edge cases. Pair every hard rule with the reason behind it.
+3. **No examples** — prescriptive instructions with zero concrete examples. One good example is worth ten rules.
+4. **Verbose role framing** — paragraph-long "You are..." opener instead of one tight sentence.
+5. **Missing "What You Don't Do" / negative constraints** — pipeline agents without explicit negatives have the most scope creep.
+6. **Missing Gotchas section** — known failure modes are not captured; they will recur.
+7. **Judgment task without a decision scaffold** — review/audit/triage agent uses "always/never" rules instead of a Classify → Ground → Context → Reassess pattern.
+8. **Judgment task without calibration scaffolds** — for review/audit agents, no rubric for how findings get bucketed (low/med/high). Flag as `prompt-quality.missing_calibration` with stake `med`. (Spec SI-1: this is the folded `scoring` concern.)
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml`
+2. `skills/skill-improver/references/prompt-quality/protocol.md`
+
+If `evidence-pack.yaml` is malformed or missing, emit
+`{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}`
+and stop.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Set `fix` only when the change is a single contiguous block addition (e.g., a missing "What You Don't Do" section). Multi-section rewrites go to `consideration`.
+- `fix.category` must use a `prompt-quality.<sub>` namespace (e.g., `prompt-quality.missing_what_you_dont_do`, `prompt-quality.missing_calibration`).
+- If the target has no body to evaluate (frontmatter-only stub), emit `{"observations": [], "scope_match": false}` and stop.
+
+## Output
+
+Write `$RUN_DIR/prompt-quality.json` per the per-agent return contract in
+`skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "prompt-quality",
+  "summary": "1-2 sentences",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "prompt-quality-1",
+      "file": "agents/foo.md.eta",
+      "anchor": {"start": "30:d3a", "end": "30:d3a"},
+      "narrative": "Pipeline reviewer agent has no \"What You Don't Do\" section, so scope-creep into adjacent dims is unconstrained.",
+      "bucket": "med",
+      "evidence": [
+        "agents/foo.md.eta:30 body ends with 'Output: ...' — no negative-constraint section"
+      ],
+      "consideration": "Add an explicit '## What You Don't Do' section listing the dims/decisions this agent must NOT touch (e.g., security concerns belong to security-dim, not here).",
+      "fix": {
+        "category": "prompt-quality.missing_what_you_dont_do",
+        "content": "## What You Don't Do\n\n- Make design decisions — that's /mold's job.\n- Add tests — that's /cook's job.\n- Review code quality — adjacent dims own those concerns."
+      }
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/skill-improver-prompt-quality.md.eta
+++ b/agents/skill-improver-prompt-quality.md.eta
@@ -1,0 +1,89 @@
+---
+name: skill-improver-prompt-quality
+description: Prompt-quality reviewer in /skill-improver — surfaces missing why-explanations, example gaps, decision-scaffold absences, and missing "What You Don't Do" sections.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: cyan
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: prompt-quality
+  stake: medium
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the prompt-quality reviewer in /skill-improver. Amplify the agent/skill author's attention; do not judge for them.
+
+Prompt-quality covers: structured sections, *why* explanations alongside rules, examples-over-rules, concise role framing, decision scaffolds for judgment tasks, a Gotchas section, and an explicit "What You Don't Do" / negative-constraint section. For judgment-shaped agents (review, audit, triage), surface missing **calibration scaffolds** — the rubric that tells the agent how to bucket findings (this folds the dotfiles `scoring` dim per spec SI-1). Skip activation/frontmatter (activation owns it) and output schema (output-format owns it).
+
+## Patterns to look for
+
+1. **Wall of text** — long unstructured prose where a table, bullets, or section break would scan faster.
+2. **Rule without why** — "Never use X" with no explanation of *why*. Brittle; fails edge cases. Pair every hard rule with the reason behind it.
+3. **No examples** — prescriptive instructions with zero concrete examples. One good example is worth ten rules.
+4. **Verbose role framing** — paragraph-long "You are..." opener instead of one tight sentence.
+5. **Missing "What You Don't Do" / negative constraints** — pipeline agents without explicit negatives have the most scope creep.
+6. **Missing Gotchas section** — known failure modes are not captured; they will recur.
+7. **Judgment task without a decision scaffold** — review/audit/triage agent uses "always/never" rules instead of a Classify → Ground → Context → Reassess pattern.
+8. **Judgment task without calibration scaffolds** — for review/audit agents, no rubric for how findings get bucketed (low/med/high). Flag as `prompt-quality.missing_calibration` with stake `med`. (Spec SI-1: this is the folded `scoring` concern.)
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml`
+2. `skills/skill-improver/references/prompt-quality/protocol.md`
+
+If `evidence-pack.yaml` is malformed or missing, emit
+`{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}`
+and stop.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Set `fix` only when the change is a single contiguous block addition (e.g., a missing "What You Don't Do" section). Multi-section rewrites go to `consideration`.
+- `fix.category` must use a `prompt-quality.<sub>` namespace (e.g., `prompt-quality.missing_what_you_dont_do`, `prompt-quality.missing_calibration`).
+- If the target has no body to evaluate (frontmatter-only stub), emit `{"observations": [], "scope_match": false}` and stop.
+
+## Output
+
+Write `$RUN_DIR/prompt-quality.json` per the per-agent return contract in
+`skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "prompt-quality",
+  "summary": "1-2 sentences",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "prompt-quality-1",
+      "file": "agents/foo.md.eta",
+      "anchor": {"start": "30:d3a", "end": "30:d3a"},
+      "narrative": "Pipeline reviewer agent has no \"What You Don't Do\" section, so scope-creep into adjacent dims is unconstrained.",
+      "bucket": "med",
+      "evidence": [
+        "agents/foo.md.eta:30 body ends with 'Output: ...' — no negative-constraint section"
+      ],
+      "consideration": "Add an explicit '## What You Don't Do' section listing the dims/decisions this agent must NOT touch (e.g., security concerns belong to security-dim, not here).",
+      "fix": {
+        "category": "prompt-quality.missing_what_you_dont_do",
+        "content": "## What You Don't Do\n\n- Make design decisions — that's /mold's job.\n- Add tests — that's /cook's job.\n- Review code quality — adjacent dims own those concerns."
+      }
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/skill-improver-tool-scoping.md.eta
+++ b/agents/skill-improver-tool-scoping.md.eta
@@ -1,0 +1,99 @@
+---
+name: skill-improver-tool-scoping
+description: Tool-scoping reviewer in /skill-improver — surfaces tier mismatches, read-only claims with reachable write tools, and skill-delegation gaps.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: orange
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: tool-scoping
+  stake: high
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the tool-scoping reviewer in /skill-improver. Amplify the agent/skill author's attention; do not judge for them.
+
+Tool-scoping covers: which tier the target falls into (read-only / write-scoped / focused sub-agent), whether the `tools` allowlist and any `disallowedTools` align with the stated role, and whether `skills:` declarations match the agent's actual delegation pattern. Skip frontmatter routing fields (activation owns them) and narrative quality (prompt-quality owns it).
+
+## The three-tier model
+
+| Tier | Tools | Use case | Frontmatter signal |
+|---|---|---|---|
+| Read-only | tilth_read, tilth_search, optional bash | Reviewers, auditors, explorers | `tools` excludes write tools; `disallowedTools` only if the host grants broad defaults |
+| Write-scoped | + tilth_edit | Implementers, fixers | `tools` enumerates only what is used |
+| Focused sub-agent | 2-4 tools max | Pipeline sub-tasks | Tight `tools` list, no `disallowedTools` needed because nothing else is allowed in |
+
+## Patterns to look for
+
+1. **Read-only claim with write tools reachable** — agent body says "this is a read-only reviewer" but `tools` includes write-capable entries (`mcp__tilth__tilth_edit`, `Edit`, `Write`, `NotebookEdit`) or the target has no explicit allowlist in a host that grants broad defaults.
+2. **Tier mismatch** — agent declares `tools: [tilth_edit]` but the body says "do not modify files".
+3. **Over-broad `tools`** — focused sub-agent declares 8+ tools when 2-3 would suffice. Each unused tool burns context budget on tool-decision noise.
+4. **`skills:` missing the actual delegation** — agent body uses `cheez-search` but `skills` only lists `cheez-read`.
+5. **`skills:` over-listed** — agent declares 5+ skills but the body never invokes most of them.
+6. **Wrong namespace** — `tools: [Read]` instead of `mcp__tilth__tilth_read`; the host won't expose plain `Read` to plugin sub-agents.
+7. **False-positive guard** — do NOT flag a review agent just because `disallowedTools` is absent when `tools` is an explicit read-only allowlist.
+8. **Stale `disallowedTools`** — listed tool that no longer exists in the platform.
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml`
+2. `skills/skill-improver/references/tool-scoping/protocol.md`
+
+If `evidence-pack.yaml` is malformed or missing, emit
+`{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}`
+and stop.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Set `fix` only when the change is a single-line frontmatter replacement.
+- `fix.category` must use a `tool-scoping.<sub>` namespace (e.g., `tool-scoping.prose_only_readonly`, `tool-scoping.over_broad_tools`).
+- If the target has no `tools` block at all (e.g., a skill SKILL.md without `allowed-tools`), emit `{"observations": [], "scope_match": false}` and stop.
+- Surface activation-shaped findings (description quality, trigger phrases) to the activation dim, not here.
+
+## Output
+
+Write `$RUN_DIR/tool-scoping.json` per the per-agent return contract in
+`skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "tool-scoping",
+  "summary": "1-2 sentences",
+  "stake": "high",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "tool-scoping-1",
+      "file": "agents/foo.md.eta",
+      "anchor": {"start": "8:b1c", "end": "10:c2d"},
+      "narrative": "Body declares 'this reviewer never edits source' but frontmatter includes a write-capable tool, so edits are reachable despite the prose constraint.",
+      "bucket": "high",
+      "evidence": [
+        "agents/foo.md.eta:8 tools: [mcp__tilth__tilth_read, Edit]",
+        "agents/foo.md.eta:25 'You are a read-only reviewer.'"
+      ],
+      "consideration": "Drop the write-capable tool from `tools`. If the host grants broad defaults outside this allowlist, also add disallowedTools: [Edit, Write, NotebookEdit].",
+      "fix": {
+        "category": "tool-scoping.prose_only_readonly",
+        "content": "tools:\n  - mcp__tilth__tilth_read"
+      }
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/skill-improver-tool-scoping.md.eta
+++ b/agents/skill-improver-tool-scoping.md.eta
@@ -1,0 +1,99 @@
+---
+name: skill-improver-tool-scoping
+description: Tool-scoping reviewer in /skill-improver — surfaces tier mismatches, prose-only "read-only" claims without disallowedTools, and skill-delegation gaps.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: orange
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: tool-scoping
+  stake: high
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the tool-scoping reviewer in /skill-improver. Amplify the agent/skill author's attention; do not judge for them.
+
+Tool-scoping covers: which tier the target falls into (read-only / write-scoped / focused sub-agent), whether `tools` and `disallowedTools` align with the stated role, and whether `skills:` declarations match the agent's actual delegation pattern. Skip frontmatter routing fields (activation owns them) and narrative quality (prompt-quality owns it).
+
+## The three-tier model
+
+| Tier | Tools | Use case | Frontmatter signal |
+|---|---|---|---|
+| Read-only | tilth_read, tilth_search, optional bash | Reviewers, auditors, explorers | `disallowedTools` blocks Edit/Write/NotebookEdit |
+| Write-scoped | + tilth_edit | Implementers, fixers | `tools` enumerates only what is used |
+| Focused sub-agent | 2-4 tools max | Pipeline sub-tasks | Tight `tools` list, no `disallowedTools` needed because nothing else is allowed in |
+
+## Patterns to look for
+
+1. **Prose-only "read-only"** — agent body says "this is a read-only reviewer" but `disallowedTools` is missing. Models with write tools available take irreversible actions when stuck.
+2. **Tier mismatch** — agent declares `tools: [tilth_edit]` but the body says "do not modify files".
+3. **Over-broad `tools`** — focused sub-agent declares 8+ tools when 2-3 would suffice. Each unused tool burns context budget on tool-decision noise.
+4. **`skills:` missing the actual delegation** — agent body uses `cheez-search` but `skills` only lists `cheez-read`.
+5. **`skills:` over-listed** — agent declares 5+ skills but the body never invokes most of them.
+6. **Wrong namespace** — `tools: [Read]` instead of `mcp__tilth__tilth_read`; the host won't expose plain `Read` to plugin sub-agents.
+7. **Missing `disallowedTools` on a "review" intent agent** — `metadata.intent: review` should pair with a Read/Write block list.
+8. **Stale `disallowedTools`** — listed tool that no longer exists in the platform.
+
+## Inputs (in order)
+
+1. `$RUN_DIR/evidence-pack.yaml`
+2. `skills/skill-improver/references/tool-scoping/protocol.md`
+
+If `evidence-pack.yaml` is malformed or missing, emit
+`{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}`
+and stop.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Set `fix` only when the change is a single-line frontmatter replacement.
+- `fix.category` must use a `tool-scoping.<sub>` namespace (e.g., `tool-scoping.prose_only_readonly`, `tool-scoping.over_broad_tools`).
+- If the target has no `tools` block at all (e.g., a skill SKILL.md without `allowed-tools`), emit `{"observations": [], "scope_match": false}` and stop.
+- Surface activation-shaped findings (description quality, trigger phrases) to the activation dim, not here.
+
+## Output
+
+Write `$RUN_DIR/tool-scoping.json` per the per-agent return contract in
+`skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "tool-scoping",
+  "summary": "1-2 sentences",
+  "stake": "high",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "tool-scoping-1",
+      "file": "agents/foo.md.eta",
+      "anchor": {"start": "8:b1c", "end": "10:c2d"},
+      "narrative": "Body declares 'this reviewer never edits source' but frontmatter has no disallowedTools, so Edit is reachable.",
+      "bucket": "high",
+      "evidence": [
+        "agents/foo.md.eta:8 tools: [mcp__tilth__tilth_read, Edit]",
+        "agents/foo.md.eta:25 'You are a read-only reviewer.'"
+      ],
+      "consideration": "Either drop Edit from tools or add disallowedTools: [Edit] to make the prose constraint enforceable.",
+      "fix": {
+        "category": "tool-scoping.prose_only_readonly",
+        "content": "disallowedTools:\n  - Edit\n  - Write"
+      }
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/commands/cheese.md
+++ b/commands/cheese.md
@@ -27,6 +27,7 @@ dispatch occurs.
 | Bug report / stack trace | pasted error, reproduction steps | debug flow (investigate → `/cook`) |
 | File path or glob | `src/auth/login.ts`, `src/**/*.tsx` | focused review (`/age --scope`) |
 | Research question | "what's the best rate limiter library?" | `/briesearch` |
+| Agent/skill quality | "review my agent", "audit this skill", `agents/foo.md.eta` | `/skill-improver` |
 
 ## Dispatch contract
 

--- a/commands/skill-improver.md
+++ b/commands/skill-improver.md
@@ -1,0 +1,83 @@
+---
+name: skill-improver
+description: Audit an agent or skill definition file. Runs five orthogonal LLM dimensions (activation, tool-scoping, context, prompt-quality, output-format) over a single agent or skill source file and emits a stake-weighted report plus hash-anchored sidecar JSON consumed by /cleanup.
+argument-hint: "<agent-path | skill-path>"
+---
+
+# /skill-improver
+
+`/skill-improver` is an evidence-first auditor for cheese-flow's own agent
+and skill definitions. It surfaces where to look and why, with verifiable
+evidence per observation, so the author can decide what to act on instead
+of accepting a verdict on faith.
+
+Five orthogonal dimensions fan out in parallel over a single target file.
+Each dimension emits evidence-backed observations. The orchestrator
+synthesizes a stake-weighted report and two sidecar JSON files for
+downstream automation.
+
+## Execution
+
+Invoke the `skill-improver` skill with `$ARGUMENTS`. The skill owns
+target classification, evidence pre-fetch, parallel dim dispatch,
+synthesis, sidecar emission, and cleanup.
+
+Do not reimplement orchestration in this command. This file is the
+user-facing contract; `skills/skill-improver/SKILL.md` is the implementation.
+
+## Dimensions
+
+| Dim | Stake | What it reviews |
+|---|---|---|
+| `activation` | high | Description as trigger spec, trigger phrases, third-person voice, negative triggers, portable frontmatter invocation fields |
+| `tool-scoping` | high | Read-only / write-scoped / focused-sub-agent tier match; reachable write tools versus prose claims; `skills:` aligned with delegation |
+| `context` | medium | Fork vs inline decision, model rationale, prompt-size budget, output budget, wrap-up signals |
+| `prompt-quality` | medium | Structured sections, *why* explanations, examples, decision scaffolds, "What You Don't Do" sections, calibration scaffolds for judgment agents |
+| `output-format` | medium | Summary-first layout, scannable tables, threshold tally, detail-vs-summary separation, structured output for downstream consumers |
+
+All 5 dims fire on every run. Dims whose rubric does not apply emit
+`scope_match: false` and are tallied but not rendered as sections.
+
+## Output Contract
+
+Three artifacts written to `.cheese/skill-improver/<slug>.*`:
+
+- **`<slug>.md`** — stake-weighted Markdown report:
+  - Orientation paragraph (target kind, model tier, tool surface, line count)
+  - Tally line (ran 5; N had findings)
+  - High-stake dims → medium-stake dims
+  - Cross-dimension callouts (loci where 2+ dims agree)
+- **`<slug>.fixes.json`** — hash-anchored, mechanically-applicable fixes
+  ready for `tilth_edit`. Consumed by `/cleanup` (same schema as `/age`).
+- **`<slug>.suggestions.json`** — narrative-shaped guidance keyed by
+  observation `id`. Consumed by `/fromage cook`.
+
+Confidence is bucketed (`low | med | high`). No numeric scores anywhere
+in the output.
+
+## Hand-off
+
+`/skill-improver` performs no writes to source files. After the report
+prints, the next step is yours:
+
+```
+/cleanup skill-improver/<slug>         — apply mechanical fixes
+/fromage cook --suggestions <slug>     — act on judgment guidance
+```
+
+The amplifier-pure boundary forbids auto-invoke (FR-8). The report is
+the deliverable; action is the user's call.
+
+## When to Use
+
+- Before merging a new agent or skill to catch activation, tool-scoping,
+  and context defects.
+- After writing initial agent/skill code to validate frontmatter contracts.
+- Anytime you want evidence-backed observations rather than a verdict.
+
+## What this command does NOT do
+
+- Does not generate new agents or skills from scratch — that is `/skill-creator`.
+- Does not audit arbitrary external agents or skills unless they follow
+  cheese-flow's frontmatter and sidecar contracts.
+- Does not apply fixes — `/cleanup` does that, and only after you ask it to.

--- a/commands/skill-improver.md
+++ b/commands/skill-improver.md
@@ -1,0 +1,82 @@
+---
+name: skill-improver
+description: Audit an agent or skill definition file. Runs five orthogonal LLM dimensions (activation, tool-scoping, context, prompt-quality, output-format) over a single agent or skill source file and emits a stake-weighted report plus hash-anchored sidecar JSON consumed by /cleanup.
+argument-hint: "<agent-path | skill-path>"
+---
+
+# /skill-improver
+
+`/skill-improver` is an evidence-first auditor for cheese-flow's own agent
+and skill definitions. It surfaces where to look and why, with verifiable
+evidence per observation, so the author can decide what to act on instead
+of accepting a verdict on faith.
+
+Five orthogonal dimensions fan out in parallel over a single target file.
+Each dimension emits evidence-backed observations. The orchestrator
+synthesizes a stake-weighted report and two sidecar JSON files for
+downstream automation.
+
+## Execution
+
+Invoke the `skill-improver` skill with `$ARGUMENTS`. The skill owns
+target classification, evidence pre-fetch, parallel dim dispatch,
+synthesis, sidecar emission, and cleanup.
+
+Do not reimplement orchestration in this command. This file is the
+user-facing contract; `skills/skill-improver/SKILL.md` is the implementation.
+
+## Dimensions
+
+| Dim | Stake | What it reviews |
+|---|---|---|
+| `activation` | high | Description as trigger spec, trigger phrases, third-person voice, negative triggers, frontmatter routing fields |
+| `tool-scoping` | high | Read-only / write-scoped / focused-sub-agent tier match; `disallowedTools` matching prose claims; `skills:` aligned with delegation |
+| `context` | medium | Fork vs inline decision, model rationale, prompt-size budget, output budget, wrap-up signals |
+| `prompt-quality` | medium | Structured sections, *why* explanations, examples, decision scaffolds, "What You Don't Do" sections, calibration scaffolds for judgment agents |
+| `output-format` | medium | Summary-first layout, scannable tables, threshold tally, detail-vs-summary separation, structured output for downstream consumers |
+
+All 5 dims fire on every run. Dims whose rubric does not apply emit
+`scope_match: false` and are tallied but not rendered as sections.
+
+## Output Contract
+
+Three artifacts written to `.cheese/skill-improver/<slug>.*`:
+
+- **`<slug>.md`** — stake-weighted Markdown report:
+  - Orientation paragraph (target kind, model tier, tool surface, line count)
+  - Tally line (ran 5; N had findings)
+  - High-stake dims → medium-stake dims
+  - Cross-dimension callouts (loci where 2+ dims agree)
+- **`<slug>.fixes.json`** — hash-anchored, mechanically-applicable fixes
+  ready for `tilth_edit`. Consumed by `/cleanup` (same schema as `/age`).
+- **`<slug>.suggestions.json`** — narrative-shaped guidance keyed by
+  observation `id`. Consumed by `/fromage cook`.
+
+Confidence is bucketed (`low | med | high`). No numeric scores anywhere
+in the output.
+
+## Hand-off
+
+`/skill-improver` performs no writes to source files. After the report
+prints, the next step is yours:
+
+```
+/cleanup <slug>                        — apply mechanical fixes
+/fromage cook --suggestions <slug>     — act on judgment guidance
+```
+
+The amplifier-pure boundary forbids auto-invoke (FR-8). The report is
+the deliverable; action is the user's call.
+
+## When to Use
+
+- Before merging a new agent or skill to catch activation, tool-scoping,
+  and context defects.
+- After writing initial agent/skill code to validate frontmatter contracts.
+- Anytime you want evidence-backed observations rather than a verdict.
+
+## What this command does NOT do
+
+- Does not generate new agents or skills from scratch — that is `/skill-creator`.
+- Does not audit dotfiles agents or skills outside cheese-flow.
+- Does not apply fixes — `/cleanup` does that, and only after you ask it to.

--- a/justfile
+++ b/justfile
@@ -100,6 +100,47 @@ test-age-fixtures:
         exit 1
     fi
 
+# Run /skill-improver fixture comparator against every dim under tests/skill-improver-fixtures/
+test-skill-improver-fixtures:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    fixtures_dir="tests/skill-improver-fixtures"
+    if [ ! -d "$fixtures_dir" ]; then
+        echo "no fixtures directory at $fixtures_dir" >&2
+        exit 1
+    fi
+    shopt -s nullglob
+    dim_dirs=("$fixtures_dir"/*/)
+    if [ "${#dim_dirs[@]}" -eq 0 ]; then
+        echo "no fixture subdirectories found under $fixtures_dir" >&2
+        exit 1
+    fi
+    failures=0
+    for dim_dir in "${dim_dirs[@]}"; do
+        dim=$(basename "$dim_dir")
+        expected="$dim_dir/expected.json"
+        actual="$dim_dir/actual.json"
+        if [ ! -f "$expected" ]; then
+            echo "$dim: missing expected.json" >&2
+            failures=$((failures + 1))
+            continue
+        fi
+        if [ ! -f "$actual" ]; then
+            echo "$dim: missing actual.json (run /skill-improver first to populate)" >&2
+            failures=$((failures + 1))
+            continue
+        fi
+        if uv run python python/tools/age_fixture_diff.py "$actual" "$expected"; then
+            echo "$dim: ok"
+        else
+            echo "$dim: FAIL" >&2
+            failures=$((failures + 1))
+        fi
+    done
+    if [ "$failures" -gt 0 ]; then
+        echo "$failures fixture(s) failed" >&2
+        exit 1
+    fi
 # Clean build artifacts and caches
 clean:
     rm -rf dist coverage

--- a/justfile
+++ b/justfile
@@ -90,6 +90,47 @@ test-age-fixtures:
         exit 1
     fi
 
+# Run /skill-improver fixture comparator against every dim under tests/skill-improver-fixtures/
+test-skill-improver-fixtures:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    fixtures_dir="tests/skill-improver-fixtures"
+    if [ ! -d "$fixtures_dir" ]; then
+        echo "no fixtures directory at $fixtures_dir" >&2
+        exit 1
+    fi
+    shopt -s nullglob
+    dim_dirs=("$fixtures_dir"/*/)
+    if [ "${#dim_dirs[@]}" -eq 0 ]; then
+        echo "no fixture subdirectories found under $fixtures_dir" >&2
+        exit 1
+    fi
+    failures=0
+    for dim_dir in "${dim_dirs[@]}"; do
+        dim=$(basename "$dim_dir")
+        expected="$dim_dir/expected.json"
+        actual="$dim_dir/actual.json"
+        if [ ! -f "$expected" ]; then
+            echo "$dim: missing expected.json" >&2
+            failures=$((failures + 1))
+            continue
+        fi
+        if [ ! -f "$actual" ]; then
+            echo "$dim: missing actual.json (run /skill-improver first to populate)" >&2
+            failures=$((failures + 1))
+            continue
+        fi
+        if uv run python python/tools/age_fixture_diff.py "$actual" "$expected"; then
+            echo "$dim: ok"
+        else
+            echo "$dim: FAIL" >&2
+            failures=$((failures + 1))
+        fi
+    done
+    if [ "$failures" -gt 0 ]; then
+        echo "$failures fixture(s) failed" >&2
+        exit 1
+    fi
 # Clean build artifacts and caches
 clean:
     rm -rf dist coverage

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cleanup
-description: Mechanical apply of /age's hash-anchored sidecar fixes via tilth_edit. The cleanup-wolf sub-agent is the only LLM in the path, fired per anchor mismatch.
+description: Mechanical apply of hash-anchored sidecar fixes via tilth_edit. Supports /age slugs and source-qualified sidecars such as skill-improver/<slug>; cleanup-wolf is the only LLM in the path.
 license: MIT
 compatibility: Requires Claude Code >= 2.1.30 / claude-agent-sdk >= 0.2.63 (tilth_edit must be exposed to plugin sub-agents).
 metadata:
@@ -15,26 +15,37 @@ allowed-tools:
 ---
 # Cleanup — Mechanical Fix Apply
 
-Apply `/age` sidecar fixes mechanically via `tilth_edit`. No LLM in the
-happy path. The `cleanup-wolf` sub-agent fires only on hash mismatch.
+Apply sidecar fixes mechanically via `tilth_edit`. No LLM in the happy
+path. The `cleanup-wolf` sub-agent fires only on hash mismatch.
 
 ## Arguments
 
 ```
-/cleanup <slug>
+/cleanup <slug | source/slug>
 ```
 
-`slug` is the same slug produced by `/age`. Resolves to:
+Plain `<slug>` is backward-compatible with `/age` and resolves to:
 
 ```
 .cheese/age/<slug>.fixes.json
 ```
 
+Source-qualified slugs resolve under that source directory:
+
+```
+/cleanup age/<slug>              -> .cheese/age/<slug>.fixes.json
+/cleanup skill-improver/<slug>   -> .cheese/skill-improver/<slug>.fixes.json
+```
+
+Only `age` and `skill-improver` are valid sources. Reject any other
+`source/slug` before loading files.
+
 All harnesses share the project-root `.cheese/` runtime directory.
 
 ## Phase 1 — Load
 
-Load `.cheese/age/<slug>.fixes.json`.
+Resolve the fixes path from the argument, then load
+`.cheese/<source>/<slug>.fixes.json`.
 
 Validate schema: every entry must have all of
 `id`, `dimension`, `file`, `anchor`, `content`, `rationale`, `category`.
@@ -45,8 +56,8 @@ invalid `id` values. Do not apply any fixes from a malformed file.
 If the file does not exist, fail fast:
 
 ```
-ERROR: .cheese/age/<slug>.fixes.json not found.
-Run /age first to generate the fixes sidecar.
+ERROR: .cheese/<source>/<slug>.fixes.json not found.
+Run the matching review skill first to generate the fixes sidecar.
 ```
 
 ## Phase 2 — Apply Each Fix
@@ -92,7 +103,7 @@ match and applies with `tilth_edit`. Returns one of:
 
 ## Phase 3 — Emit Report
 
-Write `.cheese/age/<slug>.cleanup-report.md`:
+Write `.cheese/<source>/<slug>.cleanup-report.md`:
 
 ```markdown
 # Cleanup Report — <slug>

--- a/skills/skill-improver/SKILL.md
+++ b/skills/skill-improver/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: skill-improver
+description: Agent and skill code auditor. Runs five orthogonal LLM dimensions (activation, tool-scoping, context, prompt-quality, output-format) and emits evidence-backed observations with optional hash-anchored fixes.
+license: MIT
+compatibility: Requires Claude Code >= 2.1.30 / claude-agent-sdk >= 0.2.63 (older versions cannot expose tilth tools to plugin sub-agents).
+metadata:
+  owner: cheese-flow
+  category: review
+allowed-tools:
+  - read
+  - write
+  - bash
+  - subagent
+  - mcp
+---
+
+# skill-improver — Agent and Skill Auditor
+
+Amplify the agent/skill author's attention. Surface evidence, unknowns, and
+activation defects. Do not render verdicts.
+
+## Compatibility Check
+
+Before dispatching agents, verify `tilth_*` MCP tools are available to
+plugin sub-agents. If unavailable, fail fast:
+
+```
+ERROR: tilth MCP tools are not exposed to sub-agents.
+Upgrade to Claude Code >= 2.1.30 / claude-agent-sdk >= 0.2.63.
+See: anthropics/claude-code#13605
+```
+
+Do not attempt graceful degradation. The dim agents require `tilth_read`
+and `tilth_search`; without them every agent silently misses evidence.
+
+## Always-Fire Rationale
+
+All 5 dims fire on every invocation. Gating by heuristics risks silent misses.
+Each agent self-noops with `scope_match: false` + empty observations when its
+rubric does not apply. Empty dims are tallied; only non-empty dims render as
+report sections.
+
+## Arguments
+
+```
+/skill-improver <agent-path | skill-path>
+```
+
+- `path` — path to the target agent (e.g., `agents/foo.md.eta`)
+  or skill (e.g., `skills/foo/SKILL.md`).
+- With no path, ask the user (mirrors `/mold`'s "if no path, ask" rule).
+
+## Phase 0 — Classify (no LLM)
+
+Parse argv: extract target path. Validate file exists. Classify as agent or skill.
+
+```bash
+TARGET="$1"
+if [ ! -f "$TARGET" ]; then
+  echo "ERROR: File not found: $TARGET" >&2
+  exit 1
+fi
+SLUG="$(basename "$TARGET" | tr '/:.-' '----' | head -c 32)"
+RUN_DIR="${TMPDIR:-/tmp}/cheese-flow-skill-improver-$(date +%Y%m%d-%H%M%S)-${SLUG}"
+mkdir -p "$RUN_DIR"
+```
+
+## Phase 1 — Pre-fetch Evidence (parallel)
+
+Run all fetches in parallel. Merge into `$RUN_DIR/evidence-pack.yaml`.
+
+**Parallel tasks:**
+
+- `cheez-read $TARGET` → full file content
+- `cheez-search <symbols-in-target>` → usages and definitions
+- Parse frontmatter with `parseFrontmatter()` → extract metadata
+
+**Merge into evidence pack:**
+
+```yaml
+# $RUN_DIR/evidence-pack.yaml
+target: <TARGET>
+target_type: agent|skill
+source: <full file content>
+frontmatter: <parsed frontmatter object>
+outline: <cheez-read outline mode>
+usages: <cheez-search results>
+```
+
+No inline source in outline mode; agents use `cheez-read` for follow-up reads.
+
+## Phase 2 — Dispatch All 5 Dim Agents (parallel)
+
+Spawn all agents in parallel. Each agent:
+- Reads `$RUN_DIR/evidence-pack.yaml` as primary evidence
+- Reads `references/<dim>/protocol.md` for the per-dim rubric
+- Calls `cheez-read $TARGET` directly for follow-up source reads
+- Writes `$RUN_DIR/<dim>.json` per the per-agent return contract
+
+Agents to dispatch:
+- `skill-improver-activation`
+- `skill-improver-tool-scoping`
+- `skill-improver-context`
+- `skill-improver-prompt-quality`
+- `skill-improver-output-format`
+
+Pass to each agent: `RUN_DIR`, `TARGET`, `TARGET_TYPE`.
+
+When a dim does not apply, it emits:
+
+```json
+{"dimension": "<dim>", "scope_match": false, "observations": [], "stake": "<dim-stake>", "summary": "Dim does not apply."}
+```
+
+## Phase 3 — Synthesize (orchestrator, deterministic; no LLM)
+
+Collect all `$RUN_DIR/<dim>.json` files.
+
+**Render Markdown report** → `.cheese/skill-improver/<slug>.md`:
+
+```
+# Skill-Improver Report — <slug>
+
+## Orientation
+<1-2 sentence factual description of the target file>
+
+Ran 5 dims. <N> had findings. <5-N> were empty.
+
+## High-Stake Dimensions
+(activation, tool-scoping — non-empty only)
+
+## Medium-Stake Dimensions
+(context, prompt-quality, output-format — non-empty only)
+
+## Cross-Dimension Callouts
+(loci where 2+ dims agree; omit if empty)
+```
+
+**Split observations into sidecar JSON files:**
+
+`.cheese/skill-improver/<slug>.fixes.json`:
+- observations with a `fix` field (hash-anchored, syntactically complete)
+
+`.cheese/skill-improver/<slug>.suggestions.json`:
+- observations with `consideration` only (no `fix`)
+
+Both match the schema in `skills/age/references/sidecar-schema.md` (shared with
+/age and /cleanup for cross-flow reuse via cleanup-wolf).
+
+## Phase 4 — Hand-off (no auto-invoke)
+
+Print:
+
+```
+Skill-improver report: .cheese/skill-improver/<slug>.md
+Fixes:                 .cheese/skill-improver/<slug>.fixes.json   (<N> entries)
+Suggestions:           .cheese/skill-improver/<slug>.suggestions.json   (<M> entries)
+
+Next steps:
+  /cleanup <slug>                           — apply mechanical fixes
+  /fromage cook --suggestions <slug>        — act on judgment guidance
+```
+
+Do NOT auto-invoke either skill. The amplifier-pure boundary forbids it
+(spec FR-8, SI-3 inheriting `/age` D-14-final). The report is the
+deliverable; action is the user's call.
+
+## Phase 5 — Cleanup
+
+```bash
+rm -rf "$RUN_DIR"
+```
+
+## Rules
+
+- File I/O from dim agents via `cheez-read` / `cheez-search` (NFR-1).
+  No host `Read` / `Grep` / `Edit`, no direct `tilth_edit`.
+- Hash anchors use tilth `line:hash` strings natively (NFR-2).
+- No numeric scores in user-facing output.
+- Confidence rendered as `low | med | high` bucket only.
+- Narrative before bucket in every observation.
+- No writes to production source files during review. `/cleanup` is the
+  only path that writes; `/skill-improver` never invokes it (FR-8).
+- Dim stake is fixed per dim; do not vary at runtime.

--- a/skills/skill-improver/SKILL.md
+++ b/skills/skill-improver/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: skill-improver
+description: Agent and skill code auditor. Runs five orthogonal LLM dimensions (activation, tool-scoping, context, prompt-quality, output-format) and emits evidence-backed observations with optional hash-anchored fixes.
+license: MIT
+compatibility: Requires Claude Code >= 2.1.30 / claude-agent-sdk >= 0.2.63 (older versions cannot expose tilth tools to plugin sub-agents).
+metadata:
+  owner: cheese-flow
+  category: review
+allowed-tools:
+  - read
+  - write
+  - bash
+  - subagent
+  - mcp
+---
+
+# skill-improver — Agent and Skill Auditor
+
+Amplify the agent/skill author's attention. Surface evidence, unknowns, and
+activation defects. Do not render verdicts.
+
+## Compatibility Check
+
+Before dispatching agents, verify `tilth_*` MCP tools are available to
+plugin sub-agents. If unavailable, fail fast:
+
+```
+ERROR: tilth MCP tools are not exposed to sub-agents.
+Upgrade to Claude Code >= 2.1.30 / claude-agent-sdk >= 0.2.63.
+See: anthropics/claude-code#13605
+```
+
+Do not attempt graceful degradation. The dim agents require `tilth_read`
+and `tilth_search`; without them every agent silently misses evidence.
+
+## Always-Fire Rationale
+
+All 5 dims fire on every invocation. Gating by heuristics risks silent misses.
+Each agent self-noops with `scope_match: false` + empty observations when its
+rubric does not apply. Empty dims are tallied; only non-empty dims render as
+report sections.
+
+## Arguments
+
+```
+/skill-improver <agent-path | skill-path>
+```
+
+- `path` — path to the target agent (e.g., `agents/foo.md.eta`)
+  or skill (e.g., `skills/foo/SKILL.md`).
+- With no path, ask the user (mirrors `/mold`'s "if no path, ask" rule).
+
+## Phase 0 — Classify (no LLM)
+
+Parse argv: extract target path. Validate file exists. Classify as agent or skill.
+
+```bash
+TARGET="$1"
+if [ ! -f "$TARGET" ]; then
+  echo "ERROR: File not found: $TARGET" >&2
+  exit 1
+fi
+SLUG="$(
+  printf '%s' "$TARGET" |
+    sed -E 's#^\./##; s#/SKILL\.md$##; s#\.md\.eta$##; s#[^A-Za-z0-9]+#-#g; s#^-+|-+$##g' |
+    tr '[:upper:]' '[:lower:]' |
+    cut -c 1-64
+)"
+if [ -z "$SLUG" ]; then
+  echo "ERROR: Could not derive slug from target: $TARGET" >&2
+  exit 1
+fi
+RUN_DIR="${TMPDIR:-/tmp}/cheese-flow-skill-improver-$(date +%Y%m%d-%H%M%S)-${SLUG}"
+mkdir -p "$RUN_DIR"
+```
+
+## Phase 1 — Pre-fetch Evidence (parallel)
+
+Run all fetches in parallel. Merge into `$RUN_DIR/evidence-pack.yaml`.
+
+**Parallel tasks:**
+
+- `cheez-read $TARGET` → full file content
+- `cheez-search <symbols-in-target>` → usages and definitions
+- Parse frontmatter with `parseFrontmatter()` → extract metadata
+
+**Merge into evidence pack:**
+
+```yaml
+# $RUN_DIR/evidence-pack.yaml
+target: <TARGET>
+target_type: agent|skill
+source: <full file content>
+frontmatter: <parsed frontmatter object>
+outline: <cheez-read outline mode>
+usages: <cheez-search results>
+```
+
+No inline source in outline mode; agents use `cheez-read` for follow-up reads.
+
+## Phase 2 — Dispatch All 5 Dim Agents (parallel)
+
+Spawn all agents in parallel. Each agent:
+- Reads `$RUN_DIR/evidence-pack.yaml` as primary evidence
+- Reads `references/<dim>/protocol.md` for the per-dim rubric
+- Calls `cheez-read $TARGET` directly for follow-up source reads
+- Writes `$RUN_DIR/<dim>.json` per the per-agent return contract
+
+Agents to dispatch:
+- `skill-improver-activation`
+- `skill-improver-tool-scoping`
+- `skill-improver-context`
+- `skill-improver-prompt-quality`
+- `skill-improver-output-format`
+
+Pass to each agent: `RUN_DIR`, `TARGET`, `TARGET_TYPE`.
+
+When a dim does not apply, it emits:
+
+```json
+{"dimension": "<dim>", "scope_match": false, "observations": [], "stake": "<dim-stake>", "summary": "Dim does not apply."}
+```
+
+## Phase 3 — Synthesize (orchestrator, deterministic; no LLM)
+
+Collect all `$RUN_DIR/<dim>.json` files.
+
+**Render Markdown report** → `.cheese/skill-improver/<slug>.md`:
+
+```
+# Skill-Improver Report — <slug>
+
+## Orientation
+<1-2 sentence factual description of the target file>
+
+Ran 5 dims. <N> had findings. <5-N> were empty.
+
+## High-Stake Dimensions
+(activation, tool-scoping — non-empty only)
+
+## Medium-Stake Dimensions
+(context, prompt-quality, output-format — non-empty only)
+
+## Cross-Dimension Callouts
+(loci where 2+ dims agree; omit if empty)
+```
+
+**Split observations into sidecar JSON files:**
+
+`.cheese/skill-improver/<slug>.fixes.json`:
+- observations with a `fix` field (hash-anchored, syntactically complete)
+
+`.cheese/skill-improver/<slug>.suggestions.json`:
+- observations with `consideration` only (no `fix`)
+
+Both match the schema in `skills/age/references/sidecar-schema.md` (shared with
+/age and /cleanup for cross-flow reuse via cleanup-wolf).
+
+## Phase 4 — Hand-off (no auto-invoke)
+
+Print:
+
+```
+Skill-improver report: .cheese/skill-improver/<slug>.md
+Fixes:                 .cheese/skill-improver/<slug>.fixes.json   (<N> entries)
+Suggestions:           .cheese/skill-improver/<slug>.suggestions.json   (<M> entries)
+
+Next steps:
+  /cleanup skill-improver/<slug>            — apply mechanical fixes
+  /fromage cook --suggestions <slug>        — act on judgment guidance
+```
+
+Do NOT auto-invoke either skill. The amplifier-pure boundary forbids it
+(spec FR-8, SI-3 inheriting `/age` D-14-final). The report is the
+deliverable; action is the user's call.
+
+## Phase 5 — Cleanup
+
+```bash
+rm -rf "$RUN_DIR"
+```
+
+## Rules
+
+- File I/O from dim agents via `cheez-read` / `cheez-search` (NFR-1).
+  No host `Read` / `Grep` / `Edit`, no direct `tilth_edit`.
+- Hash anchors use tilth `line:hash` strings natively (NFR-2).
+- No numeric scores in user-facing output.
+- Confidence rendered as `low | med | high` bucket only.
+- Narrative before bucket in every observation.
+- No writes to production source files during review. `/cleanup` is the
+  only path that writes; `/skill-improver` never invokes it (FR-8).
+- Dim stake is fixed per dim; do not vary at runtime.

--- a/skills/skill-improver/references/activation/protocol.md
+++ b/skills/skill-improver/references/activation/protocol.md
@@ -1,0 +1,104 @@
+# Activation Dim — Protocol
+
+The activation reviewer treats the `description` field as a **trigger
+specification** for the routing model, not a summary for humans. It also
+inspects frontmatter routing fields that affect when and how the target
+is invoked.
+
+## Why this dim exists
+
+Skills under-trigger at a baseline of ~20%. Most of the gap is structural,
+not semantic: routing models match on **explicit phrasing** that the
+description provides, not on inferred intent. A description that reads
+as a summary ("A tool for X") is a routing miss.
+
+## Three-part description pattern
+
+Effective descriptions follow:
+
+```
+[Core capability]. [Secondary capabilities]. Use when [trigger1],
+[trigger2], or when user mentions "[keyword1]", "[keyword2]".
+```
+
+Stronger when it ends with `or invokes /<command-name>` so the routing
+model can also match on slash-command intent.
+
+## Failure modes (with examples)
+
+### `activation.summary_not_trigger`
+
+```yaml
+# Bad
+description: A tool for reviewing PR comments.
+
+# Good
+description: Review PR comments and route fixes. Use when the user says
+  "audit pr", "review feedback", "respond to PR", or invokes /respond.
+```
+
+### `activation.first_person_voice`
+
+The description is injected into the routing model's system prompt.
+First-person breaks the framing.
+
+```yaml
+# Bad
+description: I review PR comments and propose fixes.
+
+# Good
+description: Reviews PR comments and proposes fixes.
+```
+
+### `activation.missing_negative_triggers`
+
+When two skills have adjacent domains, both routing decisions are
+ambiguous. Negative triggers disambiguate.
+
+```yaml
+# /skill-improver
+description: ... Do NOT use for creating new skills from scratch — use
+  /skill-creator for that.
+```
+
+### `activation.keyword_gap`
+
+The description must list synonyms users actually say. Missing common
+phrasings = missed activations.
+
+| Concept | Cover at least these |
+|---|---|
+| review | review, audit, check, inspect, evaluate |
+| improve | improve, optimize, tighten, refactor, clean up |
+| trigger | trigger, activate, fire, route, match |
+
+### `activation.routing_field_misuse`
+
+Frontmatter routing fields with documented semantics:
+
+| Field | When to set |
+|---|---|
+| `disable-model-invocation: true` | Destructive or infrequently-needed skills (only `/cmd` triggers) |
+| `effort: high` | Research-heavy or judgment-heavy skills |
+| `effort: low` | Simple formatting / fetch tasks |
+| `user-invocable: false` | Background skills that should not appear in `/` menu |
+| `context: fork` | Skill reads ≥30 files or produces verbose output |
+| `agent` | Pairs with `context: fork` to specify subagent type |
+
+Common defects:
+
+- `context: fork` on a guideline-only skill (no actionable task → empty subagent)
+- `disable-model-invocation` missing on a destructive skill
+- `effort: low` on a judgment-heavy review skill
+
+### `activation.name_directory_mismatch`
+
+For skills, `frontmatter.name` must equal the parent directory name
+(enforced by `lint-skills-directory`). Surface as `bucket: high` because
+linting will fail outright.
+
+## What this dim does NOT do
+
+- Does not evaluate prompt body quality — that's prompt-quality.
+- Does not evaluate tool reachability — that's tool-scoping.
+- Does not evaluate output structure — that's output-format.

--- a/skills/skill-improver/references/activation/protocol.md
+++ b/skills/skill-improver/references/activation/protocol.md
@@ -1,0 +1,108 @@
+# Activation Dim — Protocol
+
+The activation reviewer treats the `description` field as a **trigger
+specification** for the routing model, not a summary for humans. It also
+inspects portable frontmatter fields that affect when and how the target
+is invoked.
+
+## Why this dim exists
+
+Skills under-trigger at a baseline of ~20%. Most of the gap is structural,
+not semantic: routing models match on **explicit phrasing** that the
+description provides, not on inferred intent. A description that reads
+as a summary ("A tool for X") is a routing miss.
+
+## Three-part description pattern
+
+Effective descriptions follow:
+
+```
+[Core capability]. [Secondary capabilities]. Use when [trigger1],
+[trigger2], or when user mentions "[keyword1]", "[keyword2]".
+```
+
+Stronger when it ends with `or invokes /<command-name>` so the routing
+model can also match on slash-command intent.
+
+## Failure modes (with examples)
+
+### `activation.summary_not_trigger`
+
+```yaml
+# Bad
+description: A tool for reviewing PR comments.
+
+# Good
+description: Review PR comments and route fixes. Use when the user says
+  "audit pr", "review feedback", "respond to PR", or invokes /respond.
+```
+
+### `activation.first_person_voice`
+
+The description is injected into the routing model's system prompt.
+First-person breaks the framing.
+
+```yaml
+# Bad
+description: I review PR comments and propose fixes.
+
+# Good
+description: Reviews PR comments and proposes fixes.
+```
+
+### `activation.missing_negative_triggers`
+
+When two skills have adjacent domains, both routing decisions are
+ambiguous. Negative triggers disambiguate.
+
+```yaml
+# /skill-improver
+description: ... Do NOT use for creating new skills from scratch — use
+  /skill-creator for that.
+```
+
+### `activation.keyword_gap`
+
+The description must list synonyms users actually say. Missing common
+phrasings = missed activations.
+
+| Concept | Cover at least these |
+|---|---|
+| review | review, audit, check, inspect, evaluate |
+| improve | improve, optimize, tighten, refactor, clean up |
+| trigger | trigger, activate, fire, route, match |
+
+### `activation.routing_field_misuse`
+
+Portable frontmatter fields with documented invocation semantics:
+
+| Field | When to set |
+|---|---|
+| `name` | Must match the command filename, agent filename, or skill directory slug |
+| Skill `context: fork` | Skill reads many files or produces verbose output |
+| Skill `context: inline` | Skill result is concise and immediately action-relevant |
+| Agent `effort: high` | Research-heavy or judgment-heavy agent |
+| Agent `effort: low` | Simple formatting or fetch agent |
+| Agent `permissionMode` | Only when the agent role really needs non-default edit permission |
+
+Common defects:
+
+- `context: fork` on a guideline-only skill (no actionable task → empty subagent)
+- `effort: low` on a judgment-heavy review agent
+- `permissionMode: acceptEdits` on a read-only review agent
+- frontmatter `name` mismatches the path slug
+
+Do not suggest unsupported frontmatter keys; the compiler rejects any key
+not accepted by the portable schemas.
+
+### `activation.name_directory_mismatch`
+
+For skills, `frontmatter.name` must equal the parent directory name
+(enforced by `lint-skills-directory`). Surface as `bucket: high` because
+linting will fail outright.
+
+## What this dim does NOT do
+
+- Does not evaluate prompt body quality — that's prompt-quality.
+- Does not evaluate tool reachability — that's tool-scoping.
+- Does not evaluate output structure — that's output-format.

--- a/skills/skill-improver/references/context/protocol.md
+++ b/skills/skill-improver/references/context/protocol.md
@@ -1,0 +1,121 @@
+# Context Dim — Protocol
+
+The context reviewer checks whether the target manages its context
+budget responsibly: fork vs inline, model selection with rationale,
+prompt size budget, output budget, sub-agent delegation, and wrap-up
+signals.
+
+## Why this dim exists
+
+Every token in an agent's context competes with the task. Agents that
+produce or consume too much context degrade their own performance and
+their orchestrator's. Context budgets are the difference between a
+skill that scales across long sessions and one that pollutes the
+parent's context after a few invocations.
+
+## Decision rules
+
+### Fork vs inline
+
+**Fork (`context: fork`) when at least one of:**
+- Output > ~500 lines (build logs, test runs, large diffs).
+- Only a summary is needed by the caller, not the raw content.
+- The task is independent and idempotent (re-runnable).
+
+**Inline when all of:**
+- Result is concise, immediately needed, action-relevant.
+- The skill is guideline-only (no actionable task → forking returns nothing useful).
+
+### Model selection
+
+| Model | When |
+|---|---|
+| `claude-opus-4-X` | Judgment-heavy: review, architecture, complex reasoning |
+| `claude-sonnet-4-X` | Implementation, exploration, most general work |
+| `claude-haiku-4-X` | Focused fetch, simple transforms, token-constrained sub-agents |
+
+Document the rationale in the agent body. A `model: claude-haiku-4-5`
+declaration without prose justification is a finding (`context.missing_model_rationale`).
+
+### Prompt size budget
+
+| Size | Behavior |
+|---|---|
+| < 500 lines / ~1500 tokens | Strong instruction following |
+| 500–800 lines | Risk of mid-prompt drift |
+| > 800 lines | Push detail into `references/` and read on demand |
+
+### Output budget
+
+| Direction | Budget |
+|---|---|
+| Agent → caller | < 2K chars summary; write detail to `$RUN_DIR/<dim>.json` and return a pointer |
+| Inline skill output | Should fit without scrolling |
+| Forked sub-agent output | Caller only sees the return value; pointer pattern still recommended for very long detail |
+
+### Wrap-up signals
+
+Long-running agents (research loops, retry chains, scrapers) need a
+tool-call cap or they run indefinitely. Pattern:
+
+> After ~60 tool calls, wrap up the current finding and emit your
+> output. Do not start a new investigation.
+
+## Failure modes
+
+### `context.missing_fork`
+
+Skill produces verbose output (multi-file audits, full reports) but
+runs inline. Caller's context absorbs the entire report.
+
+### `context.fork_with_no_task`
+
+Guideline-only skill declares `context: fork`. The sub-agent has no
+actionable prompt and returns nothing useful.
+
+### `context.missing_model_rationale`
+
+`models.default` set without prose justification. Future maintainers
+can't tell whether `haiku` was intentional or copied.
+
+### `context.body_too_long`
+
+Prompt body > 500 lines. Push protocol detail into `references/<topic>.md`
+and read on demand.
+
+### `context.no_output_budget`
+
+Agent dumps full diff/test/build output to caller. Should write to
+`$RUN_DIR/<dim>.json` and return a one-line summary + pointer.
+
+### `context.no_subagent_delegation`
+
+Agent serially tries multiple strategies (fetch from 3 sources, review
+from 3 angles) when 3 parallel sub-agents would be faster and isolate
+context.
+
+### `context.no_wrap_up_signal`
+
+Long-running loop has no tool-call cap. Risk: indefinite runtime,
+context degradation.
+
+### `context.effort_mismatch`
+
+`metadata.effort: low` set on a judgment-heavy agent (or vice versa).
+Routing model gets the wrong cost signal.
+
+## Stake calibration
+
+| Defect | Default bucket |
+|---|---|
+| `missing_fork` on a verbose-output skill | `med` |
+| `fork_with_no_task` (subagent gets nothing) | `med` |
+| `body_too_long` (drift risk) | `med` |
+| `missing_model_rationale` | `low` |
+| `no_wrap_up_signal` on a long-running loop | `med` |
+
+## What this dim does NOT do
+
+- Does not evaluate description trigger phrases — that's activation.
+- Does not evaluate which tools are wired — that's tool-scoping.
+- Does not evaluate output schema — that's output-format.

--- a/skills/skill-improver/references/fixture-protocol.md
+++ b/skills/skill-improver/references/fixture-protocol.md
@@ -1,0 +1,131 @@
+# Fixture Protocol
+
+L2 quality gate for `/skill-improver`. One fixture per dim under
+`tests/skill-improver-fixtures/<dim>/`. Runnable via
+`just test-skill-improver-fixtures`.
+
+The protocol mirrors `skills/age/references/fixture-protocol.md` but the
+input is a target file rather than a diff (per spec FR-1, SI-5).
+
+---
+
+## Directory layout
+
+```
+tests/skill-improver-fixtures/
+  <dim>/
+    target.md.eta   -- seeded agent or skill definition with one
+                       deliberate defect that the dim's rubric should
+                       catch. Real-shape file, not synthetic stub.
+    expected.json   -- subset of the per-agent return contract
+```
+
+One directory per dim: `activation`, `tool-scoping`, `context`,
+`prompt-quality`, `output-format`.
+
+---
+
+## `expected.json` schema
+
+A subset of the per-agent return contract (`skills/age/references/sidecar-schema.md`).
+Only fields used by the comparator need to be present:
+
+```json
+{
+  "dimension": "<dim>",
+  "observations": [
+    {
+      "id": "<dim>-1",
+      "bucket": "high",
+      "narrative": "...",
+      "anchor": {"start": "3:000"}
+    }
+  ]
+}
+```
+
+Required fields per observation: `id`, `bucket`, `narrative`,
+`anchor.start`. All other fields (`evidence`, `consideration`, `fix`,
+etc.) are optional in `expected.json` and ignored by the comparator.
+
+Hash digits are placeholders (`000`); the comparator only uses the line
+number prefix and ignores the hash component (per `age_fixture_diff.py`
+tolerances).
+
+---
+
+## Comparison tolerances (reused from /age)
+
+`python/tools/age_fixture_diff.py` (no fork, no copy) enforces:
+
+| Field | Rule |
+|---|---|
+| `dimension` | Exact match |
+| `bucket` | Exact match (`low`, `med`, or `high`) |
+| `narrative` | Levenshtein ratio ≥ 0.6 via `difflib.SequenceMatcher` |
+| `anchor.start` (line number) | Within ±1 of expected (hash ignored) |
+
+Any observation failing one of the four rules fails the L2 gate. Other
+fields are informational only.
+
+---
+
+## How `just test-skill-improver-fixtures` works
+
+The justfile loops each dim directory and calls the comparator with two
+explicit file arguments:
+
+```bash
+python python/tools/age_fixture_diff.py <dim>/actual.json <dim>/expected.json
+```
+
+The comparator:
+
+1. Receives `actual.json` (written by the dim agent during a real
+   `/skill-improver` run against `target.md.eta`) and `expected.json`
+   (the checked-in fixture).
+2. Verifies the `dimension` field matches.
+3. Matches observations by `id` first (exact), then falls back to fuzzy
+   scoring. Each actual observation is consumed at most once.
+4. Exits non-zero if any expected observation is unmatched; prints a
+   JSON summary with `misses` for each failure.
+
+The recipe expects `actual.json` to be present per dim. Run the dim
+agent against the seeded target to populate it before invoking the
+gate (mirrors `/age`'s flow).
+
+---
+
+## Adding a fixture
+
+1. Create `tests/skill-improver-fixtures/<dim>/target.md.eta` — a real
+   agent or skill definition with **one deliberate defect** the dim's
+   rubric should catch.
+2. Run `/skill-improver tests/skill-improver-fixtures/<dim>/target.md.eta`
+   to generate the dim's `actual.json`.
+3. Copy `actual.json` to `expected.json` and trim to only the fields
+   required by the comparator schema above.
+4. Run `just test-skill-improver-fixtures` and confirm the fixture
+   passes baseline.
+5. Commit both `target.md.eta` and `expected.json`.
+
+The seeded defect must be specific to the dim under test — e.g., a
+`activation` fixture has a description-as-summary defect, not a
+tool-scoping one. Cross-dim fixtures dilute the L2 signal.
+
+---
+
+## Failure modes
+
+**missing id** — `expected.json` references an observation `id` that is
+absent from `actual.json` and no fuzzy match succeeds. Reported in
+`misses`.
+
+**missing actual.json** — the dim agent did not write output. Fail with:
+`missing actual.json (run /skill-improver first to populate)`.
+
+**bucket mismatch** — actual bucket differs from expected. Exact match
+required.
+
+**narrative drift** — Levenshtein ratio below 0.6. Update
+`expected.json` when the narrative intentionally changes.

--- a/skills/skill-improver/references/output-format/protocol.md
+++ b/skills/skill-improver/references/output-format/protocol.md
@@ -1,0 +1,132 @@
+# Output-Format Dim — Protocol
+
+The output-format reviewer checks the structure of the target's emitted
+output: summary-first layout, scannable tables, threshold communication,
+detail-vs-summary separation, and structured output for downstream consumers.
+
+## Why this dim exists
+
+Reports that mix summary and detail, or that scatter findings across
+prose paragraphs, force the reader to do parser work. Structured output
+also lets downstream skills (`/cleanup`, `/fromage cook`) act on
+findings without LLM intervention.
+
+## Patterns the dim looks for
+
+### `output-format.no_summary_first`
+
+Detail comes before any one-line assessment. Reader must scroll to
+learn the verdict.
+
+```
+# Bad
+... 80 lines of detail ...
+Result: ready to merge.
+
+# Good
+**Result: ready to merge** (3 findings, all bucketed as `med`).
+
+... 80 lines of detail ...
+```
+
+### `output-format.no_findings_table`
+
+Multiple findings emitted as prose paragraphs instead of a scannable
+table. Use a table when there are ≥ 2 findings.
+
+```
+| id | category | file:line | narrative | bucket |
+|---|---|---|---|---|
+| activation-1 | activation.missing_triggers | agents/foo.md.eta:3 | Description has no quoted user phrases. | high |
+```
+
+### `output-format.no_threshold_tally`
+
+Agent applies a threshold (e.g., surface only findings at `med` or
+`high`) but never declares "N findings below threshold (not shown)".
+Reader can't tell whether the agent looked.
+
+```
+Surfacing 4 findings (`med` and above).
+Below threshold: 7 findings (not shown).
+```
+
+### `output-format.detail_to_caller`
+
+Full report dumped into caller's context. Should write to
+`$RUN_DIR/<dim>.json` (or a named temp file) and return only a
+pointer + summary.
+
+```
+Report: $RUN_DIR/skill-improver/<slug>.md
+Fixes:  $RUN_DIR/skill-improver/<slug>.fixes.json   (3 entries)
+Suggestions: $RUN_DIR/skill-improver/<slug>.suggestions.json (5 entries)
+```
+
+### `output-format.unstructured_output`
+
+Output is freeform prose. Downstream consumers can't parse it.
+Structured JSON output is required when:
+
+- Findings are intended for `/cleanup` consumption.
+- Findings feed into `/fromage cook --suggestions`.
+- The output appears in a CI log that needs grepping.
+
+### `output-format.no_clean_run_signal`
+
+Identical-looking output for "0 findings" and "N findings". Reader
+can't grep for green. Add a one-line state header:
+
+```
+Status: clean (0 findings).
+```
+
+### `output-format.no_schema_reference`
+
+Agent emits JSON without linking to a schema doc. Future maintainers
+can't verify drift. Reference `skills/age/references/sidecar-schema.md`
+for /age-shaped output (which /skill-improver reuses per spec SI-2).
+
+## Layout pattern (summary-first + detail)
+
+```markdown
+## Summary
+
+<one-line verdict>
+
+| dim | findings | high | med | low |
+|---|---|---|---|---|
+
+## High-stakes findings
+
+### <dim>
+
+<observation block>
+
+## Medium-stakes findings
+
+### <dim>
+
+<observation block>
+
+## Below threshold
+
+<N> findings (not shown).
+```
+
+## Stake calibration
+
+| Defect | Default bucket |
+|---|---|
+| `unstructured_output` on a report-emitting agent | `med` |
+| `no_summary_first` | `med` |
+| `no_threshold_tally` | `med` |
+| `detail_to_caller` (context pollution) | `med` |
+| `no_clean_run_signal` | `low` |
+| `no_schema_reference` | `low` |
+
+## What this dim does NOT do
+
+- Does not evaluate description routing copy — that's activation.
+- Does not evaluate tool reachability — that's tool-scoping.
+- Does not evaluate prompt body wording — that's prompt-quality.

--- a/skills/skill-improver/references/prompt-quality/protocol.md
+++ b/skills/skill-improver/references/prompt-quality/protocol.md
@@ -1,0 +1,107 @@
+# Prompt-Quality Dim — Protocol
+
+The prompt-quality reviewer checks the body's clarity and structure:
+sections, *why* explanations, examples, role framing, decision scaffolds,
+gotchas, "What You Don't Do" sections, and (for judgment agents)
+calibration scaffolds.
+
+This dim folds the separate `scoring` concern under the
+`prompt-quality.missing_calibration` finding. Not all agents are judgment
+agents, so calibration is a sub-rubric here rather than a standalone dim.
+
+## Why this dim exists
+
+Prompt structure has measurable effects on instruction following:
+
+- Tables and bulleted rules are followed more reliably than prose.
+- Rules paired with *why* generalize to edge cases; rules without it
+  fail on novel inputs.
+- One concrete example outperforms ten abstract rules.
+
+## Patterns the dim looks for
+
+### `prompt-quality.wall_of_text`
+
+Long prose blocks where a table or bullets would scan faster. Heuristic:
+> 30 consecutive lines without a heading, table, or list.
+
+### `prompt-quality.rule_without_why`
+
+Hard rules ("Never use `find`") with no rationale. Brittle. Pair every
+rule with the reason behind it.
+
+```
+# Bad
+Never use `find`.
+
+# Good
+Use `fd` instead of `find` because fd respects .gitignore and is faster
+on large repos. (Rule: avoid `find`.)
+```
+
+### `prompt-quality.no_examples`
+
+Prescriptive instructions with zero concrete examples. Add at least
+one. Two establish a pattern. Three confirm it.
+
+### `prompt-quality.verbose_role_framing`
+
+Paragraph-long "You are..." opener instead of one tight sentence.
+
+```
+# Bad
+You are a sophisticated agent designed to perform comprehensive and
+thoughtful audits of agent and skill definitions, taking into account
+the user's preferences and the broader project context...
+
+# Good
+You are the activation reviewer in /skill-improver. Amplify the
+author's attention; do not judge for them.
+```
+
+### `prompt-quality.missing_what_you_dont_do`
+
+Pipeline agents without an explicit "What You Don't Do" / negative
+constraints section have the most scope creep with adjacent phases.
+
+### `prompt-quality.missing_gotchas`
+
+No "Gotchas" section. These prevent repeated failures and are the
+highest-value content per token.
+
+### `prompt-quality.missing_decision_scaffold`
+
+Judgment task using "always/never" rules instead of a structured
+scaffold (Classify → Ground → Context → Reassess; or
+degrees-of-freedom). Match constraint level to risk.
+
+### `prompt-quality.missing_calibration` (folds the `scoring` concern)
+
+For review/audit/triage agents, no rubric for how findings are
+bucketed. The agent will pattern-match the rubric description rather
+than apply calibrated probabilities.
+
+A good calibration scaffold:
+
+1. **Classify the claim type** — base bucket + cap per type.
+2. **Evidence grounding** — modifiers based on verification quality.
+3. **Context modifiers** — signals that adjust severity.
+4. **Re-assess borderline items** — independent second pass.
+
+Surface as `bucket: med` for any review-intent agent missing this scaffold.
+
+## Stake calibration
+
+| Defect | Default bucket |
+|---|---|
+| `missing_what_you_dont_do` on a pipeline agent | `med` |
+| `missing_calibration` on a judgment agent | `med` |
+| `wall_of_text` (cosmetic) | `low` |
+| `rule_without_why` | `low` |
+| `verbose_role_framing` | `low` |
+
+## What this dim does NOT do
+
+- Does not evaluate description routing copy — that's activation.
+- Does not evaluate tool reachability — that's tool-scoping.
+- Does not evaluate output schema or summary-first structure — that's output-format.

--- a/skills/skill-improver/references/prompt-quality/protocol.md
+++ b/skills/skill-improver/references/prompt-quality/protocol.md
@@ -1,0 +1,108 @@
+# Prompt-Quality Dim — Protocol
+
+The prompt-quality reviewer checks the body's clarity and structure:
+sections, *why* explanations, examples, role framing, decision scaffolds,
+gotchas, "What You Don't Do" sections, and (for judgment agents)
+calibration scaffolds.
+
+This dim folds the dotfiles `scoring` concern under the
+`prompt-quality.missing_calibration` finding (per spec SI-1: not all
+agents are judgment agents, so calibration is a sub-rubric here rather
+than a standalone dim).
+
+## Why this dim exists
+
+Prompt structure has measurable effects on instruction following:
+
+- Tables and bulleted rules are followed more reliably than prose.
+- Rules paired with *why* generalize to edge cases; rules without it
+  fail on novel inputs.
+- One concrete example outperforms ten abstract rules.
+
+## Patterns the dim looks for
+
+### `prompt-quality.wall_of_text`
+
+Long prose blocks where a table or bullets would scan faster. Heuristic:
+> 30 consecutive lines without a heading, table, or list.
+
+### `prompt-quality.rule_without_why`
+
+Hard rules ("Never use `find`") with no rationale. Brittle. Pair every
+rule with the reason behind it.
+
+```
+# Bad
+Never use `find`.
+
+# Good
+Use `fd` instead of `find` because fd respects .gitignore and is faster
+on large repos. (Rule: avoid `find`.)
+```
+
+### `prompt-quality.no_examples`
+
+Prescriptive instructions with zero concrete examples. Add at least
+one. Two establish a pattern. Three confirm it.
+
+### `prompt-quality.verbose_role_framing`
+
+Paragraph-long "You are..." opener instead of one tight sentence.
+
+```
+# Bad
+You are a sophisticated agent designed to perform comprehensive and
+thoughtful audits of agent and skill definitions, taking into account
+the user's preferences and the broader project context...
+
+# Good
+You are the activation reviewer in /skill-improver. Amplify the
+author's attention; do not judge for them.
+```
+
+### `prompt-quality.missing_what_you_dont_do`
+
+Pipeline agents without an explicit "What You Don't Do" / negative
+constraints section have the most scope creep with adjacent phases.
+
+### `prompt-quality.missing_gotchas`
+
+No "Gotchas" section. These prevent repeated failures and are the
+highest-value content per token.
+
+### `prompt-quality.missing_decision_scaffold`
+
+Judgment task using "always/never" rules instead of a structured
+scaffold (Classify → Ground → Context → Reassess; or
+degrees-of-freedom). Match constraint level to risk.
+
+### `prompt-quality.missing_calibration` (folds the `scoring` concern)
+
+For review/audit/triage agents, no rubric for how findings are
+bucketed. The agent will pattern-match the rubric description rather
+than apply calibrated probabilities.
+
+A good calibration scaffold:
+
+1. **Classify the claim type** — base bucket + cap per type.
+2. **Evidence grounding** — modifiers based on verification quality.
+3. **Context modifiers** — signals that adjust severity.
+4. **Re-assess borderline items** — independent second pass.
+
+Surface as `bucket: med` for any review-intent agent missing this scaffold.
+
+## Stake calibration
+
+| Defect | Default bucket |
+|---|---|
+| `missing_what_you_dont_do` on a pipeline agent | `med` |
+| `missing_calibration` on a judgment agent | `med` |
+| `wall_of_text` (cosmetic) | `low` |
+| `rule_without_why` | `low` |
+| `verbose_role_framing` | `low` |
+
+## What this dim does NOT do
+
+- Does not evaluate description routing copy — that's activation.
+- Does not evaluate tool reachability — that's tool-scoping.
+- Does not evaluate output schema or summary-first structure — that's output-format.

--- a/skills/skill-improver/references/report-template.md
+++ b/skills/skill-improver/references/report-template.md
@@ -1,0 +1,84 @@
+# /skill-improver Report Template
+
+The orchestrator's Phase 3 fills in every `<!-- placeholder -->` comment.
+Do NOT include numeric scores anywhere in the rendered output.
+
+The shape mirrors `skills/age/references/report-template.md` so /age and
+/skill-improver readers do not have to learn two layouts.
+
+---
+
+## Skill-Improver Review: <!-- placeholder: slug, e.g. "agents-foo-md-eta-2026-04-29" -->
+
+<!-- placeholder: orientation paragraph — 2-4 factual sentences built by the
+orchestrator from the target's frontmatter. State the target kind (agent vs
+skill), declared model tier, tool surface (read-only / write-scoped / focused),
+and prompt body line count. Not evaluative.
+
+Example: "Target: agents/foo.md.eta — a Claude Code review agent declared at
+haiku tier with 6 tools (read-only) and a 92-line body. Activation dim found
+no trigger phrases; tool-scoping dim found Edit reachable despite a 'read-only'
+prose claim." -->
+
+Ran <!-- placeholder: 5 --> dims; <!-- placeholder: N --> had findings
+(`<!-- placeholder: dim-names with findings -->`).
+<!-- placeholder: dims with scope_match: false, if any -->
+
+---
+
+## High-stakes findings
+
+<!-- placeholder: one section per high-stake dim (activation, tool-scoping)
+with observations. Omit dim section entirely if empty — it is counted in the
+tally above. -->
+
+### <!-- placeholder: dim name, e.g. "activation" -->
+
+<!-- placeholder: per-observation block, repeat for each observation:
+
+<narrative text>
+
+bucket: low|med|high
+
+**Evidence**
+- <evidence[0]>
+- <evidence[1]>
+
+**Consideration** (omit if fix is set)
+<consideration text>
+
+**Fix available** (omit if fix is absent)
+Category: <fix.category>
+
+-->
+
+---
+
+## Medium-stakes findings
+
+<!-- placeholder: one section per medium-stake dim (context, prompt-quality,
+output-format) with observations. Same per-observation format as above. -->
+
+### <!-- placeholder: dim name -->
+
+<!-- placeholder: per-observation blocks -->
+
+---
+
+## Cross-dimension callouts
+
+<!-- placeholder: panel appears only when group_by_locus() finds observations
+from ≥ 2 dims within a 3-line window. Omit entirely if no cross-dim overlap.
+
+Format per callout:
+
+**<file>:<approx-line>** — agreement across: <dim1>, <dim2>
+- <dim1>: <observation narrative, one line>
+- <dim2>: <observation narrative, one line>
+
+-->
+
+---
+
+*Report written to `.cheese/skill-improver/<slug>.md`. Fixes: <!-- placeholder: N -->. Suggestions: <!-- placeholder: N -->.*
+*To apply fixes: `/cleanup skill-improver/<slug>` — to act on suggestions: `/fromage cook --suggestions <slug>`*

--- a/skills/skill-improver/references/report-template.md
+++ b/skills/skill-improver/references/report-template.md
@@ -1,0 +1,84 @@
+# /skill-improver Report Template
+
+The orchestrator's Phase 3 fills in every `<!-- placeholder -->` comment.
+Do NOT include numeric scores anywhere in the rendered output.
+
+The shape mirrors `skills/age/references/report-template.md` so /age and
+/skill-improver readers do not have to learn two layouts.
+
+---
+
+## Skill-Improver Review: <!-- placeholder: slug, e.g. "agents-foo-md-eta-2026-04-29" -->
+
+<!-- placeholder: orientation paragraph — 2-4 factual sentences built by the
+orchestrator from the target's frontmatter. State the target kind (agent vs
+skill), declared model tier, tool surface (read-only / write-scoped / focused),
+and prompt body line count. Not evaluative.
+
+Example: "Target: agents/foo.md.eta — a Claude Code review agent declared at
+haiku tier with 6 tools (read-only) and a 92-line body. Activation dim found
+no trigger phrases; tool-scoping dim found Edit reachable despite a 'read-only'
+prose claim." -->
+
+Ran <!-- placeholder: 5 --> dims; <!-- placeholder: N --> had findings
+(`<!-- placeholder: dim-names with findings -->`).
+<!-- placeholder: dims with scope_match: false, if any -->
+
+---
+
+## High-stakes findings
+
+<!-- placeholder: one section per high-stake dim (activation, tool-scoping)
+with observations. Omit dim section entirely if empty — it is counted in the
+tally above. -->
+
+### <!-- placeholder: dim name, e.g. "activation" -->
+
+<!-- placeholder: per-observation block, repeat for each observation:
+
+<narrative text>
+
+bucket: low|med|high
+
+**Evidence**
+- <evidence[0]>
+- <evidence[1]>
+
+**Consideration** (omit if fix is set)
+<consideration text>
+
+**Fix available** (omit if fix is absent)
+Category: <fix.category>
+
+-->
+
+---
+
+## Medium-stakes findings
+
+<!-- placeholder: one section per medium-stake dim (context, prompt-quality,
+output-format) with observations. Same per-observation format as above. -->
+
+### <!-- placeholder: dim name -->
+
+<!-- placeholder: per-observation blocks -->
+
+---
+
+## Cross-dimension callouts
+
+<!-- placeholder: panel appears only when group_by_locus() finds observations
+from ≥ 2 dims within a 3-line window. Omit entirely if no cross-dim overlap.
+
+Format per callout:
+
+**<file>:<approx-line>** — agreement across: <dim1>, <dim2>
+- <dim1>: <observation narrative, one line>
+- <dim2>: <observation narrative, one line>
+
+-->
+
+---
+
+*Report written to `.cheese/skill-improver/<slug>.md`. Fixes: <!-- placeholder: N -->. Suggestions: <!-- placeholder: N -->.*
+*To apply fixes: `/cleanup <slug>` — to act on suggestions: `/fromage cook --suggestions <slug>`*

--- a/skills/skill-improver/references/tool-scoping/protocol.md
+++ b/skills/skill-improver/references/tool-scoping/protocol.md
@@ -1,0 +1,110 @@
+# Tool-Scoping Dim — Protocol
+
+The tool-scoping reviewer checks whether the target's `tools` allowlist,
+any `disallowedTools`, and `skills:` declarations match its stated role
+and behavioral footprint.
+
+## Why this dim exists
+
+Over-broad tool access degrades behavior in two ways:
+
+1. **Token waste** — every declared tool burns budget on tool-decision
+   noise even when never used.
+2. **Irreversible-action drift** — when stuck, models reach for whatever
+   is available. A read-only reviewer with `Edit` declared will edit
+   when a prose-only constraint says it shouldn't.
+
+Prose constraints ("this is a read-only agent") are weaker than structural
+tool limits. In this repo, `tools` is an explicit allowlist; an allowlist
+containing only read tools is sufficient. Use `disallowedTools` as a
+defense-in-depth signal only when write tools are otherwise reachable or a
+host grants broad defaults.
+
+## Three-tier model
+
+Every agent should fall into one of these tiers:
+
+| Tier | `tools` | `disallowedTools` | Use case |
+|---|---|---|---|
+| Read-only | `tilth_read`, `tilth_search`, optional `bash` | only when host defaults expose write tools | Reviewers, auditors, explorers |
+| Write-scoped | + `tilth_edit` | tighten to exclude unused | Implementers, fixers |
+| Focused sub-agent | 2–4 tools max | none needed | Pipeline sub-tasks |
+
+A target that does not fall cleanly into one tier likely has scope
+creep; surface as `tool-scoping.tier_mismatch` with `bucket: med`.
+
+## Failure modes (with examples)
+
+### `tool-scoping.prose_only_readonly`
+
+Body says "read-only" but write tools are reachable. Common in agents
+cloned from a write-scoped template. Do not flag missing `disallowedTools`
+when `tools` is an explicit read-only allowlist.
+
+```yaml
+# Bad
+tools: [mcp__tilth__tilth_read, mcp__tilth__tilth_edit]
+# Body: "You are a read-only reviewer."
+
+# Good: explicit allowlist, no write tools reachable
+tools: [mcp__tilth__tilth_read]
+
+# Also good when the host grants broad defaults
+tools: [mcp__tilth__tilth_read]
+disallowedTools: [Edit, Write, NotebookEdit]
+```
+
+### `tool-scoping.over_broad_tools`
+
+Focused sub-agent declares 8+ tools when 2–3 would suffice. Each
+declared tool burns context.
+
+### `tool-scoping.skill_delegation_gap`
+
+Agent body uses a skill that's not in `skills:`, or declares a skill
+it never invokes.
+
+```yaml
+# Bad
+skills: [cheez-read]
+# Body: uses cheez-search heavily
+
+# Good
+skills: [cheez-read, cheez-search]
+```
+
+### `tool-scoping.wrong_namespace`
+
+Plain tool names instead of MCP namespaces. The host won't expose
+`Read` to plugin sub-agents — must use `mcp__tilth__tilth_read`.
+
+```yaml
+# Bad
+tools: [Read, Grep]
+
+# Good
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+```
+
+### `tool-scoping.stale_disallowed`
+
+`disallowedTools` lists a tool that no longer exists in the platform.
+Lint-only, but signals stale config.
+
+## Stake calibration
+
+| Defect | Default bucket |
+|---|---|
+| `prose_only_readonly` with a reachable write tool | `high` |
+| `wrong_namespace` (host won't expose) | `high` |
+| `over_broad_tools` (cosmetic) | `med` |
+| `skill_delegation_gap` (false positive likely) | `med` |
+| `stale_disallowed` | `low` |
+
+## What this dim does NOT do
+
+- Does not evaluate the description copy — that's activation.
+- Does not evaluate prompt body — that's prompt-quality.
+- Does not evaluate output schema — that's output-format.

--- a/skills/skill-improver/references/tool-scoping/protocol.md
+++ b/skills/skill-improver/references/tool-scoping/protocol.md
@@ -1,0 +1,109 @@
+# Tool-Scoping Dim — Protocol
+
+The tool-scoping reviewer checks whether the target's `tools`,
+`disallowedTools`, and `skills:` declarations match its stated role and
+behavioral footprint.
+
+## Why this dim exists
+
+Over-broad tool access degrades behavior in two ways:
+
+1. **Token waste** — every declared tool burns budget on tool-decision
+   noise even when never used.
+2. **Irreversible-action drift** — when stuck, models reach for whatever
+   is available. A read-only reviewer with `Edit` declared will edit
+   when a prose-only constraint says it shouldn't.
+
+Prose constraints ("this is a read-only agent") are weaker than hard
+`disallowedTools` blocks. Always enforce structurally where possible.
+
+## Three-tier model
+
+Every agent should fall into one of these tiers:
+
+| Tier | `tools` | `disallowedTools` | Use case |
+|---|---|---|---|
+| Read-only | `tilth_read`, `tilth_search`, optional `bash` | `[Edit, Write, NotebookEdit]` | Reviewers, auditors, explorers |
+| Write-scoped | + `tilth_edit` | tighten to exclude unused | Implementers, fixers |
+| Focused sub-agent | 2–4 tools max | none needed | Pipeline sub-tasks |
+
+A target that does not fall cleanly into one tier likely has scope
+creep; surface as `tool-scoping.tier_mismatch` with `bucket: med`.
+
+## Failure modes (with examples)
+
+### `tool-scoping.prose_only_readonly`
+
+Body says "read-only" but `disallowedTools` is unset. Common in agents
+cloned from a write-scoped template.
+
+```yaml
+# Bad
+tools: [mcp__tilth__tilth_read, mcp__tilth__tilth_edit]
+# Body: "You are a read-only reviewer."
+
+# Good
+tools: [mcp__tilth__tilth_read]
+disallowedTools: [Edit, Write, NotebookEdit]
+```
+
+### `tool-scoping.over_broad_tools`
+
+Focused sub-agent declares 8+ tools when 2–3 would suffice. Each
+declared tool burns context.
+
+### `tool-scoping.skill_delegation_gap`
+
+Agent body uses a skill that's not in `skills:`, or declares a skill
+it never invokes.
+
+```yaml
+# Bad
+skills: [cheez-read]
+# Body: uses cheez-search heavily
+
+# Good
+skills: [cheez-read, cheez-search]
+```
+
+### `tool-scoping.wrong_namespace`
+
+Plain tool names instead of MCP namespaces. The host won't expose
+`Read` to plugin sub-agents — must use `mcp__tilth__tilth_read`.
+
+```yaml
+# Bad
+tools: [Read, Grep]
+
+# Good
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+```
+
+### `tool-scoping.missing_disallowed_on_review`
+
+`metadata.intent: review` (or `audit`, `triage`) without a
+`disallowedTools` block. Review-intent agents should be read-only by
+default.
+
+### `tool-scoping.stale_disallowed`
+
+`disallowedTools` lists a tool that no longer exists in the platform.
+Lint-only, but signals stale config.
+
+## Stake calibration
+
+| Defect | Default bucket |
+|---|---|
+| `prose_only_readonly` on a review agent | `high` |
+| `wrong_namespace` (host won't expose) | `high` |
+| `over_broad_tools` (cosmetic) | `med` |
+| `skill_delegation_gap` (false positive likely) | `med` |
+| `stale_disallowed` | `low` |
+
+## What this dim does NOT do
+
+- Does not evaluate the description copy — that's activation.
+- Does not evaluate prompt body — that's prompt-quality.
+- Does not evaluate output schema — that's output-format.

--- a/tests/compiler-commands.test.ts
+++ b/tests/compiler-commands.test.ts
@@ -138,6 +138,7 @@ describe("shipped command scaffolds", () => {
       "cook.md",
       "culture.md",
       "mold.md",
+      "skill-improver.md",
     ];
     for (const root of [".claude", ".codex"]) {
       const manifest = await readManifest(projectRoot, root);

--- a/tests/compiler-commands.test.ts
+++ b/tests/compiler-commands.test.ts
@@ -119,7 +119,7 @@ describe("compileHarnessBundles command output", () => {
 });
 
 describe("shipped command scaffolds", () => {
-  it("copies all eight scaffolded top-level commands into each harness", async () => {
+  it("copies all scaffolded top-level commands into each harness", async () => {
     const projectRoot = await makeProjectRoot("cheese-flow-shipped-commands-");
     await seedAgentsAndSkills(projectRoot);
     await cp(path.resolve("commands"), path.join(projectRoot, "commands"), {
@@ -140,6 +140,7 @@ describe("shipped command scaffolds", () => {
       "cure.md",
       "mold.md",
       "nih-audit.md",
+      "skill-improver.md",
     ];
     for (const root of [".claude", ".codex"]) {
       const manifest = await readManifest(projectRoot, root);

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -322,6 +322,11 @@ describe("compileHarnessBundles", () => {
       "milknado-planner.md",
       "nih-scanner.md",
       "press.md",
+      "skill-improver-activation.md",
+      "skill-improver-context.md",
+      "skill-improver-output-format.md",
+      "skill-improver-prompt-quality.md",
+      "skill-improver-tool-scoping.md",
       "taste-readability.md",
       "taste-scope.md",
       "taste-spec.md",
@@ -342,6 +347,7 @@ describe("compileHarnessBundles", () => {
       "nested-dir",
       "nih-audit",
       "research",
+      "skill-improver",
     ]);
     expect(manifest.commands).toEqual([]);
   });

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -271,6 +271,11 @@ describe("installHarnessArtifacts", () => {
       "milknado-executor.md",
       "milknado-planner.md",
       "press.md",
+      "skill-improver-activation.md",
+      "skill-improver-context.md",
+      "skill-improver-output-format.md",
+      "skill-improver-prompt-quality.md",
+      "skill-improver-tool-scoping.md",
     ]);
     expect(manifest.skills).toEqual([
       "age",
@@ -286,6 +291,7 @@ describe("installHarnessArtifacts", () => {
       "mold",
       "nested-dir",
       "research",
+      "skill-improver",
     ]);
     expect(manifest.commands).toEqual([]);
   });

--- a/tests/skill-improver-fixtures/activation/expected.json
+++ b/tests/skill-improver-fixtures/activation/expected.json
@@ -1,0 +1,14 @@
+{
+  "dimension": "activation",
+  "stake": "high",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "activation-1",
+      "file": "tests/skill-improver-fixtures/activation/target.md.eta",
+      "anchor": { "start": "3:000" },
+      "bucket": "high",
+      "narrative": "Description reads as a summary ('A tool for reviewing PR comments.') with no quoted user phrases, no /command reference, and no negative triggers — routing model has nothing concrete to match against."
+    }
+  ]
+}

--- a/tests/skill-improver-fixtures/activation/target.md.eta
+++ b/tests/skill-improver-fixtures/activation/target.md.eta
@@ -1,0 +1,33 @@
+---
+name: pr-reviewer
+description: A tool for reviewing PR comments.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+color: red
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the PR comment reviewer. Read each comment, classify it, and
+emit a triage table. The output is consumed by /respond.
+
+## Inputs
+
+1. The PR diff via cheez-read.
+2. The list of review comments via gh api.
+
+## Output
+
+A triage table with one row per comment.

--- a/tests/skill-improver-fixtures/context/expected.json
+++ b/tests/skill-improver-fixtures/context/expected.json
@@ -1,0 +1,14 @@
+{
+  "dimension": "context",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "context-1",
+      "file": "tests/skill-improver-fixtures/context/target.md.eta",
+      "anchor": { "start": "25:000" },
+      "bucket": "med",
+      "narrative": "Agent reads every Markdown file under docs/, every README, every CHANGELOG, every ADR, every spec, and the root CLAUDE.md, then dumps the full content back to the caller — output is unbounded and there is no fork or output-budget pointer pattern."
+    }
+  ]
+}

--- a/tests/skill-improver-fixtures/context/target.md.eta
+++ b/tests/skill-improver-fixtures/context/target.md.eta
@@ -1,0 +1,36 @@
+---
+name: docs-summary
+description: Summarizes the project docs for a quick onboarding pass.
+  Use when the user says "summarize docs", "what is this project",
+  or invokes /docs-summary.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: blue
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: summary
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the docs summary agent. Read every Markdown file under
+`docs/`, every README in nested packages, every CHANGELOG, every
+ADR file, every .claude/specs/ entry, and the root CLAUDE.md. Then
+emit the full text of each as a series of headed blocks back to
+the caller for downstream synthesis.
+
+## Behavior
+
+For each file: print the path, print the file size, print the full
+content. Repeat for every file you found. Do not summarize, do not
+truncate, do not skip. The caller will handle the synthesis.

--- a/tests/skill-improver-fixtures/output-format/expected.json
+++ b/tests/skill-improver-fixtures/output-format/expected.json
@@ -1,0 +1,14 @@
+{
+  "dimension": "output-format",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "output-format-1",
+      "file": "tests/skill-improver-fixtures/output-format/target.md.eta",
+      "anchor": { "start": "30:000" },
+      "bucket": "med",
+      "narrative": "Output section explicitly forbids tables, summary lines, and temp-file pointers — every finding lands as prose in the caller's context with no summary-first layout, no scannable structure, and no detail-vs-summary separation."
+    }
+  ]
+}

--- a/tests/skill-improver-fixtures/output-format/target.md.eta
+++ b/tests/skill-improver-fixtures/output-format/target.md.eta
@@ -1,0 +1,40 @@
+---
+name: dep-auditor
+description: Audits package dependencies for unused, outdated, or
+  vulnerable entries. Use when the user says "audit deps", "check
+  packages", or invokes /dep-audit.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: blue
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: audit
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the dependency auditor. Read the project's package manifest
+and emit findings for each issue you discover.
+
+## Inputs
+
+1. The package manifest path (package.json, pyproject.toml, etc).
+2. The lockfile path.
+
+## Output
+
+For each finding, write a paragraph naming the package, the issue,
+the severity, and the recommended fix. Stack the paragraphs together
+into a single response and return it directly to the caller. Do not
+write to a temp file. Do not use a table. Do not include a summary
+line. The caller will read the full response.

--- a/tests/skill-improver-fixtures/prompt-quality/expected.json
+++ b/tests/skill-improver-fixtures/prompt-quality/expected.json
@@ -1,0 +1,14 @@
+{
+  "dimension": "prompt-quality",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "prompt-quality-1",
+      "file": "tests/skill-improver-fixtures/prompt-quality/target.md.eta",
+      "anchor": { "start": "23:000" },
+      "bucket": "med",
+      "narrative": "Triage agent classifies failures into a small enum (flake, real bug, infra, unknown) but ships no calibration scaffold telling the agent how to bucket borderline cases — judgment task without a confidence rubric will pattern-match the description rather than apply calibrated probabilities."
+    }
+  ]
+}

--- a/tests/skill-improver-fixtures/prompt-quality/target.md.eta
+++ b/tests/skill-improver-fixtures/prompt-quality/target.md.eta
@@ -1,0 +1,43 @@
+---
+name: ci-triage
+description: Triages CI failures and proposes a one-line root cause. Use
+  when the user says "ci failed", "what broke", or invokes /ci-triage.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: yellow
+effort: medium
+metadata:
+  owner: cheese-flow
+  intent: triage
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the CI triage reviewer. Look at the failing job log and
+classify the failure into one of: flake, real bug, infra issue, or
+unknown. Then emit a triage table with one row per failure.
+
+## Inputs
+
+1. The failing job's log via gh api.
+2. The PR diff via cheez-read.
+
+## Output
+
+A Markdown table with one row per failure. Each row has: job, file,
+classification, one-line root cause.
+
+## Hard rules
+
+- Read-only.
+- Do not modify any source files.
+- Do not run the build or tests.

--- a/tests/skill-improver-fixtures/tool-scoping/expected.json
+++ b/tests/skill-improver-fixtures/tool-scoping/expected.json
@@ -1,0 +1,14 @@
+{
+  "dimension": "tool-scoping",
+  "stake": "high",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "tool-scoping-1",
+      "file": "tests/skill-improver-fixtures/tool-scoping/target.md.eta",
+      "anchor": { "start": "11:000" },
+      "bucket": "high",
+      "narrative": "Body declares 'You are a read-only code auditor' but tools includes tilth_edit and there is no disallowedTools block — the prose constraint is not enforceable."
+    }
+  ]
+}

--- a/tests/skill-improver-fixtures/tool-scoping/target.md.eta
+++ b/tests/skill-improver-fixtures/tool-scoping/target.md.eta
@@ -1,0 +1,36 @@
+---
+name: code-auditor
+description: Reviews source code for safety issues. Use when the user
+  says "audit", "code review", or invokes /audit.
+models:
+  default: claude-haiku-4-5
+  claude-code: claude-haiku-4-5-20251001
+  codex: gpt-5.1-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+  - mcp__tilth__tilth_edit
+skills:
+  - cheez-read
+  - cheez-search
+color: red
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are a read-only code auditor. Surface safety findings as an
+observation table. You do not modify any files.
+
+## Inputs
+
+1. The repo root path.
+2. A file glob to scope the audit.
+
+## Output
+
+A Markdown table with one row per finding.

--- a/tests/skill-improver-flow.test.ts
+++ b/tests/skill-improver-flow.test.ts
@@ -1,0 +1,330 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter } from "../src/lib/frontmatter.js";
+import {
+  parseAgentFrontmatter,
+  parseCommandFrontmatter,
+  parseSkillFrontmatter,
+} from "../src/lib/schemas.js";
+
+const root = path.resolve(".");
+
+const DIMS = [
+  "activation",
+  "tool-scoping",
+  "context",
+  "prompt-quality",
+  "output-format",
+] as const;
+
+const STAKE_BY_DIM: Record<(typeof DIMS)[number], "high" | "medium"> = {
+  activation: "high",
+  "tool-scoping": "high",
+  context: "medium",
+  "prompt-quality": "medium",
+  "output-format": "medium",
+};
+
+const FIXTURE_STAKE_BY_DIM: Record<(typeof DIMS)[number], "high" | "medium"> = {
+  ...STAKE_BY_DIM,
+};
+
+const FIXTURE_BUCKET_BY_DIM: Record<(typeof DIMS)[number], "high" | "med"> = {
+  activation: "high",
+  "tool-scoping": "high",
+  context: "med",
+  "prompt-quality": "med",
+  "output-format": "med",
+};
+
+const FIXTURE_NARRATIVE_KEYWORDS: Record<(typeof DIMS)[number], RegExp> = {
+  activation: /trigger|summary|routing|description/iu,
+  "tool-scoping": /read-only|disallowedTools|Edit|tilth_edit/u,
+  context: /fork|output|budget|unbounded|verbose/iu,
+  "prompt-quality": /calibration|scaffold|rubric|judgment/iu,
+  "output-format": /summary|table|structured|temp file|pointer/iu,
+};
+
+async function readSource(relativePath: string): Promise<string> {
+  return readFile(path.join(root, relativePath), "utf8");
+}
+
+describe("/skill-improver command shim", () => {
+  it("ships commands/skill-improver.md as a slim shim that delegates to the skill", async () => {
+    const source = await readSource("commands/skill-improver.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    const command = parseCommandFrontmatter(parsed.data);
+
+    expect(command.name).toBe("skill-improver");
+    expect(parsed.body).toContain(
+      "Invoke the `skill-improver` skill with `$ARGUMENTS`",
+    );
+  });
+
+  it("lists all five dimensions in the command body", async () => {
+    const source = await readSource("commands/skill-improver.md");
+    for (const dim of DIMS) {
+      expect(source).toContain(dim);
+    }
+  });
+
+  it("declares the amplifier-pure boundary (no writes) in the command body", async () => {
+    const source = await readSource("commands/skill-improver.md");
+    expect(source).toMatch(/no writes/iu);
+  });
+});
+
+describe("/skill-improver skill orchestrator", () => {
+  it("ships skills/skill-improver/SKILL.md with the skill name", async () => {
+    const source = await readSource("skills/skill-improver/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    const skill = parseSkillFrontmatter(parsed.data);
+
+    expect(skill.name).toBe("skill-improver");
+  });
+
+  it("mentions all five dim names in the orchestrator body", async () => {
+    const source = await readSource("skills/skill-improver/SKILL.md");
+    for (const dim of DIMS) {
+      expect(source).toContain(dim);
+    }
+  });
+
+  it("references reuse of /cleanup and cleanup-wolf rather than new cleanup machinery", async () => {
+    const source = await readSource("skills/skill-improver/SKILL.md");
+    expect(source).toContain("/cleanup");
+    expect(source).toContain("cleanup-wolf");
+  });
+
+  it("references the shared sidecar schema (fixes.json and suggestions.json)", async () => {
+    const source = await readSource("skills/skill-improver/SKILL.md");
+    expect(source).toContain("fixes.json");
+    expect(source).toContain("suggestions.json");
+  });
+
+  it("declares the Claude Code >= 2.1.30 / claude-agent-sdk >= 0.2.63 compatibility gate", async () => {
+    const source = await readSource("skills/skill-improver/SKILL.md");
+    expect(source).toContain("2.1.30");
+    expect(source).toContain("0.2.63");
+  });
+
+  it("derives slugs from the target path so skill SKILL.md files do not collide", async () => {
+    const source = await readSource("skills/skill-improver/SKILL.md");
+    expect(source).not.toContain('basename "$TARGET"');
+    expect(source).toContain("s#/SKILL\\.md$##");
+    expect(source).toContain("s#\\.md\\.eta$##");
+    expect(source).toContain("cut -c 1-64");
+  });
+
+  it("hands fixes to cleanup with a source-qualified skill-improver slug", async () => {
+    const sources = [
+      await readSource("commands/skill-improver.md"),
+      await readSource("skills/skill-improver/SKILL.md"),
+      await readSource("skills/skill-improver/references/report-template.md"),
+    ];
+    for (const source of sources) {
+      expect(source).toContain("/cleanup skill-improver/<slug>");
+      expect(source).not.toContain("/cleanup <slug>");
+    }
+  });
+
+  it("documents cleanup support for skill-improver sidecar sources", async () => {
+    const source = await readSource("skills/cleanup/SKILL.md");
+    expect(source).toContain("/cleanup <slug | source/slug>");
+    expect(source).toContain(".cheese/skill-improver/<slug>.fixes.json");
+    expect(source).toContain(
+      "Only `age` and `skill-improver` are valid sources",
+    );
+  });
+});
+
+describe("/skill-improver dim agents", () => {
+  for (const dim of DIMS) {
+    it(`ships agents/skill-improver-${dim}.md.eta with the correct frontmatter contract`, async () => {
+      const source = await readSource(`agents/skill-improver-${dim}.md.eta`);
+      const parsed = parseFrontmatter<unknown>(source);
+      const frontmatter = parseAgentFrontmatter(parsed.data);
+
+      expect(frontmatter.name).toBe(`skill-improver-${dim}`);
+      expect(frontmatter.models.default).toBe("claude-haiku-4-5");
+      expect(frontmatter.tools).toEqual([
+        "mcp__tilth__tilth_read",
+        "mcp__tilth__tilth_search",
+      ]);
+      expect(frontmatter.skills).toEqual(
+        expect.arrayContaining(["cheez-read", "cheez-search"]),
+      );
+      expect(frontmatter.metadata).toBeDefined();
+      expect(frontmatter.metadata?.dim).toBe(dim);
+      expect(frontmatter.metadata?.stake).toBe(STAKE_BY_DIM[dim]);
+      expect(frontmatter.metadata?.intent).toBe("review");
+      expect(frontmatter.metadata?.owner).toBe("cheese-flow");
+    });
+
+    it(`states the per-agent return contract ($RUN_DIR/${dim}.json) in the body`, async () => {
+      const source = await readSource(`agents/skill-improver-${dim}.md.eta`);
+      const parsed = parseFrontmatter<unknown>(source);
+      expect(parsed.body).toContain(`$RUN_DIR/${dim}.json`);
+    });
+  }
+});
+
+describe("/skill-improver fixture targets", () => {
+  for (const dim of DIMS) {
+    it(`seeds expected.json with a finding bucketed at ${FIXTURE_BUCKET_BY_DIM[dim]} matching the dim's rubric`, async () => {
+      const source = await readSource(
+        `tests/skill-improver-fixtures/${dim}/expected.json`,
+      );
+      const parsed = JSON.parse(source) as {
+        dimension: string;
+        stake?: string;
+        observations: Array<{
+          id: string;
+          bucket: string;
+          narrative: string;
+          anchor: { start: string };
+        }>;
+      };
+
+      expect(parsed.dimension).toBe(dim);
+      expect(parsed.stake).toBe(FIXTURE_STAKE_BY_DIM[dim]);
+      expect(parsed.observations.length).toBeGreaterThanOrEqual(1);
+
+      const first = parsed.observations[0];
+      if (!first) throw new Error("expected at least one observation");
+
+      expect(first.id).toBe(`${dim}-1`);
+      expect(first.bucket).toBe(FIXTURE_BUCKET_BY_DIM[dim]);
+      expect(first.narrative).toMatch(FIXTURE_NARRATIVE_KEYWORDS[dim]);
+      expect(first.anchor.start).toMatch(/^\d+:[0-9a-f]+$/u);
+    });
+
+    it(`seeds target.md.eta with parseable agent frontmatter that exercises the ${dim} dim`, async () => {
+      const source = await readSource(
+        `tests/skill-improver-fixtures/${dim}/target.md.eta`,
+      );
+      const parsed = parseFrontmatter<unknown>(source);
+      const frontmatter = parseAgentFrontmatter(parsed.data);
+
+      expect(frontmatter.name.length).toBeGreaterThan(0);
+      expect(frontmatter.description.length).toBeGreaterThan(0);
+      expect(parsed.body.length).toBeGreaterThan(0);
+    });
+  }
+});
+
+describe("/skill-improver reference files", () => {
+  it("ships skills/skill-improver/references/report-template.md", async () => {
+    const source = await readSource(
+      "skills/skill-improver/references/report-template.md",
+    );
+    expect(source).toContain("Skill-Improver Review");
+    expect(source).toMatch(/orientation/iu);
+    expect(source).toContain("Cross-dimension callouts");
+  });
+
+  it("ships skills/skill-improver/references/fixture-protocol.md", async () => {
+    const source = await readSource(
+      "skills/skill-improver/references/fixture-protocol.md",
+    );
+    expect(source).toContain("age_fixture_diff.py");
+    expect(source).toContain("expected.json");
+    expect(source).toContain("target.md.eta");
+  });
+
+  for (const dim of DIMS) {
+    it(`ships skills/skill-improver/references/${dim}/protocol.md`, async () => {
+      const source = await readSource(
+        `skills/skill-improver/references/${dim}/protocol.md`,
+      );
+      expect(source.length).toBeGreaterThan(200);
+      expect(source).toContain(dim);
+    });
+  }
+});
+
+describe("/skill-improver amplifier-pure boundary", () => {
+  it("does not document a --fix flag in SKILL.md (FR-8: no auto-apply)", async () => {
+    const source = await readSource("skills/skill-improver/SKILL.md");
+    expect(source).not.toMatch(/--fix\b/u);
+  });
+
+  it("does not document a --fix flag in commands/skill-improver.md", async () => {
+    const source = await readSource("commands/skill-improver.md");
+    expect(source).not.toMatch(/--fix\b/u);
+  });
+
+  for (const dim of DIMS) {
+    it(`agents/skill-improver-${dim}.md.eta documents fix as a {category, content} object, not a string`, async () => {
+      const source = await readSource(`agents/skill-improver-${dim}.md.eta`);
+      expect(source).toContain('"fix"');
+      expect(source).toMatch(/"category"\s*:/u);
+      expect(source).toMatch(/"content"\s*:/u);
+    });
+  }
+});
+
+describe("/skill-improver review-rubric guardrails", () => {
+  it("does not teach activation reviewers to suggest unsupported frontmatter keys", async () => {
+    const source = [
+      await readSource("agents/skill-improver-activation.md.eta"),
+      await readSource(
+        "skills/skill-improver/references/activation/protocol.md",
+      ),
+    ].join("\n");
+    expect(source).not.toMatch(
+      /disable-model-invocation|user-invocable|\bagent:\b/u,
+    );
+    expect(source).toContain("Never suggest unsupported frontmatter keys");
+  });
+
+  it("treats explicit read-only tool allowlists as sufficient for review agents", async () => {
+    const source = [
+      await readSource("agents/skill-improver-tool-scoping.md.eta"),
+      await readSource(
+        "skills/skill-improver/references/tool-scoping/protocol.md",
+      ),
+    ].join("\n");
+    expect(source).toContain(
+      "do NOT flag a review agent just because `disallowedTools` is absent",
+    );
+    expect(source).toMatch(
+      /Do not flag missing `disallowedTools`\s+when `tools` is an explicit read-only allowlist\./u,
+    );
+  });
+});
+
+describe("/skill-improver routing", () => {
+  it("is mentioned in the /cheese routing table", async () => {
+    const source = await readSource("commands/cheese.md");
+    expect(source).toContain("/skill-improver");
+  });
+});
+
+describe("/skill-improver justfile recipe", () => {
+  it("declares a test-skill-improver-fixtures recipe", async () => {
+    const source = await readSource("justfile");
+    expect(source).toMatch(/^test-skill-improver-fixtures:/mu);
+  });
+
+  it("reuses python python/tools/age_fixture_diff.py as the comparator", async () => {
+    const source = await readSource("justfile");
+    const recipeMatch = source.match(
+      /test-skill-improver-fixtures:[\s\S]*?(?=\n[a-zA-Z][a-zA-Z0-9_-]*[: ]|\n#|$)/u,
+    );
+    expect(recipeMatch).not.toBeNull();
+    const recipe = recipeMatch?.[0] ?? "";
+    expect(recipe).toContain("python python/tools/age_fixture_diff.py");
+  });
+
+  it("iterates the tests/skill-improver-fixtures/*/ directories", async () => {
+    const source = await readSource("justfile");
+    const recipeMatch = source.match(
+      /test-skill-improver-fixtures:[\s\S]*?(?=\n[a-zA-Z][a-zA-Z0-9_-]*[: ]|\n#|$)/u,
+    );
+    expect(recipeMatch).not.toBeNull();
+    const recipe = recipeMatch?.[0] ?? "";
+    expect(recipe).toContain("tests/skill-improver-fixtures");
+  });
+});

--- a/tests/skill-improver-flow.test.ts
+++ b/tests/skill-improver-flow.test.ts
@@ -1,0 +1,271 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter } from "../src/lib/frontmatter.js";
+import {
+  parseAgentFrontmatter,
+  parseCommandFrontmatter,
+  parseSkillFrontmatter,
+} from "../src/lib/schemas.js";
+
+const root = path.resolve(".");
+
+const DIMS = [
+  "activation",
+  "tool-scoping",
+  "context",
+  "prompt-quality",
+  "output-format",
+] as const;
+
+const STAKE_BY_DIM: Record<(typeof DIMS)[number], "high" | "medium"> = {
+  activation: "high",
+  "tool-scoping": "high",
+  context: "medium",
+  "prompt-quality": "medium",
+  "output-format": "medium",
+};
+
+const FIXTURE_STAKE_BY_DIM: Record<(typeof DIMS)[number], "high" | "medium"> = {
+  ...STAKE_BY_DIM,
+};
+
+const FIXTURE_BUCKET_BY_DIM: Record<(typeof DIMS)[number], "high" | "med"> = {
+  activation: "high",
+  "tool-scoping": "high",
+  context: "med",
+  "prompt-quality": "med",
+  "output-format": "med",
+};
+
+const FIXTURE_NARRATIVE_KEYWORDS: Record<(typeof DIMS)[number], RegExp> = {
+  activation: /trigger|summary|routing|description/iu,
+  "tool-scoping": /read-only|disallowedTools|Edit|tilth_edit/u,
+  context: /fork|output|budget|unbounded|verbose/iu,
+  "prompt-quality": /calibration|scaffold|rubric|judgment/iu,
+  "output-format": /summary|table|structured|temp file|pointer/iu,
+};
+
+async function readSource(relativePath: string): Promise<string> {
+  return readFile(path.join(root, relativePath), "utf8");
+}
+
+describe("/skill-improver command shim", () => {
+  it("ships commands/skill-improver.md as a slim shim that delegates to the skill", async () => {
+    const source = await readSource("commands/skill-improver.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    const command = parseCommandFrontmatter(parsed.data);
+
+    expect(command.name).toBe("skill-improver");
+    expect(parsed.body).toContain(
+      "Invoke the `skill-improver` skill with `$ARGUMENTS`",
+    );
+  });
+
+  it("lists all five dimensions in the command body", async () => {
+    const source = await readSource("commands/skill-improver.md");
+    for (const dim of DIMS) {
+      expect(source).toContain(dim);
+    }
+  });
+
+  it("declares the amplifier-pure boundary (no writes) in the command body", async () => {
+    const source = await readSource("commands/skill-improver.md");
+    expect(source).toMatch(/no writes/iu);
+  });
+});
+
+describe("/skill-improver skill orchestrator", () => {
+  it("ships skills/skill-improver/SKILL.md with the skill name", async () => {
+    const source = await readSource("skills/skill-improver/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    const skill = parseSkillFrontmatter(parsed.data);
+
+    expect(skill.name).toBe("skill-improver");
+  });
+
+  it("mentions all five dim names in the orchestrator body", async () => {
+    const source = await readSource("skills/skill-improver/SKILL.md");
+    for (const dim of DIMS) {
+      expect(source).toContain(dim);
+    }
+  });
+
+  it("references reuse of /cleanup and cleanup-wolf rather than new cleanup machinery", async () => {
+    const source = await readSource("skills/skill-improver/SKILL.md");
+    expect(source).toContain("/cleanup");
+    expect(source).toContain("cleanup-wolf");
+  });
+
+  it("references the shared sidecar schema (fixes.json and suggestions.json)", async () => {
+    const source = await readSource("skills/skill-improver/SKILL.md");
+    expect(source).toContain("fixes.json");
+    expect(source).toContain("suggestions.json");
+  });
+
+  it("declares the Claude Code >= 2.1.30 / claude-agent-sdk >= 0.2.63 compatibility gate", async () => {
+    const source = await readSource("skills/skill-improver/SKILL.md");
+    expect(source).toContain("2.1.30");
+    expect(source).toContain("0.2.63");
+  });
+});
+
+describe("/skill-improver dim agents", () => {
+  for (const dim of DIMS) {
+    it(`ships agents/skill-improver-${dim}.md.eta with the correct frontmatter contract`, async () => {
+      const source = await readSource(`agents/skill-improver-${dim}.md.eta`);
+      const parsed = parseFrontmatter<unknown>(source);
+      const frontmatter = parseAgentFrontmatter(parsed.data);
+
+      expect(frontmatter.name).toBe(`skill-improver-${dim}`);
+      expect(frontmatter.models.default).toBe("claude-haiku-4-5");
+      expect(frontmatter.tools).toEqual([
+        "mcp__tilth__tilth_read",
+        "mcp__tilth__tilth_search",
+      ]);
+      expect(frontmatter.skills).toEqual(
+        expect.arrayContaining(["cheez-read", "cheez-search"]),
+      );
+      expect(frontmatter.metadata).toBeDefined();
+      expect(frontmatter.metadata?.dim).toBe(dim);
+      expect(frontmatter.metadata?.stake).toBe(STAKE_BY_DIM[dim]);
+      expect(frontmatter.metadata?.intent).toBe("review");
+      expect(frontmatter.metadata?.owner).toBe("cheese-flow");
+    });
+
+    it(`states the per-agent return contract ($RUN_DIR/${dim}.json) in the body`, async () => {
+      const source = await readSource(`agents/skill-improver-${dim}.md.eta`);
+      const parsed = parseFrontmatter<unknown>(source);
+      expect(parsed.body).toContain(`$RUN_DIR/${dim}.json`);
+    });
+  }
+});
+
+describe("/skill-improver fixture targets", () => {
+  for (const dim of DIMS) {
+    it(`seeds expected.json with a finding bucketed at ${FIXTURE_BUCKET_BY_DIM[dim]} matching the dim's rubric`, async () => {
+      const source = await readSource(
+        `tests/skill-improver-fixtures/${dim}/expected.json`,
+      );
+      const parsed = JSON.parse(source) as {
+        dimension: string;
+        stake?: string;
+        observations: Array<{
+          id: string;
+          bucket: string;
+          narrative: string;
+          anchor: { start: string };
+        }>;
+      };
+
+      expect(parsed.dimension).toBe(dim);
+      expect(parsed.stake).toBe(FIXTURE_STAKE_BY_DIM[dim]);
+      expect(parsed.observations.length).toBeGreaterThanOrEqual(1);
+
+      const first = parsed.observations[0];
+      if (!first) throw new Error("expected at least one observation");
+
+      expect(first.id).toBe(`${dim}-1`);
+      expect(first.bucket).toBe(FIXTURE_BUCKET_BY_DIM[dim]);
+      expect(first.narrative).toMatch(FIXTURE_NARRATIVE_KEYWORDS[dim]);
+      expect(first.anchor.start).toMatch(/^\d+:[0-9a-f]+$/u);
+    });
+
+    it(`seeds target.md.eta with parseable agent frontmatter that exercises the ${dim} dim`, async () => {
+      const source = await readSource(
+        `tests/skill-improver-fixtures/${dim}/target.md.eta`,
+      );
+      const parsed = parseFrontmatter<unknown>(source);
+      const frontmatter = parseAgentFrontmatter(parsed.data);
+
+      expect(frontmatter.name.length).toBeGreaterThan(0);
+      expect(frontmatter.description.length).toBeGreaterThan(0);
+      expect(parsed.body.length).toBeGreaterThan(0);
+    });
+  }
+});
+
+describe("/skill-improver reference files", () => {
+  it("ships skills/skill-improver/references/report-template.md", async () => {
+    const source = await readSource(
+      "skills/skill-improver/references/report-template.md",
+    );
+    expect(source).toContain("Skill-Improver Review");
+    expect(source).toMatch(/orientation/iu);
+    expect(source).toContain("Cross-dimension callouts");
+  });
+
+  it("ships skills/skill-improver/references/fixture-protocol.md", async () => {
+    const source = await readSource(
+      "skills/skill-improver/references/fixture-protocol.md",
+    );
+    expect(source).toContain("age_fixture_diff.py");
+    expect(source).toContain("expected.json");
+    expect(source).toContain("target.md.eta");
+  });
+
+  for (const dim of DIMS) {
+    it(`ships skills/skill-improver/references/${dim}/protocol.md`, async () => {
+      const source = await readSource(
+        `skills/skill-improver/references/${dim}/protocol.md`,
+      );
+      expect(source.length).toBeGreaterThan(200);
+      expect(source).toContain(dim);
+    });
+  }
+});
+
+describe("/skill-improver amplifier-pure boundary", () => {
+  it("does not document a --fix flag in SKILL.md (FR-8: no auto-apply)", async () => {
+    const source = await readSource("skills/skill-improver/SKILL.md");
+    expect(source).not.toMatch(/--fix\b/u);
+  });
+
+  it("does not document a --fix flag in commands/skill-improver.md", async () => {
+    const source = await readSource("commands/skill-improver.md");
+    expect(source).not.toMatch(/--fix\b/u);
+  });
+
+  for (const dim of DIMS) {
+    it(`agents/skill-improver-${dim}.md.eta documents fix as a {category, content} object, not a string`, async () => {
+      const source = await readSource(`agents/skill-improver-${dim}.md.eta`);
+      expect(source).toContain('"fix"');
+      expect(source).toMatch(/"category"\s*:/u);
+      expect(source).toMatch(/"content"\s*:/u);
+    });
+  }
+});
+
+describe("/skill-improver routing", () => {
+  it("is mentioned in the /cheese routing table", async () => {
+    const source = await readSource("commands/cheese.md");
+    expect(source).toContain("/skill-improver");
+  });
+});
+
+describe("/skill-improver justfile recipe", () => {
+  it("declares a test-skill-improver-fixtures recipe", async () => {
+    const source = await readSource("justfile");
+    expect(source).toMatch(/^test-skill-improver-fixtures:/mu);
+  });
+
+  it("reuses python python/tools/age_fixture_diff.py as the comparator", async () => {
+    const source = await readSource("justfile");
+    const recipeMatch = source.match(
+      /test-skill-improver-fixtures:[\s\S]*?(?=\n[a-zA-Z][a-zA-Z0-9_-]*[: ]|\n#|$)/u,
+    );
+    expect(recipeMatch).not.toBeNull();
+    const recipe = recipeMatch?.[0] ?? "";
+    expect(recipe).toContain("python python/tools/age_fixture_diff.py");
+  });
+
+  it("iterates the tests/skill-improver-fixtures/*/ directories", async () => {
+    const source = await readSource("justfile");
+    const recipeMatch = source.match(
+      /test-skill-improver-fixtures:[\s\S]*?(?=\n[a-zA-Z][a-zA-Z0-9_-]*[: ]|\n#|$)/u,
+    );
+    expect(recipeMatch).not.toBeNull();
+    const recipe = recipeMatch?.[0] ?? "";
+    expect(recipe).toContain("tests/skill-improver-fixtures");
+  });
+});


### PR DESCRIPTION
## Summary

Ports `/skill-improver` into cheese-flow as a sibling of `/age` (per `.claude/specs/skill-improver-extraction.md` — SI-1, SI-3). Five orthogonal LLM dimensions audit a single agent or skill definition file, mirroring `/age`'s evidence-first, bucket-confidence, sidecar-JSON shape. The shipped `/cleanup` skill consumes `<slug>.fixes.json` unchanged (SI-2) — zero new mechanical-apply machinery.

| Dim | Stake | Brief |
|---|---|---|
| `activation` | high | Description-as-trigger-spec, trigger phrases, third-person voice, negative triggers, frontmatter routing fields |
| `tool-scoping` | high | Tier match (read-only / write-scoped / focused sub-agent); `disallowedTools` matching prose claims; `skills:` aligned with delegation |
| `context` | medium | Fork vs inline, model rationale, prompt-size budget, output budget, wrap-up signals |
| `prompt-quality` | medium | Structured sections, *why* explanations, decision scaffolds, "What You Don't Do" sections, calibration scaffolds for judgment agents |
| `output-format` | medium | Summary-first layout, scannable tables, threshold tally, detail-vs-summary separation |

## What lands

- \`commands/skill-improver.md\` — slim shim mirroring \`commands/age.md\`
- \`skills/skill-improver/SKILL.md\` + 7 reference files (\`report-template.md\`, \`fixture-protocol.md\`, \`<dim>/protocol.md\` × 5)
- \`agents/skill-improver-<dim>.md.eta\` × 5 (haiku-class, read-only, tilth-only)
- \`tests/skill-improver-fixtures/<dim>/{target.md.eta,expected.json}\` × 5 — each seeds a real defect for its dim
- \`tests/skill-improver-flow.test.ts\` — 46 contract tests
- \`justfile\` recipe \`test-skill-improver-fixtures\` (reuses \`python/tools/age_fixture_diff.py\`)
- Wires \`/skill-improver\` into the \`/cheese\` routing table
- Updates compiler tests to enumerate the new commands/agents/skills

## Spec adherence

- Amplifier-pure boundary preserved: \`/skill-improver\` never auto-invokes \`/cleanup\` (FR-8 inheriting \`/age\` D-14-final). No \`--fix\` flag.
- \`fix\` field shape is \`{category, content}\` per the shared sidecar schema (not a string).
- Per-dim brief content matches the spec's interface-sketch table verbatim.
- \`analytics\` dim deferred (SI-6) until cheese-flow gains session-data infra.
- \`scoring\` concern folded into \`prompt-quality.missing_calibration\` (SI-1).

## Test plan

- [x] \`npm run test\` — 275/275 pass (was 261, added 14 strengthened tests for the new contract)
- [x] \`npm run lint:skills\` — clean (13 skills scanned)
- [x] \`just build\` — green (TypeScript + Python pipelines + 99% coverage)
- [ ] L2 fixture gate (\`just test-skill-improver-fixtures\`) — populated by a real \`/skill-improver\` run; harness expectation matches \`/age\`'s pattern (recipe exits non-zero until \`actual.json\` is generated, same as \`test-age-fixtures\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)