### PR TITLE
feat(cheez-search): add ast-grep fallback for AST-shape patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,12 @@ just clean       # Remove build artifacts and caches
 
 For anything else, call the underlying tool directly (`npx tsx src/index.ts ...`, `npm run <script>`, `uv run ...`).
 
+## Required host tools
+
+- **Node 22+** and **npm** — TypeScript build, MCP servers (`tilth`, milknado), and `@ast-grep/cli`.
+- **uv** — Python toolchain for `milknado` and `python/` checks.
+- **`sg` (ast-grep)** — invoked from agent prompts (e.g. `nih-scanner`) for AST-shape patterns the tilth MCP doesn't cover. `just install` pulls `@ast-grep/cli` into `node_modules/.bin`; for a global `sg` use `brew install ast-grep`, `cargo install ast-grep`, or `npm i -g @ast-grep/cli`.
+
 ## Project Overview
 
 cheese-flow is opinionated scaffolding for portable agents and skills that compile into harness-specific markdown bundles (Claude Code, Codex, Cursor, Copilot CLI).

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Opinionated scaffolding for portable agents and skills that can be compiled into
 
 ## Getting started
 
+Host prerequisites: Node 22+, `uv`, and `sg` (ast-grep) on `PATH`. The repo's
+`@ast-grep/cli` devDependency keeps a copy in `node_modules/.bin` for the build,
+but agent prompts shell out to bare `sg`, so install it globally too:
+`brew install ast-grep`, `cargo install ast-grep`, or `npm i -g @ast-grep/cli`.
+
 ```bash
 npm install
 npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "cheese": "dist/index.js"
       },
       "devDependencies": {
+        "@ast-grep/cli": "^0.42.1",
         "@biomejs/biome": "^2.4.12",
         "@types/node": "^25.6.0",
         "@vitest/coverage-v8": "^4.1.4",
@@ -29,6 +30,158 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@ast-grep/cli": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli/-/cli-0.42.1.tgz",
+      "integrity": "sha512-L1D7JX7p/RohtvE4IViKelWCtEYjQDvmlZ85aP4LmJVoQth/iC/+z/fCXmg6qSK8zr9IjC9okpxDZX7x1arKbQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "ast-grep": "ast-grep",
+        "sg": "sg"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "optionalDependencies": {
+        "@ast-grep/cli-darwin-arm64": "0.42.1",
+        "@ast-grep/cli-darwin-x64": "0.42.1",
+        "@ast-grep/cli-linux-arm64-gnu": "0.42.1",
+        "@ast-grep/cli-linux-x64-gnu": "0.42.1",
+        "@ast-grep/cli-win32-arm64-msvc": "0.42.1",
+        "@ast-grep/cli-win32-ia32-msvc": "0.42.1",
+        "@ast-grep/cli-win32-x64-msvc": "0.42.1"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-arm64": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-arm64/-/cli-darwin-arm64-0.42.1.tgz",
+      "integrity": "sha512-G9rk0NAN10mybxi611CVNqwPtPO+yF0rFqPzpdgHBa4roeCq5FYsg2q/WqxM95st3jilNS9UIfZFD0i3BDfKEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-x64": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-x64/-/cli-darwin-x64-0.42.1.tgz",
+      "integrity": "sha512-IZ1HY69zj6sj4QnHKPR71FjtuCDImhLW5v5QhTGq6Fl0T9fjhQP/g9aEk7PrJB1puOk4HhTw/J/u0wZOPmp4bA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-arm64-gnu": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-0.42.1.tgz",
+      "integrity": "sha512-eirVmtAciL1cXwvODYkqKEFtWgxxYyhNLTTNchdKynktFixuAmAvn0OUX0bcQnhXH5DgsdT4+1+CtvjuPc5uGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-x64-gnu": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-x64-gnu/-/cli-linux-x64-gnu-0.42.1.tgz",
+      "integrity": "sha512-DrsV3+LkzwcaCw2AkLqM5o9ISaS4ZfJIL96RIdFRD+ydp5Mirsdw3aZdDmBqpa6nxt2NjMsFWgOivvzPiKzGAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-arm64-msvc": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-0.42.1.tgz",
+      "integrity": "sha512-9DabeCAtOQEUTiCVB6fpoJ0mI21brEAa5oY2jjOzaz1SBwYuh9TPLnKBn8F+PYbUU/4Umyy26YwVg+xw4+J/Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-ia32-msvc": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-0.42.1.tgz",
+      "integrity": "sha512-xQlxTwaqiCzOUZc5lB6rp/glS0DmQd67ID6MliRZ3TH1PvX+a3oiP+QEdSgcvfcArObuKxtRGNKlOfgwMe+J8Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-x64-msvc": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-x64-msvc/-/cli-win32-x64-msvc-0.42.1.tgz",
+      "integrity": "sha512-bOMSGeTKGfYBB1m+S0WLiA2GUkNVBaHOy+mKw27mf/kd6W2KNG3DJwAWry35qargLL0WP9PBcCaOkdnzeNyZ3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@ast-grep/cli": "^0.42.1",
     "@biomejs/biome": "^2.4.12",
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^4.1.4",

--- a/references/tilth/tilth-mcp.md
+++ b/references/tilth/tilth-mcp.md
@@ -34,7 +34,7 @@ tilth_search(query: "handleAuth", scope: "src/")
 **Parameters:**
 - `query` (required): Symbol name, comma-separated symbols, text string, or regex
 - `scope`: Directory to search in (default: cwd)
-- `kind`: `"symbol"` (default), `"content"`, or `"callers"`
+- `kind`: `"symbol"` (default), `"content"`, `"regex"`, or `"callers"`
 - `expand`: Number of matches to show full source (default: 2)
 - `context`: Path to file being edited — boosts nearby results
 - `glob`: File pattern filter — `"*.rs"`, `"!*.test.ts"`, `"*.{go,rs}"`
@@ -58,11 +58,17 @@ tilth_search(query: "ServeHTTP, HandlersChain, Next", scope: ".")
 tilth_search(query: "validateToken", kind: "callers", scope: ".")
 ```
 
-**Content/regex search:**
+**Content search (literal text):**
 ```
 tilth_search(query: "TODO: fix", kind: "content", scope: ".")
-tilth_search(query: "/rate.*limit/i", kind: "content", scope: ".")
 ```
+
+**Regex search:**
+```
+tilth_search(query: "rate.?limit", kind: "regex", scope: ".")
+tilth_search(query: "FIXME\\(.*?\\):", kind: "regex", scope: "src/")
+```
+Pass the bare regex — do not wrap in `/.../` delimiters.
 
 ### tilth_read — Smart File Reading
 

--- a/skills/cheez-search/SKILL.md
+++ b/skills/cheez-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cheez-search
 compatibility: Requires tilth MCP server
-allowed-tools: mcp__tilth__tilth_search, mcp__tilth__tilth_deps, Bash
+allowed-tools: mcp__tilth__tilth_search, mcp__tilth__tilth_deps, bash
 description: >
   AST-aware code search using tilth MCP. Finds definitions first, then usages.
   Use tree-sitter structural matching instead of blind text grep. Understand

--- a/skills/cheez-search/SKILL.md
+++ b/skills/cheez-search/SKILL.md
@@ -42,6 +42,26 @@ looking at without a second read.
 
 ---
 
+## Choose your search kind
+
+All five rows below are first-class — picking the right one is the difference
+between one call and a long grep walk.
+
+| Goal | Tool | Example |
+|------|------|---------|
+| Find where a symbol is defined / used | `tilth_search` (default `kind: "symbol"`) | `tilth_search(query: "handleAuth", scope: "src/")` |
+| Find every call site of a function | `tilth_search(kind: "callers")` | `tilth_search(query: "validateToken", kind: "callers")` |
+| Find literal strings, TODOs, error messages | `tilth_search(kind: "content")` | `tilth_search(query: "TODO: fix", kind: "content")` |
+| Find lines matching a regex | `tilth_search(kind: "regex")` | `tilth_search(query: "rate.?limit", kind: "regex")` |
+| Match an AST shape (template with metavars) | `sg` (ast-grep, via Bash) | `sg --lang typescript -p 'JSON.parse(JSON.stringify($X))' --json src/` |
+| Module import / blast-radius graph | `tilth_deps` | `tilth_deps(path: "src/auth.ts")` |
+
+**Rule of thumb:** stay in tilth for anything name-shaped or text-shaped.
+Drop to `sg` only when the pattern needs structural metavariables (`$X`,
+`$$$BODY`) that tilth can't express.
+
+---
+
 ## MCP Tool Reference
 
 ### tilth_search — Symbol and Content Search
@@ -138,16 +158,75 @@ Search for text that isn't a code symbol:
 tilth_search(query: "TODO: fix", kind: "content", scope: ".")
 ```
 
-**Regex search:**
-```
-tilth_search(query: "/rate.*limit/i", kind: "content", scope: ".")
-```
-
 Use content search for:
 - Finding TODOs, FIXMEs, NOTEs
 - Searching error messages
-- Finding specific strings or patterns
-- Regex matching
+- Locating specific literal strings
+
+---
+
+## Regex Search — `kind: "regex"`
+
+For patterns that aren't a single literal, switch kinds rather than embedding
+slashes in a content query:
+
+```
+tilth_search(query: "rate.?limit", kind: "regex", scope: ".")
+tilth_search(query: "FIXME\\(.*?\\):", kind: "regex", scope: "src/")
+```
+
+- Full regex syntax — alternation, character classes, lookarounds depending
+  on the engine version.
+- Use `glob` to bound the file set; regex is the most expensive `kind`.
+- Don't wrap the pattern in `/.../` delimiters — pass the bare regex.
+
+---
+
+## AST-shape Patterns — ast-grep fallback
+
+tilth covers names and text. For *shapes* with metavariables — “any call to
+`JSON.parse(JSON.stringify(…))`”, “any `for` loop with `time.Sleep` in its
+body” — use `sg` (ast-grep) via Bash. The agent template's `tools:` frontmatter
+must list `bash` for these calls to land.
+
+```bash
+# AST template: $X is a metavar that matches any single node.
+sg --lang typescript -p 'JSON.parse(JSON.stringify($X))' --json src/
+
+# $$$BODY matches a sequence of statements.
+sg --lang rust -p 'impl std::fmt::Display for $TYPE { $$$BODY }' --json src/
+
+# Bound the scan; never splice unvalidated user input as the path.
+SCOPE=$(realpath "$SCOPE_INPUT")
+sg --lang python -p 're.match($PATTERN, $INPUT)' --json "$SCOPE"
+```
+
+**When `sg` is the right pick:**
+
+- The pattern needs metavars (`$X`, `$$$BODY`) or specific node kinds.
+- You're surveying a structural shape across a directory (NIH scans, anti-pattern
+  sweeps, refactor previews).
+- Tree-sitter symbol search would over-match because the *name* isn't fixed.
+
+**When to stay in tilth:**
+
+- Looking for a known symbol name → `kind: "symbol"`.
+- Looking for a known string or comment → `kind: "content"`.
+- Looking for callers of a known function → `kind: "callers"`.
+- Need the result inlined with file outline + `── calls ──` footer → tilth.
+
+**Hard rules for sg invocations:**
+
+- Validate any path that flows from user input or `$ARGUMENTS` before splicing
+  it into the command line. Reject `;`, `&`, `|`, backtick, `$(`, `>`, `<`,
+  newline. Resolve to an absolute path with `realpath` (or `tilth_files`) and
+  confirm it sits under the repo root.
+- Always pass `--json` and parse defensively — the JSON shape varies between
+  ast-grep versions.
+- Filter test/build/vendor directories with `--globs` or by post-filtering the
+  JSON output.
+
+See `agents/nih-scanner.md.eta` for the canonical multi-language sg recipe.
 
 ---
 
@@ -338,12 +417,20 @@ tilth_deps(path: "src/auth/index.ts")
 # Check ── imported by ── section
 ```
 
+### "Find every `JSON.parse(JSON.stringify(…))` deep-clone hack"
+```bash
+sg --lang typescript -p 'JSON.parse(JSON.stringify($X))' --json src/
+# Switch to sg whenever the pattern needs metavars; tilth has no $X.
+```
+
 ---
 
 ## DO NOT
 
-- **DO NOT use Grep/rg** — use tilth_search
-- **DO NOT blind text search** — use semantic symbol search
+- **DO NOT use Grep/rg** — use `tilth_search`. `sg` (ast-grep) is the *only*
+  sanctioned shell escape, and only for AST-shape patterns tilth can't express.
+- **DO NOT blind text search** — use a semantic `kind` (`symbol`, `callers`,
+  `content`, `regex`) before reaching for `sg`.
 - **DO NOT re-read expanded results** — they're already shown
 - **DO NOT use for file reading** — use cheez-read (tilth_read)
 - **DO NOT use for editing** — use cheez-write (tilth_edit)

--- a/skills/cheez-search/SKILL.md
+++ b/skills/cheez-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cheez-search
 compatibility: Requires tilth MCP server
-allowed-tools: mcp__tilth__tilth_search, mcp__tilth__tilth_deps
+allowed-tools: mcp__tilth__tilth_search, mcp__tilth__tilth_deps, Bash
 description: >
   AST-aware code search using tilth MCP. Finds definitions first, then usages.
   Use tree-sitter structural matching instead of blind text grep. Understand
@@ -44,7 +44,7 @@ looking at without a second read.
 
 ## Choose your search kind
 
-All five rows below are first-class — picking the right one is the difference
+All six rows below are first-class — picking the right one is the difference
 between one call and a long grep walk.
 
 | Goal | Tool | Example |


### PR DESCRIPTION
## Summary

- Adds `@ast-grep/cli ^0.42.1` as a devDependency so `just install` provisions `sg` into `node_modules/.bin` without a separate host step.
- Documents `sg` as a host prerequisite in `AGENTS.md` and `README.md` with three install paths (brew / cargo / npm -g).
- Updates `skills/cheez-search/SKILL.md` to teach the full search-kind matrix (`symbol` / `callers` / `content` / `regex` / ast-shape via `sg`), split regex out of the buggy `kind: "content"` example into a proper `kind: "regex"` section, and add an "AST-shape Patterns" fallback section with input-validation rules for `{scope}` splicing.
- Tightens the DO NOT block so `sg` is recognized as the only sanctioned shell escape — never raw `grep`/`rg`.

## Why pre-PR

The `lift-nih-skill` branch depends on `sg` being available to the `nih-scanner` agent (Step-3 AST sweeps for hand-rolled UUID, JSON deep-clone hacks, manual retry shapes, etc.). Landing the install + skill docs first lets that branch rebase on a stable baseline.

## Test plan

- [x] `just build` passes (typecheck, lint, lint:skills, vitest with coverage thresholds, pytest, ruff)
- [x] `npm run lint:skills` clean
- [x] `node_modules/.bin/sg --version` returns `ast-grep 0.42.1`
- [ ] Reviewer to sanity-check the cheez-search cheat sheet against an actual ast-grep call

## Out of scope

- The lift-nih-skill work (`/age` nih dim, `/nih-audit`, fixtures) — follows in a separate PR that will rebase on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)