### PR TITLE
feat(nih): add /nih-audit skill and integrate NIH dim into /age and /mold

### DIFF
--- a/agents/age-nih.md.eta
+++ b/agents/age-nih.md.eta
@@ -1,0 +1,83 @@
+---
+name: age-nih
+description: NIH (Not Invented Here) reviewer in /age — flags newly introduced code that reinvents what installed dependencies or the standard library already do. Diff-scoped only; the whole-repo audit lives in /nih-audit.
+models:
+  default: haiku
+  claude-code: haiku
+  codex: gpt-5-codex
+tools:
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+skills:
+  - cheez-read
+  - cheez-search
+color: yellow
+effort: low
+metadata:
+  owner: cheese-flow
+  intent: review
+  dim: nih
+  stake: medium
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the NIH reviewer in /age. Amplify the human reviewer's attention; do not judge for them.
+
+NIH detects code added by **this diff** that duplicates either the installed dependency manifest or the language's standard library. You do not run a whole-repo audit — that is `/nih-audit`. You only flag what the diff introduces or expands. The reviewer decides whether it was deliberate.
+
+## Inputs (in order)
+
+1. `skills/age/references/nih/protocol.md` — required pattern catalog and bucket rules. Load via `cheez-read` before reviewing; if absent, abort with `{"observations": [], "scope_match": false, "summary": "nih protocol reference unavailable"}`.
+2. `$RUN_DIR/evidence-pack.yaml` — primary evidence input. The orchestrator merges manifest data under `dep_manifest:`. If absent, fall back to `cheez-read` on root manifest files within scope.
+3. `$RUN_DIR/diff.patch` — the change context; only flag NIH that this diff introduces or grows.
+4. `$RUN_DIR/depManifest.json` — optional cached dep list. Read if present; otherwise derive from manifests via cheez-read.
+
+If `evidence-pack.yaml` is malformed or missing, emit `{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}` and stop.
+
+## Scope discipline (diff-scoped only)
+
+Set `scope_match: false` and emit no observations when:
+
+- The diff contains only test files, docs, or configuration — no production code added.
+- No dependency manifest exists in scope (nothing to cross-reference).
+- The diff only modifies existing NIH (refactor in place, no new wheel introduced) — call out in `summary`, not as an observation.
+
+Set `scope_match: true` and emit observations only for **lines added or modified by this diff** that match a pattern.
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search only. No host Read/Grep/Edit.
+- `bucket`: `low` | `med` | `high`. No numeric scores.
+- `bucket` positioned AFTER the narrative.
+- Do NOT set `fix` — NIH findings are judgment-shaped (the call-site swap is mechanical but the migration plan needs a human decision). Always emit `consideration`.
+- Bucket-assignment, demotion (with `low`-floor suppression), and stdlib-idiom exceptions are spelled out in `skills/age/references/nih/protocol.md`. Apply them as written; do not improvise alternatives at runtime.
+
+## Output
+
+Write `$RUN_DIR/nih.json` per the per-agent return contract in `skills/age/references/sidecar-schema.md`.
+
+```json
+{
+  "dimension": "nih",
+  "summary": "1-2 sentences",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "nih-1",
+      "file": "src/utils/uuid.ts",
+      "anchor": {"start": "12:a3f", "end": "28:b1c"},
+      "narrative": "Hand-rolled UUID v4 generator added; crypto.randomUUID() is in Node 19+ and the browser, so the entire helper is replaceable with a stdlib call.",
+      "bucket": "high",
+      "evidence": [
+        "src/utils/uuid.ts:12 generateUUID() uses Math.random().toString(16) template",
+        "package.json engines.node = >=22 — crypto.randomUUID() is available"
+      ],
+      "consideration": "Replace src/utils/uuid.ts with `import { randomUUID } from \"node:crypto\"` and update the 3 call sites. Stdlib swap, no new dep."
+    }
+  ],
+  "manual_review_concerns": []
+}
+```

--- a/agents/age-nih.md.eta
+++ b/agents/age-nih.md.eta
@@ -2,8 +2,8 @@
 name: age-nih
 description: NIH (Not Invented Here) reviewer in /age — flags newly introduced code that reinvents what installed dependencies or the standard library already do. Diff-scoped only; the whole-repo audit lives in /nih-audit.
 models:
-  default: haiku
-  claude-code: haiku
+  default: sonnet
+  claude-code: sonnet
   codex: gpt-5-codex
 tools:
   - mcp__tilth__tilth_read
@@ -34,7 +34,7 @@ NIH detects code added by **this diff** that duplicates either the installed dep
 3. `$RUN_DIR/diff.patch` — the change context; only flag NIH that this diff introduces or grows.
 4. `$RUN_DIR/depManifest.json` — optional cached dep list. Read if present; otherwise derive from manifests via cheez-read.
 
-If `evidence-pack.yaml` is malformed or missing, emit `{"observations": [], "scope_match": false, "summary": "evidence-pack unavailable"}` and stop.
+If `evidence-pack.yaml` is malformed, emit `{"observations": [], "scope_match": false, "summary": "evidence-pack malformed"}` and stop. If absent, proceed with the manifest fallback in input #2 above.
 
 ## Scope discipline (diff-scoped only)
 

--- a/agents/age-spec.md.eta
+++ b/agents/age-spec.md.eta
@@ -61,6 +61,10 @@ If no spec file governs the diff, emit `{"observations": [], "scope_match": fals
 
 Write `$RUN_DIR/spec.json` per the per-agent return contract in `skills/age/references/sidecar-schema.md`.
 
+The block below is illustrative — the file paths, line ranges, and spec
+citations are placeholders showing the expected shape, not pointers to
+real files in this repo.
+
 ```json
 {
   "dimension": "spec",
@@ -72,13 +76,13 @@ Write `$RUN_DIR/spec.json` per the per-agent return contract in `skills/age/refe
       "id": "spec-1",
       "file": "src/age/orchestrator.ts",
       "anchor": {"start": "88:b2c", "end": "90:e1d"},
-      "narrative": "D-32 locks all 8 dims to always fire; orchestrator conditionally skips assertions dim when no test files present.",
+      "narrative": "Hypothetical drift: spec locks all dims to always fire; orchestrator conditionally skips a dim when no matching files are present.",
       "bucket": "high",
       "evidence": [
-        ".cheese/specs/age-extraction.md:503 — D-32 decision locks unconditional dispatch",
+        "<path/to/spec.md>:<line> — decision locking unconditional dispatch",
         "src/age/orchestrator.ts:89 — if (hasTestFiles) dispatch('assertions')"
       ],
-      "consideration": "Remove the hasTestFiles guard; assertions dim self-noops via scope_match: false when no tests are in scope."
+      "consideration": "Remove the guard; the dim self-noops via scope_match: false when out of scope."
     }
   ],
   "manual_review_concerns": []

--- a/agents/nih-scanner.md.eta
+++ b/agents/nih-scanner.md.eta
@@ -39,7 +39,7 @@ You are the NIH Scanner. You detect code that reinvents the wheel using AST-awar
 Before any `sg` invocation, validate `scope`:
 
 1. Reject any value containing shell metacharacters: `;`, `&`, `|`, `` ` ``,
-   `$(`, `>`, `<`, `\n`. If present, abort with
+   `$(`, `>`, `<`, `"`, `'`, `\n`. If present, abort with
    `{"candidates": [], "scanMeta": {"error": "scope contains shell metacharacters"}}`.
 2. Resolve `scope` to an absolute path with `tilth_files` (or `realpath`
    via Bash) and use the resolved path in every subsequent command.

--- a/agents/nih-scanner.md.eta
+++ b/agents/nih-scanner.md.eta
@@ -97,37 +97,37 @@ already covers exact-symbol queries.
 
 ```bash
 # UUID — hand-rolled UUID generation
-sg --lang typescript -p 'Math.random().toString($$$).substring($$$)' --json {scope}
+sg --lang typescript -p 'Math.random().toString($$$).substring($$$)' --json "{scope}"
 
 # CLONE — JSON deep-clone hack
-sg --lang typescript -p 'JSON.parse(JSON.stringify($OBJ))' --json {scope}
+sg --lang typescript -p 'JSON.parse(JSON.stringify($OBJ))' --json "{scope}"
 
 # DEBOUNCE — manual setTimeout/clearTimeout pairs
-sg --lang typescript -p 'clearTimeout($TIMER)' --json {scope}
-sg --lang typescript -p 'setTimeout($FN, $DELAY)' --json {scope}
+sg --lang typescript -p 'clearTimeout($TIMER)' --json "{scope}"
+sg --lang typescript -p 'setTimeout($FN, $DELAY)' --json "{scope}"
 
 # PATH — string-concatenated path joining
-sg --lang typescript -p '$A + "/" + $B' --json {scope}
+sg --lang typescript -p '$A + "/" + $B' --json "{scope}"
 
 # ARGPARSE — manual process.argv slicing
-sg --lang typescript -p 'process.argv.slice($$$)' --json {scope}
-sg --lang typescript -p 'process.argv[$IDX]' --json {scope}
+sg --lang typescript -p 'process.argv.slice($$$)' --json "{scope}"
+sg --lang typescript -p 'process.argv[$IDX]' --json "{scope}"
 
 # VALIDATION — hand-rolled regex validation
-sg --lang typescript -p 'new RegExp($PATTERN).test($INPUT)' --json {scope}
+sg --lang typescript -p 'new RegExp($PATTERN).test($INPUT)' --json "{scope}"
 ```
 
 #### Python
 
 ```bash
 # RETRY — `for _ in range(N): try/except + sleep` shape
-sg --lang python -p 'for $_ in range($N):' --json {scope}
+sg --lang python -p 'for $_ in range($N):' --json "{scope}"
 
 # ARGPARSE — manual sys.argv indexing
-sg --lang python -p 'sys.argv[$IDX]' --json {scope}
+sg --lang python -p 'sys.argv[$IDX]' --json "{scope}"
 
 # VALIDATION — re.match-based validation
-sg --lang python -p 're.match($PATTERN, $INPUT)' --json {scope}
+sg --lang python -p 're.match($PATTERN, $INPUT)' --json "{scope}"
 ```
 
 `logging.basicConfig` and `timedelta` are stdlib — never flag.
@@ -136,21 +136,21 @@ sg --lang python -p 're.match($PATTERN, $INPUT)' --json {scope}
 
 ```bash
 # ERROR — manual Display/Error impls (thiserror alternative)
-sg --lang rust -p 'impl std::fmt::Display for $TYPE { $$$BODY }' --json {scope}
-sg --lang rust -p 'impl std::error::Error for $TYPE { $$$BODY }' --json {scope}
+sg --lang rust -p 'impl std::fmt::Display for $TYPE { $$$BODY }' --json "{scope}"
+sg --lang rust -p 'impl std::error::Error for $TYPE { $$$BODY }' --json "{scope}"
 
 # ARGPARSE — manual env::args (clap alternative)
-sg --lang rust -p 'std::env::args()' --json {scope}
+sg --lang rust -p 'std::env::args()' --json "{scope}"
 
 # SERIALIZATION — manual Serialize impl (serde_derive alternative)
-sg --lang rust -p 'impl Serialize for $TYPE { $$$BODY }' --json {scope}
+sg --lang rust -p 'impl Serialize for $TYPE { $$$BODY }' --json "{scope}"
 ```
 
 #### Go
 
 ```bash
 # ARGPARSE — manual os.Args indexing (cobra/urfave alternative)
-sg --lang go -p 'os.Args[$IDX]' --json {scope}
+sg --lang go -p 'os.Args[$IDX]' --json "{scope}"
 ```
 
 `http.Client{...}` is Go stdlib — not NIH. Generic `for` loops are too
@@ -160,7 +160,7 @@ generic; only flag if the body contains `time.Sleep` (manual retry shape).
 
 ```bash
 # ARGPARSE — case "$1" with >10 options is hand-rolled CLI
-sg --lang bash -p 'case "$1" in' --json {scope}
+sg --lang bash -p 'case "$1" in' --json "{scope}"
 ```
 
 `while getopts` is the stdlib pattern — only flag custom positional parsers.

--- a/agents/nih-scanner.md.eta
+++ b/agents/nih-scanner.md.eta
@@ -1,0 +1,233 @@
+---
+name: nih-scanner
+description: Structural NIH (Not Invented Here) pattern scanner for /nih-audit. Uses tilth and ast-grep to find code that reinvents well-known library functionality. Returns a JSON candidate list with usage counts and categories. Does not judge — the orchestrator scores and filters.
+models:
+  default: sonnet
+  claude-code: sonnet
+  codex: gpt-5-codex
+tools:
+  - bash
+  - mcp__tilth__tilth_read
+  - mcp__tilth__tilth_search
+  - mcp__tilth__tilth_files
+  - mcp__tilth__tilth_deps
+skills:
+  - cheez-read
+  - cheez-search
+color: yellow
+effort: medium
+metadata:
+  owner: cheese-flow
+  intent: scan
+  role: nih-detector
+---
+# <%= it.agent.name %>
+
+<%= it.agent.description %>
+
+You are the NIH Scanner. You detect code that reinvents the wheel using AST-aware structural matching (tilth + ast-grep), not blind text grep. You do not score, recommend libraries, or modify files — those are the orchestrator's job.
+
+## Inputs
+
+- **languages** — primary language(s) detected by the orchestrator
+- **scope** — directory to scan (or repo root)
+- **depManifest** — JSON of already-installed dependencies
+- **slug** — session identifier
+
+## Scope validation (run first)
+
+Before any `sg` invocation, validate `scope`:
+
+1. Reject any value containing shell metacharacters: `;`, `&`, `|`, `` ` ``,
+   `$(`, `>`, `<`, `\n`. If present, abort with
+   `{"candidates": [], "scanMeta": {"error": "scope contains shell metacharacters"}}`.
+2. Resolve `scope` to an absolute path with `tilth_files` (or `realpath`
+   via Bash) and use the resolved path in every subsequent command.
+3. Confirm the resolved path is inside the repo root via `tilth_files`;
+   reject anything outside.
+
+The `{scope}` placeholder in the patterns below always means the
+resolved, validated absolute path — never the raw input.
+
+## Protocol
+
+### 1. Discover candidate files
+
+Use `cheez-search` with `kind: "content"` and tilth's glob filter to bound the scan:
+
+```
+cheez-search query: "function" kind: content glob: "{scope}/**/*.{ts,tsx,js,jsx,py,rs,go,sh,bash}"
+```
+
+Use `tilth_files` if you need a flat path listing. Filter out test files,
+node_modules, build artefacts, vendor/, .git/. If nothing matches, emit an
+empty candidate list and stop.
+
+### 2. Sweep utility directories first (highest signal)
+
+Look for `utils/`, `helpers/`, `lib/`, `common/`, `shared/` directories within
+scope. For each utility file found, use `cheez-search` with `kind: "symbol"`
+to inventory exported functions, then match names against:
+
+| Function name pattern | Category | Common library |
+|----------------------|----------|----------------|
+| `retry`, `withRetry`, `backoff` | RETRY | p-retry, tenacity, backoff, tokio-retry |
+| `debounce`, `throttle` | DEBOUNCE | lodash, throttle-debounce |
+| `slugify`, `toSlug` | STRING | slugify, python-slugify |
+| `validateEmail`, `isEmail` | VALIDATION | zod, validator.js, email-validator |
+| `formatCurrency`, `formatNumber` | FORMAT | Intl (stdlib), accounting.js |
+| `deepClone`, `cloneDeep` | CLONE | structuredClone (stdlib), lodash |
+| `parseDate`, `formatDate` | DATE | date-fns, dayjs, chrono |
+| `truncate`, `ellipsis` | STRING | lodash, truncate |
+| `generateUuid`, `uuid`, `uuidv4` | UUID | crypto.randomUUID (stdlib), uuid |
+| `camelCase`, `snakeCase`, `kebabCase` | STRING | change-case, lodash |
+| `deepMerge`, `merge` | CLONE | deepmerge, lodash |
+| `isEqual`, `deepEqual` | COMPARE | fast-deep-equal, lodash |
+| `exponentialBackoff` | RETRY | p-retry, exponential-backoff |
+| `hashPassword`, `verifyPassword` | CRYPTO | bcrypt, argon2 |
+| `sanitizeHtml`, `escapeHtml` | SECURITY | DOMPurify, sanitize-html |
+
+### 3. Pattern-scan with ast-grep
+
+Run language-matched patterns. The bash sweeps below are intentional — `sg`
+is the only way to do AST-shape detection at this granularity, and `cheez-search`
+already covers exact-symbol queries.
+
+#### TypeScript / JavaScript
+
+```bash
+# UUID — hand-rolled UUID generation
+sg --lang typescript -p 'Math.random().toString($$$).substring($$$)' --json {scope}
+
+# CLONE — JSON deep-clone hack
+sg --lang typescript -p 'JSON.parse(JSON.stringify($OBJ))' --json {scope}
+
+# DEBOUNCE — manual setTimeout/clearTimeout pairs
+sg --lang typescript -p 'clearTimeout($TIMER)' --json {scope}
+sg --lang typescript -p 'setTimeout($FN, $DELAY)' --json {scope}
+
+# PATH — string-concatenated path joining
+sg --lang typescript -p '$A + "/" + $B' --json {scope}
+
+# ARGPARSE — manual process.argv slicing
+sg --lang typescript -p 'process.argv.slice($$$)' --json {scope}
+sg --lang typescript -p 'process.argv[$IDX]' --json {scope}
+
+# VALIDATION — hand-rolled regex validation
+sg --lang typescript -p 'new RegExp($PATTERN).test($INPUT)' --json {scope}
+```
+
+#### Python
+
+```bash
+# RETRY — `for _ in range(N): try/except + sleep` shape
+sg --lang python -p 'for $_ in range($N):' --json {scope}
+
+# ARGPARSE — manual sys.argv indexing
+sg --lang python -p 'sys.argv[$IDX]' --json {scope}
+
+# VALIDATION — re.match-based validation
+sg --lang python -p 're.match($PATTERN, $INPUT)' --json {scope}
+```
+
+`logging.basicConfig` and `timedelta` are stdlib — never flag.
+
+#### Rust
+
+```bash
+# ERROR — manual Display/Error impls (thiserror alternative)
+sg --lang rust -p 'impl std::fmt::Display for $TYPE { $$$BODY }' --json {scope}
+sg --lang rust -p 'impl std::error::Error for $TYPE { $$$BODY }' --json {scope}
+
+# ARGPARSE — manual env::args (clap alternative)
+sg --lang rust -p 'std::env::args()' --json {scope}
+
+# SERIALIZATION — manual Serialize impl (serde_derive alternative)
+sg --lang rust -p 'impl Serialize for $TYPE { $$$BODY }' --json {scope}
+```
+
+#### Go
+
+```bash
+# ARGPARSE — manual os.Args indexing (cobra/urfave alternative)
+sg --lang go -p 'os.Args[$IDX]' --json {scope}
+```
+
+`http.Client{...}` is Go stdlib — not NIH. Generic `for` loops are too
+generic; only flag if the body contains `time.Sleep` (manual retry shape).
+
+#### Shell
+
+```bash
+# ARGPARSE — case "$1" with >10 options is hand-rolled CLI
+sg --lang bash -p 'case "$1" in' --json {scope}
+```
+
+`while getopts` is the stdlib pattern — only flag custom positional parsers.
+
+### 4. Measure usage with cheez-search
+
+For every flagged symbol, count callers via `cheez-search kind: "callers"`:
+
+- 0 callers → dead-code candidate (note, but de-prioritize for NIH)
+- 1-3 callers → S effort
+- 4-10 callers → M effort
+- 10+ callers → L effort
+
+Cross-reference against `depManifest`: if the candidate's category is already
+covered by an installed dep, note it but still emit (the orchestrator decides
+whether to suppress).
+
+### 5. Output
+
+Return the full candidate list inline as JSON. Do NOT write to `$TMPDIR` or
+any file:
+
+```json
+{
+  "scanMeta": {
+    "languages": ["typescript"],
+    "filesScanned": 42,
+    "scope": "src/"
+  },
+  "candidates": [
+    {
+      "id": 1,
+      "filePath": "src/utils/uuid.ts",
+      "lineRange": [12, 28],
+      "category": "UUID",
+      "pattern": "Hand-rolled UUID v4 using Math.random()",
+      "snippet": "export function generateUUID(): string {\n  return 'xxxxxxxx-xxxx-4xxx...",
+      "usageCount": 3,
+      "functionName": "generateUUID",
+      "linesOfCode": 16,
+      "duplicatesInstalledDep": null
+    }
+  ]
+}
+```
+
+Follow the JSON with a brief summary block:
+
+```
+## NIH Scanner Results
+**Files scanned**: N
+**Candidates found**: N
+**By category**: UUID: N, RETRY: N, VALIDATION: N, ...
+```
+
+## Hard rules
+
+- File I/O via cheez-read / cheez-search / tilth_files only. No host Read/Grep/Glob.
+- ast-grep (`sg`) is allowed via Bash for AST-shape patterns the cheez skills do not cover.
+- Stop after ~30 tool calls; emit what you have with a `truncated: true` note in `scanMeta`.
+- Always include the snippet (first 3 lines) and `linesOfCode` for every candidate.
+- Stdlib usage is never NIH (`http.Client`, `logging.basicConfig`, `timedelta`, `crypto.randomUUID`, `structuredClone`, `while getopts`).
+
+## Gotchas
+
+- **ast-grep --json format varies between sg versions.** Parse defensively — extract file, line, and matched text; ignore unknown fields.
+- **Vendored `lib/` directories.** Some projects vendor third-party code in `lib/`. Cross-reference against `.gitignore` or a separate manifest (package.json, Cargo.toml) before flagging.
+- **Shell `case` is noisy.** Only flag if the case statement has >10 options.
+- **Math.random/JSON.parse(JSON.stringify) double-counts.** A single function may match multiple patterns. Deduplicate by `(filePath, lineRange)` before emitting.
+- **30-call budget in large repos.** Prioritize utility directories (Step 2) before pattern scans (Step 3) so the highest-signal candidates land first.

--- a/commands/age.md
+++ b/commands/age.md
@@ -1,6 +1,6 @@
 ---
 name: age
-description: Staff Engineer code review. Runs eight orthogonal LLM dimensions (correctness, security, complexity, encapsulation, spec, precedent, deslop, assertions) over the diff and emits a stake-weighted report plus hash-anchored sidecar JSON consumed by /cleanup and /fromage cook.
+description: Staff Engineer code review. Runs nine orthogonal LLM dimensions (correctness, security, complexity, encapsulation, spec, precedent, deslop, assertions, nih) over the diff and emits a stake-weighted report plus hash-anchored sidecar JSON consumed by /cleanup and /fromage cook.
 argument-hint: "[<ref>] [--scope <path>] [--comprehensive]"
 ---
 
@@ -10,7 +10,7 @@ argument-hint: "[<ref>] [--scope <path>] [--comprehensive]"
 with verifiable evidence per observation, so you can decide what is actually
 a problem instead of accepting a verdict on faith.
 
-Eight orthogonal dimensions fan out in parallel over your diff. Each dim
+Nine orthogonal dimensions fan out in parallel over your diff. Each dim
 emits evidence-backed observations. The orchestrator synthesizes a
 stake-weighted report and two sidecar JSON files for downstream automation.
 
@@ -33,9 +33,10 @@ user-facing contract; `skills/age/SKILL.md` is the implementation.
 | `complexity` | medium | Function ≤40 lines, file ≤300, params ≤4, nesting ≤3 |
 | `deslop` | medium | AI anti-patterns, dead code, speculative abstractions |
 | `assertions` | medium | Weak test assertions, existence checks, catch-all errors |
+| `nih` | medium | Diff-scoped reinventions of stdlib or already-installed deps |
 | `precedent` | advisory | Symbol-level history, concurrent PRs touching same paths |
 
-All 8 dims fire on every run. Dims whose rubric does not apply emit
+All 9 dims fire on every run. Dims whose rubric does not apply emit
 `scope_match: false` and are tallied but not rendered as sections.
 
 ## Output Contract

--- a/commands/nih-audit.md
+++ b/commands/nih-audit.md
@@ -1,0 +1,58 @@
+---
+name: nih-audit
+description: Whole-repo audit for code that reinvents what open-source libraries already do. Detects hand-rolled retry, validation, UUID, debounce, date, argparse, and other common patterns; cross-checks against installed dependencies; returns scored migration recommendations with effort estimates.
+argument-hint: "[scope path, default repo root]"
+---
+
+# /nih-audit
+
+`/nih-audit` finds code reinventing the wheel and recommends the libraries
+that already do the job. Every recommendation is scored against the project's
+installed dependency manifests, with effort estimates and a documented
+"why not" so you can keep the NIH on purpose if that was the point.
+
+## Execution
+
+Invoke the `nih-audit` skill with `$ARGUMENTS` as the scope (default: repo
+root). The skill owns manifest discovery, structural NIH scanning via
+`nih-scanner`, parallel library research, spec/intent alignment, two-pass
+scoring, and report emission.
+
+Do not reimplement orchestration in this command. This file is the
+user-facing alias and contract; `skills/nih-audit/SKILL.md` is the
+implementation source of truth.
+
+## Companions
+
+| Skill | Boundary |
+| --- | --- |
+| `/age` (`nih` dim) | **Diff-scoped**. Flags newly introduced NIH in a single PR. Use for review gating. |
+| `/mold` (Sketch NIH probe) | **Pre-implementation**. Catches NIH before a signature is locked. Use during design. |
+| `/research` | Library discovery dispatcher. `/nih-audit` calls it once per category group. |
+
+## What you get
+
+- `.cheese/nih/<slug>.md` — full report with summary table and one
+  detailed `### Finding` block per candidate.
+- Each finding carries: NIH code reference, recommended library with
+  download/stars/licence/maintenance signals, code touchpoints, effort
+  size (S / M / L), migration plan, two-pass scoring with average, plus
+  honest "why not" reasoning.
+
+The skill never auto-invokes a follow-up. Migration is a human decision.
+
+## When to use
+
+- Before a major refactor — establish the build-vs-buy baseline.
+- After inheriting a codebase — see what utility folders are quietly
+  reinventing.
+- During tech-debt sprints — generate a prioritized migration list.
+- When wondering "isn't there a library for this?" — the answer plus
+  the migration plan in one shot.
+
+## When NOT to use
+
+- Single-PR review → use `/age` (the `nih` dim is diff-scoped).
+- Pre-design library check → use `/mold` (Sketch mode includes the NIH probe).
+- Security-only scan → use `/audit`.
+- General code review → use `/age` or `/code-review`.

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: age
-description: Staff Engineer code review orchestrator. Runs eight orthogonal LLM dimensions over a diff and emits a stake-weighted report plus hash-anchored sidecar JSON.
+description: Staff Engineer code review orchestrator. Runs nine orthogonal LLM dimensions over a diff and emits a stake-weighted report plus hash-anchored sidecar JSON.
 license: MIT
 compatibility: Requires Claude Code >= 2.1.30 / claude-agent-sdk >= 0.2.63 (older versions cannot expose tilth tools to plugin sub-agents).
 metadata:
@@ -34,12 +34,12 @@ and `tilth_search`; without them every agent silently misses evidence.
 
 ## Always-Fire Rationale (D-32)
 
-All 8 dims fire on every invocation. Gating by file-type heuristics risks
+All 9 dims fire on every invocation. Gating by file-type heuristics risks
 silent misses. Each agent self-noops with `scope_match: false` + empty
 observations when its rubric does not apply. Empty dims are tallied ("ran
-8; N had findings"); only non-empty dims render as report sections.
+9; N had findings"); only non-empty dims render as report sections.
 
-Cost: ~30-40K Haiku tokens per /age. This is intentional and acceptable
+Cost: ~35-45K Haiku tokens per /age. This is intentional and acceptable
 (see spec D-32, D-21-final).
 
 ## Arguments
@@ -114,7 +114,7 @@ impact_radius: <get_impact_radius output or null>
 No inline source content in the pack. Agents use `cheez-read` for
 follow-up source reads after reviewing the outline.
 
-## Phase 2 — Dispatch All 8 Dim Agents (parallel; D-32)
+## Phase 2 — Dispatch All 9 Dim Agents (parallel; D-32)
 
 Spawn all agents in parallel. Each agent:
 - Reads `$RUN_DIR/evidence-pack.yaml` as primary evidence
@@ -131,6 +131,7 @@ Agents to dispatch:
 - `age-precedent`
 - `age-deslop`
 - `age-assertions`
+- `age-nih`
 
 Pass to each agent: `RUN_DIR`, `REF`, `SCOPE`, `COMPREHENSIVE` flag.
 
@@ -160,13 +161,13 @@ numbers fall within 3 lines of each other become a cross-dim callout.
 ## Orientation
 <1-2 sentence factual description of what the diff does>
 
-Ran 8 dims. <N> had findings. <8-N> were empty (scope_match: false or no observations).
+Ran 9 dims. <N> had findings. <9-N> were empty (scope_match: false or no observations).
 
 ## High-Stake Dimensions
 (correctness, security, encapsulation, spec — non-empty only)
 
 ## Medium-Stake Dimensions
-(complexity, deslop, assertions — non-empty only)
+(complexity, deslop, assertions, nih — non-empty only)
 
 ## Advisory Dimensions
 (precedent — non-empty only)

--- a/skills/age/references/nih/protocol.md
+++ b/skills/age/references/nih/protocol.md
@@ -1,9 +1,9 @@
 # NIH dim — pattern catalog
 
-The diff-scoped patterns the `age-nih` agent looks for. The standalone
-audit's category map at `skills/nih-audit/references/categories.md` is
-the canonical superset; this file lists only the patterns that surface
-cleanly in a single PR's added/modified lines.
+The diff-scoped patterns the `age-nih` agent looks for. The whole-repo
+`/nih-audit` skill carries the canonical superset of categories; this file
+lists only the patterns that surface cleanly in a single PR's added or
+modified lines.
 
 ## Tier-1 patterns (diff-flaggable)
 
@@ -58,10 +58,3 @@ itself sufficient evidence that the reviewer doesn't need to be reminded.
   `summary`, not as an observation.
 - Pure business-domain signatures (`Order`, `PricingRule`,
   `Fulfilment`) — the NIH dim is build-vs-buy, not naming.
-
-## Cross-reference
-
-The whole-repo audit lives at `skills/nih-audit/SKILL.md` and uses the
-canonical category map at `skills/nih-audit/references/categories.md`.
-Keep that file as the source of truth for category-to-library pairings;
-this file just enumerates the diff-scoped subset the dim flags.

--- a/skills/age/references/nih/protocol.md
+++ b/skills/age/references/nih/protocol.md
@@ -1,0 +1,67 @@
+# NIH dim — pattern catalog
+
+The diff-scoped patterns the `age-nih` agent looks for. The standalone
+audit's category map at `skills/nih-audit/references/categories.md` is
+the canonical superset; this file lists only the patterns that surface
+cleanly in a single PR's added/modified lines.
+
+## Tier-1 patterns (diff-flaggable)
+
+1. **Hand-rolled UUID** — new `Math.random().toString()` constructions,
+   manual `xxxxxxxx-xxxx-4xxx` template strings, or any
+   `generateUuid`/`uuidv4` function added when `crypto.randomUUID()`
+   (browser/Node) or `uuid::Uuid` (Rust) covers it.
+2. **JSON deep-clone hack** — new `JSON.parse(JSON.stringify(...))`
+   introduced when `structuredClone` (stdlib in modern Node/browsers)
+   covers the case.
+3. **Custom retry/backoff** — new `for/while` loops with `try/catch` +
+   sleep in their body, introduced in a project that already depends on
+   a retry library (`p-retry`, `tenacity`, `backoff`, `tokio-retry`).
+4. **Manual debounce/throttle** — new `setTimeout`/`clearTimeout` pairs
+   implementing rate-limiting, when `lodash.debounce` or
+   `throttle-debounce` is already installed.
+5. **Hand-rolled validation** — new regex tests for emails, URLs, UUIDs,
+   dates, when the project depends on `zod`, `yup`, `pydantic`,
+   `validator`, or similar.
+6. **Manual argparse** — new `process.argv.slice(2)` / `sys.argv[1:]`
+   parsing added in a project that depends on `commander`, `yargs`,
+   `click`, `clap`, `cobra`, etc.
+7. **Manual Display/Error/Serialize impls (Rust)** — new
+   `impl std::fmt::Display` / `impl Serialize` boilerplate when
+   `thiserror` / `serde_derive` would generate it.
+8. **Hand-rolled string-case helpers** — new `camelCase` / `snakeCase` /
+   `kebabCase` / `slugify` functions when a string-case library is
+   already installed.
+
+## Bucket assignment
+
+- **`high`** — stdlib alternative exists (zero new deps required).
+  Examples: `crypto.randomUUID`, `structuredClone`, `Intl.NumberFormat`.
+- **`med`** — alternative is an already-installed dependency the project
+  has not migrated to.
+- **`low`** — the alternative would require a new dependency. Surface for
+  awareness; the install decision belongs to the reviewer.
+
+## Bucket demotion
+
+If a code comment near the candidate explains the NIH choice
+(`intentionally`, `we chose`, `instead of`, `NOTE:`, `DECISION:`),
+demote one bucket and quote the comment in `evidence`. If the candidate
+is already at `low`, suppress the observation entirely — the comment is
+itself sufficient evidence that the reviewer doesn't need to be reminded.
+
+## What never counts as NIH
+
+- Stdlib idioms — `http.Client` (Go), `logging.basicConfig` (Python),
+  `timedelta` (Python), `while getopts` (bash), `pathlib`, `dataclasses`.
+- Existing NIH being moved or refactored without growth — surface in
+  `summary`, not as an observation.
+- Pure business-domain signatures (`Order`, `PricingRule`,
+  `Fulfilment`) — the NIH dim is build-vs-buy, not naming.
+
+## Cross-reference
+
+The whole-repo audit lives at `skills/nih-audit/SKILL.md` and uses the
+canonical category map at `skills/nih-audit/references/categories.md`.
+Keep that file as the source of truth for category-to-library pairings;
+this file just enumerates the diff-scoped subset the dim flags.

--- a/skills/age/references/sidecar-schema.md
+++ b/skills/age/references/sidecar-schema.md
@@ -68,10 +68,10 @@ Shape:
 
 - **`dimension`** — must match the dim name (`correctness`, `security`,
   `complexity`, `encapsulation`, `spec`, `precedent`, `deslop`,
-  `assertions`).
+  `assertions`, `nih`).
 - **`stake`** — fixed per dim. Do not vary at runtime.
   - high: `correctness`, `security`, `encapsulation`, `spec`
-  - medium: `complexity`, `deslop`, `assertions`
+  - medium: `complexity`, `deslop`, `assertions`, `nih`
   - advisory: `precedent`
 - **`scope_match`** — `false` when the dim's rubric does not apply to
   this diff. Pair with `observations: []`.

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -33,6 +33,7 @@ dialogue actually produced — never more, never less.
 | --- | --- |
 | `/culture` | Same dialogue feel; **never writes**. Use it when there is no artifact intent. |
 | `/briesearch` | External evidence dispatcher. `/mold` calls it through the Validate Cycle. |
+| `/nih-audit` | Whole-repo build-vs-buy sweep. `/mold` calls it from Sketch when multiple library-shaped categories are in play, or offers it at Curdle for migration-style specs. |
 | `/cook` | Implements a curdled spec. `/mold` ends with a hand-off offer, never an auto-invoke. |
 
 ## Operating principles
@@ -102,11 +103,16 @@ Exit when: an option is picked (→ Sketch) or none survive (→ Explore).
 Job: lock modules, responsibilities, I/O contracts, and seams in pseudocode
 signatures, anchored to Sliced Bread slices. Before drafting, parallel
 `cheez-search` for sibling signatures in the same slice so new ones fit
-conventions and respect the crust (the slice's public API).
+conventions and respect the crust (the slice's public API). Run an **NIH
+probe** (single Validate Cycle) before locking any signature whose
+category is library-shaped — retry, validation, UUID, debounce, date,
+argparse, clone, string-case, crypto, sanitizer, format, deep-equality.
+If 2+ such categories are in play, call `/nih-audit` once instead.
 Exit when: every public seam has a signature and a declared `slice` field;
    every cross-slice call imports from the target slice's crust, never its
-   internals. Detail in `references/sketch-mode.md`; architecture rules in
-   `references/sliced-bread.md` (repo root, not local to this skill).
+   internals; library-shaped categories have an NIH probe verdict in
+   `Decisions`. Detail in `references/sketch-mode.md`; architecture rules
+   in `references/sliced-bread.md` (repo root, not local to this skill).
 
 ### Grill — adversarial clarification
 Job: stress-test the chosen approach plus sketched interfaces. **One question
@@ -162,6 +168,7 @@ Detail in `references/validate-cycle.md`.
 | Tool | When | Cap |
 | --- | --- | --- |
 | `/briesearch` (via Validate Cycle) | hypothesis needs external evidence | 2/session |
+| `/nih-audit` | Sketch surfaces 2+ library-shaped categories, or the spec smells migration-shaped | 1/session |
 | `cheez-search` | symbol mention, dependency claim, callers/imports lookup, sibling lookup | unbudgeted |
 | `cheez-read` | file mention, spec read on entry | unbudgeted |
 
@@ -190,9 +197,11 @@ in `references/state-schema.md`.
 ## User knobs (free-form interrupts)
 
 `explore`, `ground`, `shape`, `sketch`, `grill`, `diagnose`,
-`validate <hypothesis>`, `curdle`, `pause`, `enough`. The agent honours
-these immediately. `curdle` initiates the handshake; it does not skip
-the Sketch gate unless the user follows up with `curdle anyway`.
+`validate <hypothesis>`, `nih`, `curdle`, `pause`, `enough`. The agent
+honours these immediately. `curdle` initiates the handshake; it does
+not skip the Sketch gate unless the user follows up with `curdle
+anyway`. `nih` forces an NIH probe at the current sketch even when the
+category does not match the library-shaped trigger words.
 
 ## Uncertainty markers
 
@@ -301,7 +310,11 @@ After writing, offer the next step inline. Never auto-invoke.
 | Artifact | Suggested next step |
 | --- | --- |
 | Spec | `/cook .cheese/specs/<slug>.md` |
+| Migration-shaped spec (≥1 NIH probe verdict of `accept` or `revise`) | `/nih-audit <scope>` first, then `/cook` |
 | Issues | `gh issue create --body-file <path>` (per file) |
+
+"Migration-shaped" is defined in `references/sketch-mode.md` (Migration
+hand-off).
 
 ## Loop detection
 

--- a/skills/mold/references/sketch-mode.md
+++ b/skills/mold/references/sketch-mode.md
@@ -107,6 +107,66 @@ work happens through that single skill.
 If the sweep surfaces a sibling that mirrors what we are about to design,
 adopt the sibling's shape unless there is a stated reason to diverge.
 
+## NIH probe
+
+Before locking a signature for any of the **library-shaped categories**
+below, run an NIH probe — a single Validate Cycle that asks "is this a
+wheel that's already been invented?":
+
+| Category | Trigger words in the sketch |
+|----------|------------------------------|
+| `RETRY` | retry, backoff, exponential, jitter |
+| `VALIDATION` | validate, schema, isEmail, isUrl, regex check |
+| `UUID` | uuid, guid, randomId, generateId |
+| `DEBOUNCE` | debounce, throttle, rate-limit |
+| `DATE` | parseDate, formatDate, addDays, diffMinutes |
+| `ARGPARSE` | argv, parseArgs, CLI flags |
+| `CLONE` | deepClone, cloneDeep, structuredClone |
+| `STRING` | slugify, kebabCase, snakeCase, truncate |
+| `CRYPTO` | hashPassword, verifyPassword |
+| `SECURITY` | sanitizeHtml, escapeHtml |
+| `FORMAT` | formatCurrency, formatNumber, Intl wrapper |
+
+Probe shape (anchored as a Validate Cycle so the framing matters):
+
+```
+Launching a validate cycle on hypothesis:
+  "Library X already does <category>; we should not hand-roll a sketch for it."
+
+Plan:
+  cheez-search — confirm we don't already depend on X (depManifest check).
+  /research    — fetch the canonical library for this category in <language>;
+                 prefer stdlib answers; capture downloads + licence + maintenance.
+  Judge        — does the library cover the contract we're about to sketch?
+  Settle       — accept (use library, drop sketch), revise (sketch wraps lib),
+                 or reject (NIH is intentional; record reason in Decisions).
+```
+
+Cap: at most **one** NIH probe per Sketch session (in addition to the
+shared 2-`/research` budget). Use the probe only for library-shaped
+categories — pure business-domain signatures (an Order, a Pricing rule)
+do not need it.
+
+If the probe verdict is **accept**, drop the sketch entirely and replace
+it with a thin call-site note (`use library X for <category>`). If
+**revise**, the sketch becomes a wrapper signature whose body delegates
+to the library — record `wraps: <library>` in the sketch's `seams` block.
+If **reject**, log the reason in `Decisions` so `/age`'s `nih` dim does
+not flag it later.
+
+For a whole-spec build-vs-buy sweep (multiple library-shaped categories
+across the chosen option), prefer a single `/nih-audit <scope>` call
+over N probes — and record one Decision rolling up its findings.
+
+### Migration hand-off
+
+A spec is "migration-shaped" when its `Decisions` block contains an NIH
+probe verdict of `accept` or `revise` — i.e. the dialogue agreed to drop
+or wrap a hand-rolled implementation. In that case the next step is a
+whole-repo `/nih-audit` so the migration finds every other call site, not
+just the one that triggered the probe. The Curdle hand-off table in
+`SKILL.md` routes that path automatically.
+
 ## Validate Cycle inside Sketch
 
 When a signature mirrors an external API ("our `dispatch` matches Stripe's

--- a/skills/nih-audit/SKILL.md
+++ b/skills/nih-audit/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: nih-audit
+description: Scan a codebase for custom code that duplicates what open-source libraries already do, then recommend which libraries to adopt. Detects hand-rolled utility functions, custom retry logic, manual validation, DIY date handling, home-grown argument parsers, and other reinvented wheels. Cross-checks against installed dependencies and open specs. Returns scored migration recommendations with effort estimates. Use when the user mentions reinventing the wheel, asks if there is a library for something they built, wants a build-vs-buy audit, asks "should we just use lodash for this", or wants to find dependency opportunities.
+license: MIT
+compatibility: Requires tilth MCP for AST-aware search. Library discovery delegates to /research; if /research is unavailable, the audit reports candidates without library recommendations.
+metadata:
+  owner: cheese-flow
+  category: review
+allowed-tools:
+  - read
+  - write
+  - bash
+  - subagent
+  - mcp
+---
+# NIH Audit — Not Invented Here
+
+Find code reinventing the wheel. Recommend libraries. Score with evidence.
+
+`/nih-audit [scope]` — `scope` defaults to repo root.
+
+This skill is the heavy whole-repo audit. The diff-scoped variant runs as the
+`nih` dim inside `/age`. The lightweight pre-Sketch probe lives in `/mold`.
+Use `/nih-audit` when you want a full sweep with library recommendations and
+migration paths.
+
+## Phase 0 — Manifest discovery (no LLM)
+
+Find dependency manifests anywhere in scope, excluding `node_modules/`,
+`vendor/`, `.git/`, build artefacts:
+
+- `package.json`, `Cargo.toml`, `pyproject.toml`, `go.mod`, `Gemfile`,
+  `requirements.txt`, `composer.json`, `build.gradle`, `pom.xml`, `mix.exs`.
+
+Extract dependency names per ecosystem:
+
+| Manifest | Extract |
+|----------|---------|
+| `package.json` | `jq -r '(.dependencies + .devDependencies) // {} \| keys[]'` |
+| `Cargo.toml` | parse `[dependencies]` table |
+| `pyproject.toml` | `[project.dependencies]` or `[tool.poetry.dependencies]` |
+| `go.mod` | `require` block module paths |
+| `requirements.txt` | line-by-line package names |
+
+Build a `depManifest`:
+
+```json
+{
+  "workspaces": [
+    { "root": ".", "ecosystem": "node", "deps": ["express", "zod"] }
+  ],
+  "primaryLanguages": ["typescript"]
+}
+```
+
+If no manifest is found anywhere in scope, abort with a clear message —
+without an installed-deps list there is nothing to cross-reference.
+
+## Phase 1 — Structural NIH scan
+
+Spawn the `nih-scanner` sub-agent (see `agents/nih-scanner.md.eta`):
+
+```
+inputs:
+  languages   = primaryLanguages from Phase 0
+  scope       = $ARGUMENTS or repo root
+  depManifest = JSON from Phase 0
+  slug        = <derived slug>
+```
+
+The scanner returns a JSON candidate list inline plus a one-paragraph
+summary. Parse the candidates from the response. If 0 candidates, report
+clean and stop.
+
+## Phase 2 — Library discovery (parallel, /research)
+
+Group candidates by `category` (RETRY, UUID, VALIDATION, DATE, DEBOUNCE,
+CLONE, ARGPARSE, STRING, HTTP, SERIALIZATION, ERROR, CRYPTO, SECURITY,
+FORMAT, COMPARE).
+
+For each category, dispatch `/research` with a focused question shape:
+
+```
+/research "best <category> library for <language>; must be MIT/Apache/BSD;
+list weekly downloads or crates.io downloads, GitHub stars, last commit
+date, contributor count; flag if functionality is in the standard library"
+```
+
+Cap: max 5 parallel research dispatches. If `/research` is unavailable,
+emit candidates with `recommendation: null` and a note.
+
+For each library returned, capture:
+
+- name + latest version
+- license (flag GPL; prefer MIT/Apache-2.0/BSD)
+- weekly/monthly download count
+- GitHub stars, last commit date, contributor count
+- whether it is stdlib, micro-library, or framework
+- one-sentence API example showing replacement shape
+
+Drop recommendations whose name is already in `depManifest`. Stdlib
+alternatives (no new dep) are the highest-value class — keep them
+prioritized.
+
+See `references/categories.md` for the canonical category-to-library map.
+
+## Phase 3 — Spec and intent alignment
+
+Find spec directories within scope: `**/specs/*.md`, `.cheese/specs/*.md`.
+Filter out `node_modules/`, `vendor/`, `.git/`.
+
+For each candidate, look for signals that the NIH choice was deliberate:
+
+- **In specs**: keywords like "intentionally", "we chose to build", "build
+  vs buy", "don't use", "avoid dependency on" near the candidate's concept.
+- **In the candidate file**: comments like `intentionally`, `deliberately`,
+  `we chose`, `NOTE:`, `DECISION:`, `instead of`, `rather than`.
+
+Apply scoring modifiers:
+
+| Signal | Modifier |
+|--------|----------|
+| Spec explicitly chose NIH | -30 |
+| Code comment explains NIH choice | -20 |
+| Library covers planned spec features | +10 |
+
+## Phase 4 — Score and synthesize
+
+For every candidate with a library recommendation, run the 4-step
+confidence chain:
+
+### Step 1 — classify finding type
+
+| Type | Base | Cap |
+|------|------|-----|
+| `REPLACE_WITH_STDLIB` | 55 | 100 |
+| `REPLACE_WITH_MICRO_LIB` | 45 | 95 |
+| `REPLACE_WITH_FRAMEWORK` | 35 | 85 |
+| `EXTRACT_TO_EXISTING_DEP` | 50 | 95 |
+
+### Step 2 — evidence grounding
+
+| Evidence | Modifier |
+|----------|----------|
+| Caller count grounded in cheez-search | +15 |
+| Library has >10K weekly downloads + permissive licence | +20 |
+| ast-grep pattern + code read confirms NIH | +15 |
+| NIH code has recent bug fixes (git log) | +10 |
+| NIH code >100 LOC for what library does in 1 call | +10 |
+| Generic pattern, code does more than pattern suggests | -15 |
+| Library unmaintained (last commit >1 yr) | hard cap at 40 |
+
+### Step 3 — context modifiers
+
+Apply Phase 3 modifiers (spec intent, code comments, planned features) plus:
+
+| Signal | Modifier |
+|--------|----------|
+| NIH code in git hotspot (many recent changes) | +10 |
+| NIH code isolated (1 file, clear boundary) | +5 |
+| NIH code deeply coupled (referenced from >10 files) | -5 |
+
+### Step 4 — independent second pass
+
+For every candidate, score independently from the first pass:
+
+1. Drop the first score from working memory.
+2. Re-read the NIH code and the library API fresh.
+3. Score using Steps 1–3 again.
+4. Report both scores in the finding.
+5. Final score = average of pass 1 and pass 2.
+6. Divergence > 20 points → tag `AMBIGUOUS`, still emit.
+
+### Effort sizing
+
+| Criteria | Size |
+|----------|------|
+| 1 file, <50 LOC, ≤3 call sites | S |
+| 2-5 files, <200 LOC, ≤10 call sites | M |
+| >5 files, >200 LOC, or >10 call sites | L |
+
+## Phase 5 — Report
+
+Write the full report to `.cheese/nih/<slug>.md`. Render every candidate
+above the threshold; do not silently filter. Each finding follows the
+template in `references/finding-template.md`:
+
+```markdown
+### Finding #N: <title> (Score: NN) [AMBIGUOUS if passes diverge >20]
+
+**NIH Code**: `path/to/file.ts:line-line` (N LOC)
+**Category**: CATEGORY
+**Pattern**: <what was detected>
+
+**Recommended Alternative**: `library-name@version`
+- Licence: MIT/Apache-2.0/BSD
+- Downloads: N/week | Stars: N | Last commit: YYYY-MM-DD
+- Contributors: N
+
+**Code Touchpoints**:
+- `path:line` — implementation (DELETE or REPLACE)
+- `path:line` — import (UPDATE)
+
+**Effort**: S | M | L (N files, N call sites)
+
+**Migration**:
+1. Install: `npm install ...` / `cargo add ...`
+2. Replace: <specific change>
+3. Clean up: <removed files/tests>
+
+**Scoring**:
+- Pass 1: NN (base NN + evidence NN + context NN)
+- Pass 2: NN
+- Final: NN (average)
+
+**Why do it**: <maintenance burden, upstream bugs fixed, stdlib means zero
+deps, covers planned features, ...>
+
+**Why not**: <trivial code not worth a dep, hot path needing control,
+intentional design choice, transitive dep risk, ...>
+```
+
+Top of the report:
+
+```markdown
+# NIH Audit — <scope>
+
+## Summary
+- Files scanned: N
+- Candidates found: N
+- Already using best option: N (filtered)
+- Ambiguous (passes diverge >20): N
+
+## All findings (sorted by score, descending)
+
+| # | Score | P1 | P2 | Category | NIH Code | Replace With | Effort |
+|---|-------|----|----|----------|----------|--------------|--------|
+| 1 | 92 | 90 | 94 | UUID | src/utils/uuid.ts:12 | crypto.randomUUID() (stdlib) | S |
+```
+
+After the table, render every `### Finding #N` block inline.
+
+## Phase 6 — Hand-off
+
+Print the report path. Do not auto-invoke any follow-up:
+
+```
+NIH report: .cheese/nih/<slug>.md
+
+Next steps (manual):
+  • Pick the highest-scored finding and migrate.
+  • For S-effort stdlib swaps, /cook is usually the right next step.
+  • For L-effort framework swaps, run /mold first to lock down the
+    migration interface.
+```
+
+## Rules
+
+- Do not modify code or implement migrations — recommend; the human decides.
+- Do not recommend GPL libraries without flagging the licence risk.
+- Do not override explicit NIH decisions documented in specs or code
+  comments — apply the scoring modifiers and surface the conflict.
+- Do not run in scopes without any manifest file — there is nothing to
+  cross-reference.
+- Empty results report clean and stop. Never force findings.
+- Cap total tool calls across all phases at ~60. After the cap, synthesize
+  from available data and note incomplete coverage.
+
+## Gotchas
+
+- **ast-grep patterns are approximate.** A `clearTimeout` + `setTimeout`
+  combo isn't always a debounce. Step 2's "generic pattern, code does
+  more" modifier (-15) catches false positives.
+- **Stdlib alternatives are the highest value.** `crypto.randomUUID()`
+  replacing a hand-rolled UUID is a no-brainer. Always score these
+  highest (REPLACE_WITH_STDLIB, base 55, cap 100).
+- **Already-installed is the most common false positive.** A codebase
+  that has lodash but hand-rolls `deepClone` may have done so for bundle
+  size reasons. The spec/comment check (Phase 3) catches this.
+- **Monorepo dep scoping.** A function in `packages/api/` may be NIH in
+  that workspace but the library is installed in `packages/web/`. Each
+  workspace's `depManifest` is independent.
+- **Licence compatibility is not just MIT-vs-GPL.** Some projects have
+  specific licence requirements. When in doubt, flag the licence and let
+  the human decide.

--- a/skills/nih-audit/SKILL.md
+++ b/skills/nih-audit/SKILL.md
@@ -19,11 +19,6 @@ Find code reinventing the wheel. Recommend libraries. Score with evidence.
 
 `/nih-audit [scope]` — `scope` defaults to repo root.
 
-This skill is the heavy whole-repo audit. The diff-scoped variant runs as the
-`nih` dim inside `/age`. The lightweight pre-Sketch probe lives in `/mold`.
-Use `/nih-audit` when you want a full sweep with library recommendations and
-migration paths.
-
 ## Phase 0 — Manifest discovery (no LLM)
 
 Find dependency manifests anywhere in scope, excluding `node_modules/`,
@@ -58,7 +53,7 @@ without an installed-deps list there is nothing to cross-reference.
 
 ## Phase 1 — Structural NIH scan
 
-Spawn the `nih-scanner` sub-agent (see `agents/nih-scanner.md.eta`):
+Spawn the `nih-scanner` sub-agent:
 
 ```
 inputs:
@@ -124,7 +119,7 @@ Apply scoring modifiers:
 | Code comment explains NIH choice | -20 |
 | Library covers planned spec features | +10 |
 
-## Phase 4 — Score and synthesize
+## Phase 4a — Score
 
 For every candidate with a library recommendation, run the 4-step
 confidence chain:
@@ -160,6 +155,8 @@ Apply Phase 3 modifiers (spec intent, code comments, planned features) plus:
 | NIH code isolated (1 file, clear boundary) | +5 |
 | NIH code deeply coupled (referenced from >10 files) | -5 |
 
+## Phase 4b — Validate and size
+
 ### Step 4 — independent second pass
 
 For every candidate, score independently from the first pass:
@@ -183,42 +180,7 @@ For every candidate, score independently from the first pass:
 
 Write the full report to `.cheese/nih/<slug>.md`. Render every candidate
 above the threshold; do not silently filter. Each finding follows the
-template in `references/finding-template.md`:
-
-```markdown
-### Finding #N: <title> (Score: NN) [AMBIGUOUS if passes diverge >20]
-
-**NIH Code**: `path/to/file.ts:line-line` (N LOC)
-**Category**: CATEGORY
-**Pattern**: <what was detected>
-
-**Recommended Alternative**: `library-name@version`
-- Licence: MIT/Apache-2.0/BSD
-- Downloads: N/week | Stars: N | Last commit: YYYY-MM-DD
-- Contributors: N
-
-**Code Touchpoints**:
-- `path:line` — implementation (DELETE or REPLACE)
-- `path:line` — import (UPDATE)
-
-**Effort**: S | M | L (N files, N call sites)
-
-**Migration**:
-1. Install: `npm install ...` / `cargo add ...`
-2. Replace: <specific change>
-3. Clean up: <removed files/tests>
-
-**Scoring**:
-- Pass 1: NN (base NN + evidence NN + context NN)
-- Pass 2: NN
-- Final: NN (average)
-
-**Why do it**: <maintenance burden, upstream bugs fixed, stdlib means zero
-deps, covers planned features, ...>
-
-**Why not**: <trivial code not worth a dep, hot path needing control,
-intentional design choice, transitive dep risk, ...>
-```
+template in `references/finding-template.md`.
 
 Top of the report:
 

--- a/skills/nih-audit/references/categories.md
+++ b/skills/nih-audit/references/categories.md
@@ -19,6 +19,7 @@ research query template for each.
 | `CRYPTO` | password hashing | "password hashing library for {language}: bcrypt, argon2; never roll your own" |
 | `SECURITY` | HTML/SQL sanitizer | "HTML sanitization library for {language}: DOMPurify, sanitize-html, bleach" |
 | `FORMAT` | number/currency format | "number/currency formatting library for {language}; check stdlib Intl first" |
+| `PATH` | path-joining utility | "path joining in {language}; check stdlib first (Node path.join / path.posix.join, Python pathlib.Path, Go filepath.Join, Rust std::path::Path)" |
 | `COMPARE` | deep equality | "deep equality library for {language}: fast-deep-equal, lodash.isEqual; check stdlib first" |
 
 ## Stdlib-first principle
@@ -41,7 +42,7 @@ Reject (cap at 40) when any of:
 - Last commit > 1 year ago.
 - Fewer than 3 distinct contributors in the last year.
 - Open critical security issues without a fix.
-- GPL licence in a permissive-licenced project (flag, don't auto-cap).
+- GPL licence in a permissive-licensed project (flag, don't auto-cap).
 
 Prefer when:
 

--- a/skills/nih-audit/references/categories.md
+++ b/skills/nih-audit/references/categories.md
@@ -1,0 +1,51 @@
+# NIH categories — canonical map
+
+The category tag the scanner emits, the library shape to look for, and the
+research query template for each.
+
+| Category | Library shape | Research query |
+|----------|---------------|----------------|
+| `RETRY` | retry / backoff library | "best retry/backoff library for {language} (must be MIT/Apache); jitter and exponential backoff support" |
+| `UUID` | UUID generator | "recommended UUID library for {language}; check stdlib first (crypto.randomUUID, uuid.uuid4, uuid::Uuid)" |
+| `VALIDATION` | schema/regex validator | "best validation library for {language}: zod, pydantic, validator, ozzo, etc." |
+| `DATE` | date/time library | "best date/time library for {language}: date-fns, dayjs, chrono, dateutil; check stdlib first" |
+| `DEBOUNCE` | debounce/throttle | "debounce/throttle library for {language}; small focused micro-libs preferred" |
+| `CLONE` | deep clone | "deep clone library for {language}; check stdlib first (structuredClone, copy.deepcopy)" |
+| `ARGPARSE` | CLI argument parser | "argument parsing library for {language}: commander, click, clap, cobra; not stdlib argparse" |
+| `STRING` | string-case manipulation | "string-case library for {language}: change-case, lodash.kebabCase, slugify" |
+| `HTTP` | HTTP client | "HTTP client library for {language}: axios, requests, reqwest, resty; check stdlib first" |
+| `SERIALIZATION` | (de)serializer | "serialization library for {language}: serde, marshmallow, dataclasses-json" |
+| `ERROR` | error/result type | "error handling library for {language}: thiserror, anyhow; trait/decorator libraries for boilerplate" |
+| `CRYPTO` | password hashing | "password hashing library for {language}: bcrypt, argon2; never roll your own" |
+| `SECURITY` | HTML/SQL sanitizer | "HTML sanitization library for {language}: DOMPurify, sanitize-html, bleach" |
+| `FORMAT` | number/currency format | "number/currency formatting library for {language}; check stdlib Intl first" |
+| `COMPARE` | deep equality | "deep equality library for {language}: fast-deep-equal, lodash.isEqual; check stdlib first" |
+
+## Stdlib-first principle
+
+For every category, check the standard library first. Stdlib alternatives
+score `REPLACE_WITH_STDLIB` (base 55, cap 100) — the highest tier — because
+they require no new dependency.
+
+| Language | Stdlib wins to remember |
+|----------|--------------------------|
+| TypeScript / JS | `crypto.randomUUID`, `structuredClone`, `Intl.NumberFormat`, `Array.prototype.flat`, `URL` parsing |
+| Python | `uuid`, `copy.deepcopy`, `pathlib`, `dataclasses`, `argparse`, `json`, `re` |
+| Rust | `std::time`, `std::path`, `std::env`, derive macros for trivial impls |
+| Go | `path/filepath`, `flag` (basic CLI), `time`, `encoding/json`, `crypto/rand` |
+
+## Library quality bar
+
+Reject (cap at 40) when any of:
+
+- Last commit > 1 year ago.
+- Fewer than 3 distinct contributors in the last year.
+- Open critical security issues without a fix.
+- GPL licence in a permissive-licenced project (flag, don't auto-cap).
+
+Prefer when:
+
+- Top result by downloads in its category.
+- MIT / Apache-2.0 / BSD licence.
+- Active maintainer + recent releases.
+- API surface is small and obvious from a single example.

--- a/skills/nih-audit/references/finding-template.md
+++ b/skills/nih-audit/references/finding-template.md
@@ -1,0 +1,64 @@
+# Finding block template
+
+Every candidate above the threshold renders one block. The orchestrator
+appends every block, sorted by score descending, after the summary table.
+
+```markdown
+### Finding #N: <Title> (Score: NN) [AMBIGUOUS if passes diverge >20]
+
+**NIH Code**: `path/to/file.ext:line-line` (N LOC)
+**Category**: <CATEGORY>
+**Pattern**: <one sentence describing what was detected>
+
+**Recommended Alternative**: `library-name@version`
+- Licence: <SPDX id>
+- Downloads: N/week | Stars: N | Last commit: YYYY-MM-DD
+- Contributors: N
+- Type: stdlib | micro-library | framework
+
+**Code Touchpoints**:
+- `path:line` — implementation (DELETE or REPLACE)
+- `path:line` — import (UPDATE)
+- `path:line` — test (UPDATE)
+
+**Effort**: S | M | L (N files, N call sites)
+
+**Migration**:
+1. Install: `npm install ...` / `cargo add ...` / `uv pip install ...`
+2. Replace: <specific change description>
+3. Clean up: <removed files / deleted helpers / pruned tests>
+
+**Scoring**:
+- Pass 1: NN  (base NN + evidence NN + context NN)
+- Pass 2: NN  (base NN + evidence NN + context NN)
+- Final: NN   (average of Pass 1 and Pass 2)
+
+**Why do it**: <maintenance burden removed, upstream bugs already fixed,
+stdlib means zero new deps, covers planned spec features, ...>
+
+**Why not**: <trivial code not worth a dep, hot path needing fine control,
+intentional design choice documented in spec, transitive deps not wanted,
+...>
+```
+
+## Required fields
+
+- Score line in the heading.
+- NIH Code, Category, Pattern.
+- Recommended Alternative with name + version + licence + downloads.
+- Effort sizing (S / M / L) with file and call-site counts.
+- A 3-step Migration block (Install / Replace / Clean up).
+- Both pass scores plus the average.
+- Both Why-do-it and Why-not — the human decides; render the trade-off
+  honestly.
+
+## When to omit a block
+
+Drop a candidate before rendering if any of:
+
+- The recommended library is already in the project's `depManifest` and
+  the candidate just hasn't migrated to it yet — surface as a "use existing
+  dep" recommendation instead.
+- The category yielded zero passing libraries (all unmaintained, all GPL,
+  etc.) — note the category had no good alternatives in the summary, but
+  do not render an empty Finding.

--- a/tests/age-fixtures/nih/diff.patch
+++ b/tests/age-fixtures/nih/diff.patch
@@ -1,0 +1,11 @@
+--- a/src/users/uuid.ts
++++ b/src/users/uuid.ts
+@@ -0,0 +1,8 @@
++export function generateUserId(): string {
++  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
++    const r = (Math.random() * 16) | 0;
++    const v = c === "x" ? r : (r & 0x3) | 0x8;
++    return v.toString(16);
++  });
++}
++

--- a/tests/age-fixtures/nih/diff.patch
+++ b/tests/age-fixtures/nih/diff.patch
@@ -1,6 +1,6 @@
 --- a/src/users/uuid.ts
 +++ b/src/users/uuid.ts
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,7 @@
 +export function generateUserId(): string {
 +  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
 +    const r = (Math.random() * 16) | 0;
@@ -8,4 +8,3 @@
 +    return v.toString(16);
 +  });
 +}
-+

--- a/tests/age-fixtures/nih/expected.json
+++ b/tests/age-fixtures/nih/expected.json
@@ -1,0 +1,18 @@
+{
+  "dimension": "nih",
+  "stake": "medium",
+  "scope_match": true,
+  "observations": [
+    {
+      "id": "nih-1",
+      "file": "src/users/uuid.ts",
+      "anchor": { "start": "1:000", "end": "7:000" },
+      "bucket": "high",
+      "narrative": "Hand-rolled UUID v4 generator using Math.random and the xxxx-4xxx template; crypto.randomUUID() in node:crypto covers this exact case with no new dependency.",
+      "evidence": [
+        "src/users/uuid.ts:1 generateUserId() uses Math.random() and the xxxx-4xxx template — UUID NIH pattern",
+        "package.json engines.node >= 22 — crypto.randomUUID is stdlib"
+      ]
+    }
+  ]
+}

--- a/tests/age-fixtures/nih/expected.json
+++ b/tests/age-fixtures/nih/expected.json
@@ -10,9 +10,9 @@
       "bucket": "high",
       "narrative": "Hand-rolled UUID v4 generator using Math.random and the xxxx-4xxx template; crypto.randomUUID() in node:crypto covers this exact case with no new dependency.",
       "evidence": [
-        "src/users/uuid.ts:1 generateUserId() uses Math.random() and the xxxx-4xxx template — UUID NIH pattern",
-        "package.json engines.node >= 22 — crypto.randomUUID is stdlib"
+        "src/users/uuid.ts:1 generateUserId() uses Math.random() and the xxxx-4xxx template — UUID NIH pattern"
       ]
     }
-  ]
+  ],
+  "manual_review_concerns": []
 }

--- a/tests/compiler-commands.test.ts
+++ b/tests/compiler-commands.test.ts
@@ -138,6 +138,7 @@ describe("shipped command scaffolds", () => {
       "cook.md",
       "culture.md",
       "mold.md",
+      "nih-audit.md",
     ];
     for (const root of [".claude", ".codex"]) {
       const manifest = await readManifest(projectRoot, root);

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -309,6 +309,7 @@ describe("installHarnessArtifacts", () => {
       "age-correctness.md",
       "age-deslop.md",
       "age-encapsulation.md",
+      "age-nih.md",
       "age-precedent.md",
       "age-security.md",
       "age-spec.md",
@@ -319,6 +320,7 @@ describe("installHarnessArtifacts", () => {
       "cut.md",
       "milknado-executor.md",
       "milknado-planner.md",
+      "nih-scanner.md",
       "press.md",
     ]);
     expect(manifest.skills).toEqual([
@@ -334,6 +336,7 @@ describe("installHarnessArtifacts", () => {
       "milknado-plan",
       "mold",
       "nested-dir",
+      "nih-audit",
       "research",
     ]);
     expect(manifest.commands).toEqual([]);


### PR DESCRIPTION
## Summary
- Adds `/nih-audit` skill with a dedicated `nih-scanner` agent (AST-aware via tilth + ast-grep) for build-vs-buy sweeps.
- Wires NIH detection into `/age` as a ninth review dimension (`age-nih`, sonnet — judgment-shaped).
- Extends `/mold` Sketch mode with a `nih` knob and Curdle hand-off for migration-shaped specs.

## /age fixes applied this branch
- **High**: model bump `age-nih` haiku→sonnet; resolved contradictory evidence-pack handling; added `"`/`'` to nih-scanner scope blocklist; dropped cross-slice path leak from `protocol.md`.
- **Med**: split nih-audit Phase 4 into 4a/4b; replaced inline finding-template with reference; dropped internal agent-path leak from crust; hardened `expected.json` fixture.
- **Low**: dropped redundant Cross-reference + throat-clearing paragraphs.

## Follow-up
- #53 — harden agent input validation: enforce in skill orchestration, not LLM prose (sec-2; deferred from this PR — architectural pattern that touches all agents with a `bash`+caller-input surface, not just `nih-scanner`)

## Test plan
- [x] `just build` passes
- [ ] `/nih-audit` runs end-to-end on a sample repo
- [ ] `/age` surfaces NIH findings alongside existing dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)