### PR TITLE
fix(github): switch ruleset enforcement to active

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -5,7 +5,10 @@ files from this directory — apply them with `gh api` or the sync workflow belo
 
 ## Files
 
-- `main.json` — protects `main` (default branch). Status: starts in `evaluate` mode for safe rollout.
+- `main.json` — protects `main` (default branch). Enforcement: `active`.
+
+> Note: `enforcement: "evaluate"` (dry-run mode) is GitHub Enterprise-only.
+> On personal/Pro plans the only valid values are `active` and `disabled`.
 
 ## Apply
 
@@ -27,9 +30,12 @@ gh api repos/paulnsorensen/cheese-flow/rulesets/<RULESET_ID> --method DELETE
 
 ## Rollout
 
-1. Apply with `enforcement: "evaluate"` (the default in `main.json`).
-2. Open a few PRs; check the **Insights → Rule insights** tab for false positives — especially the `build` status-check context name.
-3. Edit `main.json`: change `"evaluate"` → `"active"`. Re-PUT.
+1. Apply (creates the ruleset in `active` mode).
+2. Open a small test PR to confirm the `build` status check is recognized and required.
+3. If the check name drifts (e.g. CI workflow renamed), edit `main.json` and re-PUT.
+
+If you'd rather stage it first, set `"enforcement": "disabled"` before the initial POST,
+then flip to `"active"` and PUT once you've confirmed the rules look right in the UI.
 
 ## What it protects
 

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,7 +1,7 @@
 {
   "name": "default-branch-protection",
   "target": "branch",
-  "enforcement": "evaluate",
+  "enforcement": "active",
   "conditions": {
     "ref_name": {
       "include": ["~DEFAULT_BRANCH"],


### PR DESCRIPTION
## Summary
- `enforcement: "evaluate"` (dry-run) is GitHub Enterprise-only; `gh api ... POST` returned HTTP 422 on this plan.
- Switch `main.json` to `"active"`.
- Update `README.md` with active-mode rollout, document the Enterprise-only caveat, and note the optional `disabled` → `active` staging path.

## Test plan
- [ ] Apply the ruleset: `gh api repos/paulnsorensen/cheese-flow/rulesets --method POST --input .github/rulesets/main.json` (or PUT against the existing one). Verify it returns 201/200, not 422.
- [ ] Open a small test PR; confirm the `CI / build` check is required and rule shows up under Repository rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)