### PR TITLE
feat: add harness detection install planning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,10 @@ import {
   runAllToolChecks,
 } from "./lib/doctor.js";
 import {
+  dedupeHarnessNames,
+  parseHarnessOverrides,
+} from "./lib/install-plan.js";
+import {
   formatLintReport,
   hasErrors,
   lintSkillsDirectory,
@@ -29,14 +33,13 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const defaultProjectRoot = path.resolve(__dirname, "..");
 
-function parseHarness(value: string): HarnessName {
-  if (harnessNames.includes(value as HarnessName)) {
-    return value as HarnessName;
+function parseHarnessArgument(value: string): HarnessName[] {
+  try {
+    return parseHarnessOverrides([value]);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new InvalidArgumentError(message);
   }
-
-  throw new InvalidArgumentError(
-    `Unsupported harness "${value}". Expected one of: ${harnessNames.join(", ")}.`,
-  );
 }
 
 type CompileCommandOptions = {
@@ -45,7 +48,7 @@ type CompileCommandOptions = {
 };
 
 function resolveHarnessTargets(harness: HarnessName[]): HarnessName[] {
-  return harness.length > 0 ? Array.from(new Set(harness)) : harnessNames;
+  return harness.length > 0 ? dedupeHarnessNames(harness) : harnessNames;
 }
 
 async function runCompileCommand(
@@ -86,10 +89,7 @@ program
     "Harness target(s) to compile for. Defaults to all supported harnesses.",
     (value, previous: HarnessName[] | undefined) => {
       const items = Array.isArray(previous) ? previous : [];
-      return [
-        ...items,
-        ...value.split(",").map((item) => parseHarness(item.trim())),
-      ];
+      return [...items, ...parseHarnessArgument(value)];
     },
     [] as HarnessName[],
   )

--- a/src/lib/harness-detection.ts
+++ b/src/lib/harness-detection.ts
@@ -1,0 +1,193 @@
+import { constants } from "node:fs";
+import { access, stat } from "node:fs/promises";
+import path, { delimiter } from "node:path";
+import { harnessAdapters, harnessNames } from "../adapters/index.js";
+import type { HarnessName } from "../domain/harness.js";
+
+export type HarnessInstallCapability =
+  | "auto-install"
+  | "manual-capable"
+  | "unsupported";
+export type HarnessDetectionState = "detected" | "not-detected" | "bypassed";
+export type HarnessDetectionKind = "cli" | "surface";
+
+export type HarnessDetection = {
+  state: HarnessDetectionState;
+  kind?: HarnessDetectionKind;
+  value?: string;
+  reason: string;
+};
+
+export type HarnessDetectionEnvironment = {
+  findCommand?: (command: string) => Promise<string | null>;
+  hasDirectory?: (directoryPath: string) => Promise<boolean>;
+};
+
+type CliProbe = {
+  kind: "cli";
+  command: string;
+};
+
+type SurfaceProbe = {
+  kind: "surface";
+  relativePath: string;
+};
+
+type HarnessDetectionProbe = CliProbe | SurfaceProbe;
+
+type HarnessInstallProfile = {
+  capability: HarnessInstallCapability;
+  probes: readonly HarnessDetectionProbe[];
+};
+
+const harnessInstallProfiles = {
+  "claude-code": {
+    capability: "manual-capable",
+    probes: [{ kind: "cli", command: "claude" }],
+  },
+  codex: {
+    capability: "manual-capable",
+    probes: [{ kind: "cli", command: "codex" }],
+  },
+  cursor: {
+    capability: "auto-install",
+    probes: [{ kind: "surface", relativePath: ".cursor" }],
+  },
+  "copilot-cli": {
+    capability: "auto-install",
+    probes: [{ kind: "cli", command: "copilot" }],
+  },
+} satisfies Record<HarnessName, HarnessInstallProfile>;
+
+type DetectHarnessesOptions = {
+  projectRoot: string;
+  environment?: HarnessDetectionEnvironment;
+};
+
+type DetectHarnessOptions = {
+  harness: HarnessName;
+  projectRoot: string;
+  findCommand: (command: string) => Promise<string | null>;
+  hasDirectory: (directoryPath: string) => Promise<boolean>;
+};
+
+export function getHarnessInstallCapability(
+  harness: HarnessName,
+): HarnessInstallCapability {
+  return harnessInstallProfiles[harness].capability;
+}
+
+export async function findCommandOnPath(
+  command: string,
+  searchPath = process.env.PATH ?? process.env.Path ?? "",
+): Promise<string | null> {
+  const directories = searchPath.split(delimiter).filter(Boolean);
+  const extensions = process.platform === "win32" ? pathExtensions() : [""];
+
+  for (const directory of directories) {
+    for (const extension of extensions) {
+      const candidate = path.join(directory, withExtension(command, extension));
+      try {
+        await access(candidate, constants.X_OK);
+        return candidate;
+      } catch {}
+    }
+  }
+
+  return null;
+}
+
+export async function hasDirectory(directoryPath: string): Promise<boolean> {
+  try {
+    const stats = await stat(directoryPath);
+    return stats.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export async function detectAvailableHarnesses(
+  options: DetectHarnessesOptions,
+): Promise<Record<HarnessName, HarnessDetection>> {
+  const findCommand = options.environment?.findCommand ?? findCommandOnPath;
+  const checkDirectory = options.environment?.hasDirectory ?? hasDirectory;
+  const detections = await Promise.all(
+    harnessNames.map(async (harness) => [
+      harness,
+      await detectHarness({
+        harness,
+        projectRoot: options.projectRoot,
+        findCommand,
+        hasDirectory: checkDirectory,
+      }),
+    ]),
+  );
+
+  return Object.fromEntries(detections) as Record<
+    HarnessName,
+    HarnessDetection
+  >;
+}
+
+async function detectHarness(
+  options: DetectHarnessOptions,
+): Promise<HarnessDetection> {
+  const displayName = harnessAdapters[options.harness].displayName;
+  const probes = harnessInstallProfiles[options.harness].probes;
+
+  for (const probe of probes) {
+    if (probe.kind === "cli") {
+      const commandPath = await options.findCommand(probe.command);
+      if (commandPath !== null) {
+        return {
+          state: "detected",
+          kind: "cli",
+          value: commandPath,
+          reason: `Auto-detected ${displayName} via CLI "${probe.command}".`,
+        };
+      }
+      continue;
+    }
+
+    const directoryPath = path.join(options.projectRoot, probe.relativePath);
+    if (await options.hasDirectory(directoryPath)) {
+      return {
+        state: "detected",
+        kind: "surface",
+        value: directoryPath,
+        reason: `Auto-detected ${displayName} via ${probe.relativePath}/.`,
+      };
+    }
+  }
+
+  return {
+    state: "not-detected",
+    reason: `No ${displayName} ${describeProbes(probes)} detected.`,
+  };
+}
+
+function describeProbes(probes: readonly HarnessDetectionProbe[]): string {
+  return probes.map(describeProbe).join(" or ");
+}
+
+function describeProbe(probe: HarnessDetectionProbe): string {
+  return probe.kind === "cli"
+    ? `CLI "${probe.command}" on PATH`
+    : `project surface "${probe.relativePath}"`;
+}
+
+function pathExtensions(): string[] {
+  const configured = process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM";
+  return configured.split(";").filter(Boolean);
+}
+
+function withExtension(command: string, extension: string): string {
+  if (
+    process.platform === "win32" &&
+    command.toLowerCase().endsWith(extension.toLowerCase())
+  ) {
+    return command;
+  }
+
+  return `${command}${extension}`;
+}

--- a/src/lib/install-plan.ts
+++ b/src/lib/install-plan.ts
@@ -1,0 +1,178 @@
+import { harnessAdapters, harnessNames } from "../adapters/index.js";
+import type { HarnessName } from "../domain/harness.js";
+import {
+  detectAvailableHarnesses,
+  getHarnessInstallCapability,
+  type HarnessDetection,
+  type HarnessDetectionEnvironment,
+  type HarnessInstallCapability,
+} from "./harness-detection.js";
+
+export type {
+  HarnessDetection,
+  HarnessDetectionEnvironment,
+  HarnessDetectionKind,
+  HarnessDetectionState,
+  HarnessInstallCapability,
+} from "./harness-detection.js";
+export {
+  detectAvailableHarnesses,
+  findCommandOnPath,
+  hasDirectory,
+} from "./harness-detection.js";
+
+export type HarnessSelectionMode = "auto-detect" | "explicit";
+export type HarnessSelectionStatus = "selected" | "skipped";
+
+export type HarnessInstallPlanEntry = {
+  harness: HarnessName;
+  displayName: string;
+  outputRoot: string;
+  selection: HarnessSelectionStatus;
+  capability: HarnessInstallCapability;
+  detection: HarnessDetection;
+  reason: string;
+};
+
+export type HarnessInstallPlan = {
+  selectionMode: HarnessSelectionMode;
+  requestedHarnesses: HarnessName[];
+  selectedHarnesses: HarnessName[];
+  entries: HarnessInstallPlanEntry[];
+  ok: boolean;
+  guidance?: string;
+};
+
+type CreateHarnessInstallPlanOptions = {
+  projectRoot: string;
+  environment?: HarnessDetectionEnvironment;
+  requestedHarnesses?: readonly HarnessName[];
+};
+
+type BuildPlanEntryOptions = {
+  harness: HarnessName;
+  selection: HarnessSelectionStatus;
+  detection: HarnessDetection;
+};
+
+export function parseHarnessName(value: string): HarnessName {
+  const trimmed = value.trim();
+  if (harnessNames.includes(trimmed as HarnessName)) {
+    return trimmed as HarnessName;
+  }
+
+  throw new Error(
+    `Unsupported harness "${trimmed}". Expected one of: ${harnessNames.join(", ")}.`,
+  );
+}
+
+export function dedupeHarnessNames(
+  harnesses: readonly HarnessName[],
+): HarnessName[] {
+  const seen = new Set<HarnessName>();
+  return harnesses.filter((harness) => {
+    if (seen.has(harness)) return false;
+    seen.add(harness);
+    return true;
+  });
+}
+
+export function parseHarnessOverrides(
+  values: readonly string[],
+): HarnessName[] {
+  return dedupeHarnessNames(
+    values.flatMap((value) => value.split(",").map(parseHarnessName)),
+  );
+}
+
+export async function createHarnessInstallPlan(
+  options: CreateHarnessInstallPlanOptions,
+): Promise<HarnessInstallPlan> {
+  const requestedHarnesses = dedupeHarnessNames(
+    options.requestedHarnesses ?? [],
+  );
+  if (requestedHarnesses.length > 0) {
+    return buildExplicitInstallPlan(requestedHarnesses);
+  }
+
+  return buildAutoDetectInstallPlan(
+    await detectAvailableHarnesses(options),
+    requestedHarnesses,
+  );
+}
+
+function buildExplicitInstallPlan(
+  requestedHarnesses: HarnessName[],
+): HarnessInstallPlan {
+  const requestedSet = new Set(requestedHarnesses);
+  return {
+    selectionMode: "explicit",
+    requestedHarnesses,
+    selectedHarnesses: requestedHarnesses,
+    ok: true,
+    entries: harnessNames.map((harness) =>
+      buildPlanEntry({
+        harness,
+        selection: requestedSet.has(harness) ? "selected" : "skipped",
+        detection: {
+          state: "bypassed",
+          reason: "Skipped auto-detect because --harness was provided.",
+        },
+      }),
+    ),
+  };
+}
+
+function buildAutoDetectInstallPlan(
+  detections: Record<HarnessName, HarnessDetection>,
+  requestedHarnesses: HarnessName[],
+): HarnessInstallPlan {
+  const selectedHarnesses = harnessNames.filter(
+    (harness) => detections[harness].state === "detected",
+  );
+  const guidance =
+    selectedHarnesses.length > 0
+      ? undefined
+      : 'No installed harnesses detected. Re-run with --harness <name> or use "cheese compile".';
+
+  return {
+    selectionMode: "auto-detect",
+    requestedHarnesses,
+    selectedHarnesses,
+    ok: selectedHarnesses.length > 0,
+    ...(guidance === undefined ? {} : { guidance }),
+    entries: harnessNames.map((harness) =>
+      buildPlanEntry({
+        harness,
+        selection:
+          detections[harness].state === "detected" ? "selected" : "skipped",
+        detection: detections[harness],
+      }),
+    ),
+  };
+}
+
+function buildPlanEntry(
+  options: BuildPlanEntryOptions,
+): HarnessInstallPlanEntry {
+  const adapter = harnessAdapters[options.harness];
+  const selectedReason =
+    options.detection.state === "bypassed"
+      ? "Selected explicitly via --harness."
+      : options.detection.reason;
+
+  return {
+    harness: options.harness,
+    displayName: adapter.displayName,
+    outputRoot: adapter.outputRoot,
+    selection: options.selection,
+    capability: getHarnessInstallCapability(options.harness),
+    detection: options.detection,
+    reason:
+      options.selection === "selected"
+        ? selectedReason
+        : options.detection.state === "bypassed"
+          ? "Skipped because it was not requested via --harness."
+          : options.detection.reason,
+  };
+}

--- a/tests/harness-detection.test.ts
+++ b/tests/harness-detection.test.ts
@@ -1,0 +1,176 @@
+import { randomUUID } from "node:crypto";
+import { chmod, mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  detectAvailableHarnesses,
+  findCommandOnPath,
+  getHarnessInstallCapability,
+} from "../src/lib/harness-detection.js";
+
+const createdDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    createdDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function makeDirectory(prefix: string): Promise<string> {
+  const directory = path.resolve(".test-runtime", `${prefix}-${randomUUID()}`);
+  await mkdir(directory, { recursive: true });
+  createdDirectories.push(directory);
+  return directory;
+}
+
+async function writeExecutable(
+  directory: string,
+  name: string,
+): Promise<string> {
+  const filePath = path.join(directory, name);
+  await writeFile(filePath, "#!/bin/sh\nexit 0\n", "utf8");
+  await chmod(filePath, 0o755);
+  return filePath;
+}
+
+async function withPlatform<T>(
+  platform: NodeJS.Platform,
+  run: () => Promise<T>,
+): Promise<T> {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  if (descriptor === undefined) {
+    throw new Error("process.platform descriptor is unavailable");
+  }
+
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+  try {
+    return await run();
+  } finally {
+    Object.defineProperty(process, "platform", descriptor);
+  }
+}
+
+function restoreEnv(
+  name: "PATH" | "Path" | "PATHEXT",
+  value: string | undefined,
+): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
+describe("getHarnessInstallCapability", () => {
+  it("classifies harnesses by install capability", () => {
+    expect(getHarnessInstallCapability("claude-code")).toBe("manual-capable");
+    expect(getHarnessInstallCapability("cursor")).toBe("auto-install");
+  });
+});
+
+describe("findCommandOnPath", () => {
+  it("uses PATH first, then Path, and returns null when neither is set", async () => {
+    const binDirectory = await makeDirectory("path-bin");
+    const executablePath = await writeExecutable(binDirectory, "copilot");
+    const originalPath = process.env.PATH;
+    const originalWindowsPath = process.env.Path;
+
+    try {
+      process.env.PATH = binDirectory;
+      delete process.env.Path;
+      await expect(findCommandOnPath("copilot")).resolves.toBe(executablePath);
+
+      delete process.env.PATH;
+      process.env.Path = binDirectory;
+      await expect(findCommandOnPath("copilot")).resolves.toBe(executablePath);
+
+      delete process.env.Path;
+      await expect(findCommandOnPath("copilot")).resolves.toBeNull();
+    } finally {
+      restoreEnv("PATH", originalPath);
+      restoreEnv("Path", originalWindowsPath);
+    }
+  });
+
+  it("applies win32 PATHEXT probes and preserves explicit extensions", async () => {
+    const binDirectory = await makeDirectory("win-bin");
+    const defaultExtensionPath = await writeExecutable(
+      binDirectory,
+      "codex.COM",
+    );
+    const explicitExtensionPath = await writeExecutable(
+      binDirectory,
+      "copilot.CMD",
+    );
+    const originalPathExt = process.env.PATHEXT;
+
+    try {
+      delete process.env.PATHEXT;
+      await withPlatform("win32", async () => {
+        await expect(findCommandOnPath("codex", binDirectory)).resolves.toBe(
+          defaultExtensionPath,
+        );
+      });
+
+      process.env.PATHEXT = ".EXE;.CMD";
+      await withPlatform("win32", async () => {
+        await expect(findCommandOnPath("copilot", binDirectory)).resolves.toBe(
+          explicitExtensionPath,
+        );
+        await expect(
+          findCommandOnPath("copilot.CMD", binDirectory),
+        ).resolves.toBe(explicitExtensionPath);
+      });
+    } finally {
+      restoreEnv("PATHEXT", originalPathExt);
+    }
+  });
+});
+
+describe("detectAvailableHarnesses", () => {
+  it("uses default file-system and PATH probes when no environment override is provided", async () => {
+    const projectRoot = await makeDirectory("project-root");
+    const binDirectory = await makeDirectory("detect-bin");
+    const detectedCommandPath = await writeExecutable(binDirectory, "copilot");
+    const cursorSurface = path.join(projectRoot, ".cursor");
+    const originalPath = process.env.PATH;
+    const originalWindowsPath = process.env.Path;
+
+    await mkdir(cursorSurface, { recursive: true });
+
+    try {
+      process.env.PATH = binDirectory;
+      delete process.env.Path;
+
+      const detections = await detectAvailableHarnesses({ projectRoot });
+
+      expect(detections["copilot-cli"]).toMatchObject({
+        state: "detected",
+        kind: "cli",
+        value: detectedCommandPath,
+      });
+      expect(detections.cursor).toMatchObject({
+        state: "detected",
+        kind: "surface",
+        value: cursorSurface,
+      });
+      expect(detections["claude-code"]).toEqual({
+        state: "not-detected",
+        reason: 'No Claude Code CLI "claude" on PATH detected.',
+      });
+      expect(detections.codex).toEqual({
+        state: "not-detected",
+        reason: 'No Codex CLI "codex" on PATH detected.',
+      });
+    } finally {
+      restoreEnv("PATH", originalPath);
+      restoreEnv("Path", originalWindowsPath);
+    }
+  });
+});

--- a/tests/install-plan.test.ts
+++ b/tests/install-plan.test.ts
@@ -1,0 +1,167 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { HarnessName } from "../src/domain/harness.js";
+import {
+  createHarnessInstallPlan,
+  findCommandOnPath,
+  type HarnessDetectionEnvironment,
+  type HarnessInstallPlan,
+  hasDirectory,
+  parseHarnessOverrides,
+} from "../src/lib/install-plan.js";
+
+function makeEnvironment(options: {
+  commands?: string[];
+  surfaces?: string[];
+}): HarnessDetectionEnvironment {
+  const commands = new Set(options.commands ?? []);
+  const surfaces = new Set(options.surfaces ?? []);
+
+  return {
+    findCommand: async (command) =>
+      commands.has(command) ? path.join("/mock/bin", command) : null,
+    hasDirectory: async (directoryPath) => surfaces.has(directoryPath),
+  };
+}
+
+function getEntry(plan: HarnessInstallPlan, harness: HarnessName) {
+  const entry = plan.entries.find((candidate) => candidate.harness === harness);
+  if (entry === undefined) {
+    throw new Error(`Missing plan entry for ${harness}`);
+  }
+  return entry;
+}
+
+describe("findCommandOnPath", () => {
+  it("finds commands that are already on PATH", async () => {
+    await expect(findCommandOnPath("node")).resolves.toEqual(
+      expect.any(String),
+    );
+  });
+});
+
+describe("hasDirectory", () => {
+  it("detects directories on disk", async () => {
+    await expect(hasDirectory(path.resolve("src"))).resolves.toBe(true);
+    await expect(
+      hasDirectory(path.resolve("missing-install-plan-directory")),
+    ).resolves.toBe(false);
+  });
+});
+
+describe("createHarnessInstallPlan", () => {
+  it("auto-detects a single manual-capable harness from its CLI", async () => {
+    const plan = await createHarnessInstallPlan({
+      projectRoot: "/workspace",
+      environment: makeEnvironment({ commands: ["claude"] }),
+    });
+
+    expect(plan.selectionMode).toBe("auto-detect");
+    expect(plan.ok).toBe(true);
+    expect(plan.selectedHarnesses).toEqual(["claude-code"]);
+
+    expect(getEntry(plan, "claude-code")).toMatchObject({
+      selection: "selected",
+      capability: "manual-capable",
+      detection: {
+        state: "detected",
+        kind: "cli",
+        value: path.join("/mock/bin", "claude"),
+      },
+    });
+    expect(getEntry(plan, "codex").selection).toBe("skipped");
+  });
+
+  it("auto-detects multiple harnesses from CLI and project surfaces", async () => {
+    const projectRoot = "/workspace";
+    const plan = await createHarnessInstallPlan({
+      projectRoot,
+      environment: makeEnvironment({
+        commands: ["copilot"],
+        surfaces: [path.join(projectRoot, ".cursor")],
+      }),
+    });
+
+    expect(plan.selectionMode).toBe("auto-detect");
+    expect(plan.ok).toBe(true);
+    expect(plan.selectedHarnesses).toEqual(["cursor", "copilot-cli"]);
+    expect(getEntry(plan, "cursor")).toMatchObject({
+      selection: "selected",
+      capability: "auto-install",
+      detection: {
+        state: "detected",
+        kind: "surface",
+        value: path.join(projectRoot, ".cursor"),
+      },
+    });
+    expect(getEntry(plan, "copilot-cli")).toMatchObject({
+      selection: "selected",
+      capability: "auto-install",
+      detection: {
+        state: "detected",
+        kind: "cli",
+        value: path.join("/mock/bin", "copilot"),
+      },
+    });
+  });
+
+  it("preserves explicit harness order after dedupe and bypasses auto-detect", async () => {
+    const requestedHarnesses = parseHarnessOverrides([
+      "copilot-cli,cursor",
+      "copilot-cli",
+      "claude-code,cursor",
+    ]);
+    const plan = await createHarnessInstallPlan({
+      projectRoot: "/workspace",
+      requestedHarnesses,
+      environment: makeEnvironment({ commands: ["codex"] }),
+    });
+
+    expect(requestedHarnesses).toEqual([
+      "copilot-cli",
+      "cursor",
+      "claude-code",
+    ]);
+    expect(plan.selectionMode).toBe("explicit");
+    expect(plan.ok).toBe(true);
+    expect(plan.selectedHarnesses).toEqual(requestedHarnesses);
+    expect(getEntry(plan, "copilot-cli")).toMatchObject({
+      selection: "selected",
+      capability: "auto-install",
+      detection: { state: "bypassed" },
+    });
+    expect(getEntry(plan, "claude-code")).toMatchObject({
+      selection: "selected",
+      capability: "manual-capable",
+      detection: { state: "bypassed" },
+    });
+    expect(getEntry(plan, "codex")).toMatchObject({
+      selection: "skipped",
+      detection: { state: "bypassed" },
+    });
+  });
+
+  it("returns guidance when auto-detect finds no harnesses", async () => {
+    const plan = await createHarnessInstallPlan({
+      projectRoot: "/workspace",
+      environment: makeEnvironment({}),
+    });
+
+    expect(plan.selectionMode).toBe("auto-detect");
+    expect(plan.ok).toBe(false);
+    expect(plan.selectedHarnesses).toEqual([]);
+    expect(plan.guidance).toContain("--harness <name>");
+    expect(plan.guidance).toContain("cheese compile");
+    expect(plan.entries.every((entry) => entry.selection === "skipped")).toBe(
+      true,
+    );
+  });
+});
+
+describe("parseHarnessOverrides", () => {
+  it("rejects unsupported harness names", () => {
+    expect(() => parseHarnessOverrides(["bogus"])).toThrow(
+      /Unsupported harness/u,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add harness detection primitives and install planning helpers for explicit and auto-detected installs
- reuse the new harness parsing helpers in the compile CLI so repeated or comma-separated `--harness` values stay deduped and validated
- cover detection and selection flows with focused install-plan and harness-detection tests

## Stack
- Merge after #37 (already merged)
- Merge before #41

## Testing
- `npx vitest run tests/harness-detection.test.ts tests/install-plan.test.ts tests/compiler.test.ts --reporter=dot`
- `just build` on top-of-stack #42 (`a39cb96`)
