### PR TITLE
docs(mold): rename crystallize to curdle

### DIFF
--- a/commands/mold.md
+++ b/commands/mold.md
@@ -1,6 +1,6 @@
 ---
 name: mold
-description: Iterative thinking amplifier for fuzzy ideas. Routes input to a starting mode (Explore, Ground, Shape, Sketch, Grill, Diagnose), runs Validate Cycles, locks down interfaces in pseudocode, and crystallizes a spec (and optional issues) only after a two-key handshake.
+description: Iterative thinking amplifier for fuzzy ideas. Routes input to a starting mode (Explore, Ground, Shape, Sketch, Grill, Diagnose), runs Validate Cycles, locks down interfaces in pseudocode, and curdles a spec (and optional issues) only after a two-key handshake.
 argument-hint: "<rough idea | feature request | bug | spec path | design doc>"
 ---
 
@@ -28,7 +28,7 @@ is the implementation source of truth.
 | --- | --- |
 | `/culture` | Same dialogue feel; **never writes**. Use it when there is no artifact intent. |
 | `/briesearch` | External evidence dispatcher. `/mold` calls it through the Validate Cycle. |
-| `/cook` | Implements a crystallized spec. `/mold` ends with a hand-off offer, never an auto-invoke. |
+| `/cook` | Implements a curdled spec. `/mold` ends with a hand-off offer, never an auto-invoke. |
 
 ## What you get
 

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mold
-description: Iterative thinking amplifier for fuzzy ideas. Routes input to the right starting mode (Explore, Ground, Shape, Sketch, Grill, Diagnose), runs Validate Cycles to anchor claims, locks down interfaces in pseudocode, and only crystallizes a spec (and optional issues) after a two-key handshake plus a coherence self-check.
+description: Iterative thinking amplifier for fuzzy ideas. Routes input to the right starting mode (Explore, Ground, Shape, Sketch, Grill, Diagnose), runs Validate Cycles to anchor claims, locks down interfaces in pseudocode, and only curdles a spec (and optional issues) after a two-key handshake plus a coherence self-check.
 license: MIT
 compatibility: Works in markdown-based coding harnesses with sub-agent support. Heavy delegation to /briesearch and cheez-* skills. When tilth MCP is absent, substitute the host Read tool for local file references — the no-speculation invariant (Operating Principle 2) still holds.
 metadata:
@@ -26,14 +26,14 @@ without artifact intent (use `/culture`), or library-only research (use
 ## What `/mold` is
 
 A **thinking amplifier**, not a pre-prompt. The dialogue is the point;
-artifacts are the by-product. The terminal step crystallizes whatever the
+artifacts are the by-product. The terminal step curdles whatever the
 dialogue actually produced — never more, never less.
 
 | Companion | Boundary |
 | --- | --- |
 | `/culture` | Same dialogue feel; **never writes**. Use it when there is no artifact intent. |
 | `/briesearch` | External evidence dispatcher. `/mold` calls it through the Validate Cycle. |
-| `/cook` | Implements a crystallized spec. `/mold` ends with a hand-off offer, never an auto-invoke. |
+| `/cook` | Implements a curdled spec. `/mold` ends with a hand-off offer, never an auto-invoke. |
 
 ## Operating principles
 
@@ -45,7 +45,7 @@ dialogue actually produced — never more, never less.
 3. **State a hypothesis before researching.** A bare research dispatch is
    discouraged; the Validate Cycle frame forces commitment plus a judgment
    step.
-4. **Lock down interfaces before crystallizing.** Every cross-slice seam
+4. **Lock down interfaces before curdling.** Every cross-slice seam
    gets a pseudocode signature with named unknowns, a recommended answer,
    and an explicit Sliced Bread slice (`domains/<name>`, `adapters/<name>`,
    `app`, or `domains/common`). Architecture rules in
@@ -55,7 +55,7 @@ dialogue actually produced — never more, never less.
 6. **Heavy delegation.** `/briesearch` for external research, `cheez-search`
    / `cheez-read` for in-repo grounding. Do not reinvent.
 7. **No production writes during the loop.** The only writes happen on
-   Crystallize, after explicit approval.
+   Curdle, after explicit approval.
 
 ## Routing — input shape to starting mode
 
@@ -72,7 +72,7 @@ Detail in `references/routing.md`.
 
 ## The six modes
 
-Crystallize is a terminal state, not a mode.
+Curdle is a terminal state, not a mode.
 
 ### Explore — intent extraction
 Job: collapse ambiguity with high-leverage questions. Borrow the `Beat 0`
@@ -126,7 +126,7 @@ bisection harness, differential loop, ...) before chasing hypotheses.
 The chosen loop becomes the Reproduction block in the bug-shaped spec, so
 `/cook` can verify the fix against the same signal the diagnosis used.
 Diagnose is **diagnostic-only** — hand-off to Shape ("what's the fix?")
-then Crystallize emits a bug-shaped spec plus optional follow-up issues.
+then Curdle emits a bug-shaped spec plus optional follow-up issues.
 Loop menu and discipline in `references/diagnose-mode.md`.
 
 ## The Validate Cycle (cross-mode sub-pattern)
@@ -190,9 +190,9 @@ in `references/state-schema.md`.
 ## User knobs (free-form interrupts)
 
 `explore`, `ground`, `shape`, `sketch`, `grill`, `diagnose`,
-`validate <hypothesis>`, `crystallize`, `pause`, `enough`. The agent honours
-these immediately. `crystallize` initiates the handshake; it does not skip
-the Sketch gate unless the user follows up with `crystallize anyway`.
+`validate <hypothesis>`, `curdle`, `pause`, `enough`. The agent honours
+these immediately. `curdle` initiates the handshake; it does not skip
+the Sketch gate unless the user follows up with `curdle anyway`.
 
 ## Uncertainty markers
 
@@ -205,14 +205,14 @@ the Sketch gate unless the user follows up with `crystallize anyway`.
 
 ## Termination — two-key handshake
 
-**User key:** explicit `crystallize`, `ship it`, `extract`, `that's enough`.
+**User key:** explicit `curdle`, `ship it`, `extract`, `that's enough`.
 Never inferred.
 
 **Agent key:** structured coherence self-check. Print this checklist and
 require every box checked before extraction (or an explicit override):
 
 ```
-Coherence self-check before crystallize:
+Coherence self-check before curdle:
 - [ ] Problem statement: grounded, agreed
 - [ ] At least 2 options weighed (Do Nothing included)
 - [ ] Chosen option grounded in codebase evidence
@@ -225,7 +225,7 @@ Coherence self-check before crystallize:
 - [ ] Reproduction loop captured if Diagnose ran (or `[BLOCKED]` if no loop is possible)
 ```
 
-Guard conditions are mandatory before Crystallize except where noted:
+Guard conditions are mandatory before Curdle except where noted:
 
 - *Ground gate* — at least one Ground pass with a citation before Shape's
   options. Exception: pure greenfield (the agent must say so).
@@ -237,12 +237,12 @@ Guard conditions are mandatory before Crystallize except where noted:
   radius is measured by `cheez-search` callers/imports for the touched
   symbols.
 - *Open hypotheses must settle* — any Validate Cycle launched but unjudged
-  blocks Crystallize unless the user accepts it as `[TBD]`.
+  blocks Curdle unless the user accepts it as `[TBD]`.
 
 If any box is unchecked, name it and propose the smallest move to fill it.
-The user can override with `crystallize anyway`.
+The user can override with `curdle anyway`.
 
-## Crystallize — artifact extraction
+## Curdle — artifact extraction
 
 Two artifact types:
 
@@ -317,7 +317,7 @@ Rules in `references/loop-detection.md`.
 
 ## Rules
 
-- Do not write to production paths during the dialogue. Only Crystallize
+- Do not write to production paths during the dialogue. Only Curdle
   writes files, only after the two-key handshake.
 - Do not direct-call `/briesearch` for unstated questions; wrap external
   evidence in a Validate Cycle.

--- a/skills/mold/references/diagnose-mode.md
+++ b/skills/mold/references/diagnose-mode.md
@@ -58,7 +58,7 @@ file, log dump, core dump, screen recording with timestamps), or (c)
 permission to add temporary production instrumentation. Do **not** proceed
 to hypothesise without a loop.
 
-If the answer is still "no loop", Crystallize emits an issue with the
+If the answer is still "no loop", Curdle emits an issue with the
 Reproduction block marked `[BLOCKED]` so `/cook` does not silently try
 to fix a bug it cannot verify.
 
@@ -100,17 +100,17 @@ big time saver.
 ## Phase 3 — Confirm root cause
 
 The surviving hypothesis becomes the working root cause. Before
-Crystallize, the agent must:
+Curdle, the agent must:
 
 - Run the Phase 0 loop again with the working root cause held in mind —
   the prediction the hypothesis makes must match what the loop reports.
 - Distinguish "necessary" from "sufficient": is fixing this hypothesis
   enough to make the loop go green, or are there contributing causes?
 - If the loop only goes green when **multiple** hypotheses are addressed,
-  Crystallize emits one spec for the primary fix plus an issue for each
+  Curdle emits one spec for the primary fix plus an issue for each
   contributing cause.
 
-## Hand-off to Crystallize
+## Hand-off to Curdle
 
 The bug-shaped spec absorbs:
 

--- a/skills/mold/references/issue.md
+++ b/skills/mold/references/issue.md
@@ -1,6 +1,6 @@
 # Issue template
 
-Issues are the second artifact type `/mold` can crystallize. They are
+Issues are the second artifact type `/mold` can curdle. They are
 GitHub-flavored and stand alone — independent enough to be filed as
 `gh issue create --body-file <path>` without the parent spec.
 

--- a/skills/mold/references/loop-detection.md
+++ b/skills/mold/references/loop-detection.md
@@ -38,7 +38,7 @@ acknowledgements) **two or more turns in a row**.
 You sound disengaged. Options:
   A. Switch modes — `explore` (back up) | `shape` (skip to options) |
      `sketch` (lock interfaces now).
-  B. Crystallize what we have, even if rough — I'll mark gaps as [TBD].
+  B. Curdle what we have, even if rough — I'll mark gaps as [TBD].
   C. Pause — bail out, no artifacts.
 
 Or just type the knob you want.

--- a/skills/mold/references/sketch-mode.md
+++ b/skills/mold/references/sketch-mode.md
@@ -12,7 +12,7 @@ Enter Sketch when:
 - The starting input was already a half-baked design doc with signatures.
 
 If Sketch is mandatory (chosen option touches more than one module or
-introduces a new public interface) and the user tries to skip to Crystallize,
+introduces a new public interface) and the user tries to skip to Curdle,
 the coherence gate blocks the handshake until Sketch runs.
 
 ## The pseudocode-driven question pattern
@@ -121,7 +121,7 @@ before locking the signature. Common cycles:
 
 Sketches live in the state file's `Sketches (locked interfaces)` block
 during the loop, then migrate verbatim into the spec's `Interface Sketches`
-section at Crystallize. Each sketch carries:
+section at Curdle. Each sketch carries:
 
 - `module` — slice path or file path.
 - `slice` — Sliced Bread slice (`domains/<name>`, `adapters/<name>`, `app`, or `domains/common`).

--- a/skills/mold/references/spec.md
+++ b/skills/mold/references/spec.md
@@ -1,6 +1,6 @@
 # Spec template
 
-The spec is the rich container produced at Crystallize. It absorbs
+The spec is the rich container produced at Curdle. It absorbs
 PRD-leaning, ERD-leaning, decision-log, and interface-sketch content as
 named sections. Functional and non-functional requirements are always
 present. All other conditional sections are populated only when the
@@ -226,7 +226,7 @@ specific evidence (validate cycle id, Grill turn, sibling file ref).
 
 ## Migration from state file
 
-At Crystallize:
+At Curdle:
 
 - `Decisions (resolved)` block in state → `Decisions` section in spec
   (with Context / Decision / Consequences expanded by the agent).

--- a/skills/mold/references/state-schema.md
+++ b/skills/mold/references/state-schema.md
@@ -93,13 +93,13 @@ Explore (1-3) → Ground (4-5) → Shape (6-8) → [validate cycle 1] → Sketch
   Each sketch is a small block with `module`, `slice`, `signature`,
   `responsibilities`, `seams`, `error_shape`. The `slice` field names the
   Sliced Bread slice (`domains/<name>`, `adapters/<name>`, `app`, or
-  `domains/common`) and gates the crystallize crust check.
+  `domains/common`) and gates the curdle crust check.
 - **Validate cycles** — append-only. Outcomes are exactly one of `SUPPORTED`,
   `CONTRADICTED`, `REFINED`. REFINED cycles point at their refined-form id.
   CONTRADICTED cycles get a `conflict_id` that ties to an `Open questions`
   entry.
 - **Open questions** — every entry carries one of `[?]`, `[TBD]`,
-  `[BLOCKED]`, `[CONFLICT <id>]`. The Crystallize coherence gate fails if
+  `[BLOCKED]`, `[CONFLICT <id>]`. The Curdle coherence gate fails if
   any entry lacks a marker.
 - **Grill turns** — append-only. One line per Grill question. Records the
   branch traversed, the question asked, the agent's recommended answer, and
@@ -119,12 +119,12 @@ Explore (1-3) → Ground (4-5) → Shape (6-8) → [validate cycle 1] → Sketch
 - **Create** — on first turn, after routing picks the entry mode.
 - **Update** — every turn the agent writes the file (replace, not append).
 - **Read** — the agent reads the previous state at the start of each turn.
-- **Migrate to spec** — on Crystallize, the spec template absorbs
+- **Migrate to spec** — on Curdle, the spec template absorbs
   `Decisions`, `Sketches`, `Quality gates`, and (if Diagnose ran) `Reproduction
   loop` verbatim into named sections. Validate cycles feed confidence and the
   spec's evidence rows. `Grill turns` is not migrated — it serves the
   coherence checklist and stays in scratch state.
-- **Cleanup** — after a successful Crystallize *and* the user accepts the
+- **Cleanup** — after a successful Curdle *and* the user accepts the
   hand-off offer, the run directory is removed. Otherwise it stays for the
   OS to evict.
 


### PR DESCRIPTION
## Summary
- Replaces "crystallize" with "curdle" (and all conjugations) across `/mold` to align the terminal artifact-extraction step with the project's cheese-themed verb vocabulary.
- Updates user-facing keyword commands: `curdle` and `curdle anyway` now trigger the handshake and override path.
- No logic changes — pure terminology rename across `commands/mold.md`, `skills/mold/SKILL.md`, and the six `skills/mold/references/*.md` files.

## Test plan
- [ ] Skim `/mold` flow to confirm no stray "crystallize" references remain.
- [ ] Verify `/cook` handoff still reads naturally ("curdled spec").

🤖 Generated with [Claude Code](https://claude.com/claude-code)