### PR TITLE
feat(cure,affine): introduce /cure finisher and revise /affine to collector+classifier

### DIFF
--- a/commands/affine.md
+++ b/commands/affine.md
@@ -1,0 +1,70 @@
+---
+name: affine
+description: Collect external feedback (PR threads, CI failures, merge conflicts, manual bullets) and classify it stake-weighted into a /cure-ready v2 sidecar. Collector + classifier only — /cure owns apply, replies, and re-age.
+argument-hint: "[--from <pr_url|pr_num>] [--manual]"
+---
+
+# /affine
+
+`/affine` is the *affineur* — the cheese ripener who turns wheels and adjusts
+conditions during aging. Where `/mold` → `/cook` → `/age` is the forward
+path, `/affine` ingests external feedback that `/age` cannot see: PR review
+threads, CI failures, merge conflicts, or a hand-typed list. The output is
+a `/cure`-ready v2 sidecar.
+
+## Execution
+
+Invoke the `affine` skill with `$ARGUMENTS`. The skill owns source
+auto-detect, change-order assembly, stake-weighted classification, sidecar
+emission, and the printed hand-off to `/cure`.
+
+Do not reimplement orchestration in this command. This file is the
+user-facing contract; `skills/affine/SKILL.md` is the implementation.
+
+## Loop phases
+
+```
+collect → classify → emit sidecar → hand off to /cure
+```
+
+- **collect** — pull items from the active source: PR review threads
+  (with CI failures and merge conflicts folded in when a PR is on the
+  branch) or a manual bullet list.
+- **classify** — stake-weighted (`high | medium | low`), no numeric
+  scores. Build/merge issues land high; pure style cannot.
+- **emit sidecar** — write `.cheese/affine/<slug>.fixes.json`. The schema
+  is shared with `/age`, so `/cure` can apply both with one router.
+- **hand off** — print `Run /cure --from affine <slug>` and exit. The
+  user types it; the orchestrator never chains on the user's behalf.
+
+## Arguments
+
+```
+/affine                         # auto-detect: PR on branch → manual fallback
+/affine --from <pr_url|pr#>     # explicit PR
+/affine --manual                # interactive: user types items
+```
+
+## Companions
+
+| Skill / command | Boundary |
+| --- | --- |
+| `/cure` | Consumes the sidecar `/affine` emits. Owns the user gate, apply router, replies file, and re-age verify loop. |
+| `/age` | Forward-path review skill. `/affine`'s sidecar schema is shared with `/age` so `/cure` can apply either source. |
+| `/move-my-cheese` | Branch rescue without a PR is `/move-my-cheese`'s job, not `/affine`'s. |
+
+## What `/affine` does NOT do
+
+- Apply fixes, draft replies, or speak to GitHub. Apply, replies, and
+  posting all live downstream of the sidecar (`/cure` for replies, the
+  user for posting).
+- Run `/age` itself or maintain a re-age cap. The 3-turn re-age loop
+  belongs to `/cure`.
+- Consume an existing `/age` sidecar. That path is
+  `/cure --from age <slug>`.
+- Rescue branches without a PR — that is `/move-my-cheese`.
+
+## Output
+
+- `.cheese/affine/<slug>.fixes.json` — change-order sidecar (v2 schema).
+- A printed hand-off line: `Run /cure --from affine <slug>`.

--- a/commands/cure.md
+++ b/commands/cure.md
@@ -1,0 +1,80 @@
+---
+name: cure
+description: Finish what /age started — load both sidecars, render a unified stake table, gate on user approval, apply via /cleanup + cook sub-agents + /merge-resolve, then re-age the touched paths up to a 3-turn cap.
+argument-hint: "<slug> [--from age|affine]"
+---
+
+# /cure
+
+`/cure` is the single hand-off target after `/age` (and after `/affine` for
+the iterate path). In cheesemaking, curing follows aging — the verb fits
+the post-`/age` step. Where `/age` reviews and emits sidecars, `/cure`
+loads them, gates on the user, applies the items through the right
+handler, and re-ages the touched paths.
+
+## Execution
+
+Invoke the `cure` skill with `$ARGUMENTS`. The skill owns sidecar load,
+unified stake-table rendering, the user gate, the apply router, and the
+re-age verify loop.
+
+Do not reimplement orchestration in this command. This file is the
+user-facing contract; `skills/cure/SKILL.md` is the implementation.
+
+## Loop phases
+
+```
+load → user gate → apply → re-age → (turn)
+```
+
+- **load** — read `.cheese/<source>/<slug>.fixes.json` and the optional
+  `<slug>.suggestions.json`, merge into one item list. Source is
+  auto-detected (age first, then affine) or pinned with `--from`.
+- **user gate** — render the items as a stake-grouped table; nothing
+  applies until the user picks ids by hand. The default selection is
+  empty.
+- **apply** — each approved item routes to the right handler:
+  `/cleanup`, direct `cheez-write`, a cook sub-agent, `/merge-resolve`,
+  or `/cook` with a stub spec.
+- **re-age** — `/age --scope <touched-paths>` runs internally over what
+  changed; new findings become the next iteration. Hard cap: 3 turns
+  per invocation.
+
+## Arguments
+
+```
+/cure <slug>                  # auto-detect: age sidecar first, then affine
+/cure <slug> --from age       # pin source: .cheese/age/<slug>.*
+/cure <slug> --from affine    # pin source: .cheese/affine/<slug>.*
+```
+
+## Companions
+
+| Skill / command | Boundary |
+| --- | --- |
+| `/age` | Produces the sidecar pair `/cure` consumes, and re-runs scoped to touched paths inside the loop. |
+| `/affine` | The iterate-source counterpart. `/affine` collects external feedback (PR, manual) into a sidecar; `/cure` consumes it identically to an `/age` sidecar. |
+| `/cleanup` | Mechanical applicator for anchored `edit` items. `/cure` calls it with the original `<slug>` directly. |
+| `/cook` | Handles `design` items: `/cure` writes a stub spec at `.cheese/specs/<slug>-followup.md`, `/cook` implements it. |
+| `/merge-resolve` | Handles `merge_fix` items, one file at a time. |
+
+## What `/cure` does NOT do
+
+- Run automatically after `/age`. The user types `/cure <slug>` once
+  `/age` prints the hand-off; the orchestrator does not chain on the
+  user's behalf.
+- Apply items without explicit approval. The user gate is mandatory and
+  the default selection is empty.
+- Send replies to GitHub. `reply` items are drafted to
+  `.cheese/cure/<slug>.replies.md` for the user to send manually.
+- Ingest external feedback (PR threads, manual bullets, CI failures,
+  merge conflicts). That is `/affine`'s job; `/cure` only consumes the
+  sidecar shape.
+
+## Output
+
+- `.cheese/cure/<slug>.replies.md` — drafted PR replies for human review.
+- `.cheese/cure/<slug>.turns.log.json` — per-turn input/output counts so
+  the 3-turn cap can be tuned from real data.
+- A run report summarizing applied items, skipped items, drafted
+  replies, re-age findings, and any items deferred past the cap.

--- a/skills/affine/SKILL.md
+++ b/skills/affine/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: affine
+description: Collect external feedback (PR threads, CI failures, merge conflicts, manual bullets) and classify it stake-weighted into a /cure-ready v2 sidecar. Collector + classifier only — apply, replies, and re-age live in /cure.
+license: MIT
+metadata:
+  owner: cheese-flow
+  category: cleanup
+allowed-tools:
+  - read
+  - write
+  - bash
+  - subagent
+  - mcp
+---
+
+# Affine — Collect external feedback into a /cure-ready sidecar
+
+`/affine` is the *affineur* — the cheese ripener who turns wheels and adjusts
+conditions during aging. Where `/mold` → `/cook` → `/age` builds and reviews
+new work, `/affine` ingests *external* feedback that `/age` cannot see: PR
+review threads, CI failures, merge conflicts, or a hand-typed list of items.
+
+The loop is intentional and bounded:
+
+```
+collect → classify (stake-weighted) → emit sidecar → hand off to /cure
+```
+
+`/affine` writes a v2 sidecar and prints the hand-off line. It does not
+apply, does not user-gate, does not draft replies, and does not re-age.
+Apply, gate, replies, and re-age all belong to `/cure`.
+
+## Arguments
+
+```
+/affine                         # auto-detect source
+/affine --from <pr_url|pr#>     # explicit PR
+/affine --manual                # interactive: user types items
+```
+
+### Source auto-detect
+
+When no flag is passed, pick the source in this order:
+
+1. **PR** — if the current branch has an open PR, `source=pr`. Inline review
+   threads, review-body bullets, failed CI jobs, and merge conflicts (when
+   `mergeable_state == "dirty"`) are all folded into one PR-sourced
+   change-order.
+2. **manual** — otherwise, fall back to interactive prompt; one item per
+   bullet the user types.
+
+Surface the chosen source in one line before any further work. Consuming an
+existing `/age` sidecar is `/cure --from age <slug>`'s job, not `/affine`'s.
+
+## Phase 1 — Collect
+
+Adapter detail in `references/sources.md`. The adapters share a single
+`Item` shape and emit into a v2 change-order sidecar (see
+`references/schema.md`). The schema is **additive** over the v1 contract:
+required keys unchanged, new optional fields tolerated.
+
+When `source=pr` and a PR is on the branch, the collector folds three
+PR-attribute streams into the same change-order:
+
+- review threads and review-body bullets → `category=edit | reply | design`
+- failed CI runs → `category=ci_fix`, `dimension=build`, `stake=high`
+- unmerged paths when `mergeable_state == "dirty"` → `category=merge_fix`,
+  `dimension=merge`, `stake=high`
+
+There are no `--ci` or `--merge` flags; CI and merge are PR attributes,
+not sources.
+
+## Phase 2 — Classify (stake-weighted)
+
+`classify(co) -> ChangeOrder` runs three inputs per item:
+
+- **severity** — fixed by `(category, dimension)`. Bug/security/build/merge
+  read high; convention/style reads low.
+- **blast** — approximate via `tilth_deps` plus `cheez-search` callers,
+  bucketed.
+- **consensus** — review state, maintainer status, and dimension overlap.
+  `CHANGES_REQUESTED` from a maintainer with multiple dims agreeing
+  pushes up; bot-only single-dim pushes down.
+
+Roll up to a bucket: `high | medium | low`. No numeric scores in the
+report. Hard rules and the rollup structure live in
+`references/classify.md`. Every classification's inputs (severity, blast,
+consensus) are logged so the rollup weights can be tuned from real
+sessions.
+
+## Phase 3 — Emit sidecar
+
+Write the change-order to `.cheese/affine/<slug>.fixes.json`. The schema is
+the v2 additive shape shared with `/age` (see `references/schema.md`).
+
+`/affine` writes the sidecar and exits. Cross-slice work happens via the
+sidecar plus the printed hand-off below; nothing else.
+
+## Phase 4 — Hand-off
+
+Print:
+
+```
+Affine sidecar: .cheese/affine/<slug>.fixes.json (<N> items)
+Next step:      Run /cure --from affine <slug>
+```
+
+Do not auto-invoke `/cure`. The user types the hand-off line; the
+orchestrator never chains on the user's behalf.
+
+## Rules
+
+- The hand-off is a printed prompt — the user types `/cure` themselves.
+  Nothing runs, replies, or publishes without explicit invocation.
+- Build/merge always classify high; pure style never classifies high;
+  `CHANGES_REQUESTED` without a code reference cannot exceed medium.
+- Cross-slice work is the v2 sidecar at `.cheese/affine/<slug>.fixes.json`
+  plus the printed hand-off line. No internal imports.
+- The v2 schema is additive only; existing consumers continue to apply
+  v1 sidecars unchanged.
+- `/affine` does not own the user gate, the apply router, the replies
+  file, or the re-age verify loop — those belong to `/cure`.
+
+## References
+
+- `references/sources.md` — PR / manual adapters; CI and merge folding.
+- `references/schema.md` — v2 additive sidecar schema.
+- `references/classify.md` — stake-weighted rollup, inputs, hard rules.

--- a/skills/affine/references/classify.md
+++ b/skills/affine/references/classify.md
@@ -1,0 +1,118 @@
+# Classify — stake-weighted rollup
+
+`/affine` reports stake as a bucket: `high | medium | low`. There are no
+numeric scores in user-facing output. The rollup is intentionally simple
+and logged so the weights can be tuned from real sessions.
+
+## Inputs
+
+For each item, classify reads three inputs:
+
+### `severity`
+
+Fixed by `(category, dimension)`. The table:
+
+| dimension | category | severity |
+|---|---|---|
+| `build` | `ci_fix` | high |
+| `merge` | `merge_fix` | high |
+| `safety` | `edit` | high |
+| `encap` | `edit` | high |
+| `spec` | `edit` | high |
+| `correctness` | `edit` | high |
+| `complexity` | `edit` | medium |
+| `deslop` | `edit` | medium |
+| `assertions` | `edit` | medium |
+| `reviewer` | `edit` | medium |
+| `precedent` | `edit` | low |
+| `style` | `edit` | low |
+| any | `reply` | low |
+| any | `design` | medium |
+
+### `blast`
+
+Approximate the change's reach with `tilth_deps` plus `cheez-search`
+callers, bucketed:
+
+| call sites | blast |
+|---|---|
+| > 20 | high |
+| 5–20 | medium |
+| < 5 | low |
+| no anchor (file only) | medium (default) |
+
+Bucketing avoids false precision; the call-graph traversal is bounded.
+
+### `consensus`
+
+Signals about reviewer trust and cross-dim agreement:
+
+- `+` push when:
+  - review state is `CHANGES_REQUESTED` from a maintainer
+  - 2+ dimensions raise items at the same locus
+  - the reviewer is a code owner for the touched path
+- `-` push when:
+  - the comment is bot-only (Copilot, Coderabbit) and only one dim agrees
+  - the reviewer has not approved any prior PR in the slice
+
+`consensus` is bucketed `+ | 0 | -`.
+
+## Rollup
+
+```
+stake = roll_up(severity, blast, consensus) ∈ {high, medium, low}
+```
+
+Structure: combine `severity` (high/medium/low), `blast` (high/medium/
+low), and `consensus` (`+`/`0`/`-`) into a single bucket. `severity` is
+the dominant signal; `blast` shifts up at high reach; `consensus` shifts
+one bucket either direction.
+
+The exact rollup weight table is `[?]` — pinned during implementation,
+documented here in structure now. Every classification's inputs
+(`severity`, `blast`, `consensus`) are logged alongside the resulting
+`stake` so the table can be backfit from real sessions.
+
+## Hard rules (override the rollup)
+
+These constraints are non-negotiable and override any rollup result:
+
+- **build/merge always high.** Any item with `dimension=build` or
+  `dimension=merge` (i.e. `ci_fix` and `merge_fix`) is `stake=high`. The
+  rollup never lowers them.
+- **pure style never high.** Items with `dimension=style` (or
+  conventionally style-only, no behavior change) are at most medium. The
+  rollup never raises them.
+- **`CHANGES_REQUESTED` without code reference cannot exceed medium.** A
+  maintainer may push the consensus signal up, but if the comment carries
+  no `path:line` reference and no quoted code, the item is capped at
+  `stake=medium` regardless of severity. `CHANGES_REQUESTED` with a code
+  reference is uncapped and follows the regular rollup.
+
+## Output table
+
+The user-gate table groups by stake (`high` first, then `medium`, then
+`low`), and within each group sorts by file:
+
+```
+| id | stake | category | dim | location | summary |
+```
+
+`stake` is rendered as the bucket name only — no numbers.
+
+## Logging
+
+For every item, write the inputs and the resulting bucket to the run log
+at `.cheese/affine/<slug>.classify.log.json`:
+
+```json
+{
+  "id": "aff-001",
+  "severity": "high",
+  "blast": "medium",
+  "consensus": "+",
+  "stake": "high"
+}
+```
+
+This log is the basis for tuning the rollup weights.

--- a/skills/affine/references/schema.md
+++ b/skills/affine/references/schema.md
@@ -1,0 +1,97 @@
+# Schema — v2 change-order sidecar (additive)
+
+The change-order sidecar is the shared shape between `/age`, `/affine`,
+and `/cleanup`. v2 is **additive** over v1: every required key from v1
+remains required; new fields are optional and tolerated by every
+consumer. There is no breaking change.
+
+## File locations
+
+| Source | Path |
+|---|---|
+| `/age` | `.cheese/age/<slug>.fixes.json` |
+| `/affine` | `.cheese/affine/<slug>.fixes.json` |
+
+Both files share this shape:
+
+```json
+{
+  "version": 2,
+  "slug": "<slug>",
+  "source": "age | pr | manual",
+  "items": [
+    {
+      "id": "aff-001",
+      "category": "edit | reply | ci_fix | merge_fix | design",
+      "dimension": "safety | encap | ... | reviewer | build | merge",
+      "stake": "high | medium | low",
+      "file": "src/foo.ts",
+      "anchor": { "start": 42, "end": 58, "hash": "..." },
+      "content": "...replacement...",
+      "rationale": "...",
+
+      "pr_thread_id": 1234567,
+      "review_body_id": 8901234,
+      "reviewer": "alice",
+
+      "job_id": "build-x86",
+      "log_excerpt": "...",
+      "conflicting_paths": ["src/a.ts"]
+    }
+  ]
+}
+```
+
+## Required keys (v1, unchanged)
+
+Every item must have all of:
+
+- `id` — stable identifier within the change-order.
+- `dimension` — review dimension (`safety`, `encap`, `reviewer`, `build`,
+  `merge`, etc.).
+- `file` — path the item targets.
+- `anchor` — `{ start, end, hash }` for hash-anchored apply, or `null`
+  when the source did not anchor (PR adapter, manual, ci_fix, merge_fix).
+- `content` — replacement text, or `null` when the handler infers it
+  (e.g. `merge_fix`, `reply`).
+- `rationale` — narrative explanation; the apply router falls back to
+  this when no anchor is present.
+- `category` — `edit | reply | ci_fix | merge_fix | design`.
+
+`/cleanup` Phase 1 still aborts when any of these required keys is
+missing; no v2 entry relaxes them.
+
+## Optional v2 fields (additive)
+
+These fields carry source-specific provenance and are tolerated by every
+consumer. Missing or `null` values are valid.
+
+| Field | Source | Meaning |
+|---|---|---|
+| `pr_thread_id` | PR | Inline review thread id, used to draft replies. |
+| `review_body_id` | PR | Review-body id when the item came from a body bullet. |
+| `reviewer` | PR | GitHub login of the reviewer who raised the item. |
+| `job_id` | PR (CI) | GitHub Actions run id for `category=ci_fix`. |
+| `log_excerpt` | PR (CI) | Failing-build log snippet that informs the fix. |
+| `conflicting_paths` | PR (merge) | Paths in conflict for `category=merge_fix`. |
+
+Future siblings of these fields land here without bumping the version.
+The schema is intentionally additive: consumers tolerate unknown optional
+fields, and `/cleanup` continues to apply v1 sidecars unchanged.
+
+## Compatibility contract
+
+- **`/cleanup`** validates v1 required keys, ignores unknown optional
+  fields, and applies hash-anchored items as before. Adding optional
+  fields to a sidecar never breaks `/cleanup`.
+- **`/age`** emits sidecars whose items omit the PR-only fields
+  (`pr_thread_id`, `review_body_id`, `reviewer`, `job_id`,
+  `log_excerpt`, `conflicting_paths`). The same file is consumed by
+  `/cure --from age <slug>` without conversion.
+- **`/affine`** emits sidecars that may include any optional field. The
+  sidecar is consumed by `/cure --from affine <slug>`; `/cure`'s apply
+  router routes `category=edit` items with anchors to `/cleanup`, which
+  ignores the optional fields and applies the v1 contract only.
+
+No breaking change. v2 is unchanged where it matters and additive where
+it grows.

--- a/skills/affine/references/sources.md
+++ b/skills/affine/references/sources.md
@@ -1,0 +1,115 @@
+# Sources — PR / manual adapters
+
+Every source produces a v2 change-order: a list of `Item`s with the shape
+documented in `schema.md`. The PR adapter is the only one that folds in
+PR-attribute items (CI failures, merge conflicts) — see D5.
+
+Consuming an existing `/age` sidecar is `/cure --from age <slug>`'s job, not
+`/affine`'s (D8). `/affine` only collects *external* feedback — feedback
+that `/age` itself cannot see.
+
+## Auto-detect
+
+When the user invokes `/affine` with no flag:
+
+1. If the current branch has an open PR → `source = pr`.
+2. Otherwise → `source = manual`.
+
+The chosen source is announced in one line before any further work.
+
+## `from_pr(pr) -> [Item]`
+
+PR adapter. Activates when `source = pr`, whether explicit (`--from`) or
+auto-detected. Pulls three streams and merges them into one
+change-order.
+
+```
+from_pr(pr) -> ChangeOrder(source=pr):
+  threads = pr_read("get_review_comments", pr)
+              where !is_resolved && !is_outdated
+  bodies  = pr_read("get_reviews", pr)
+              where body != "" and not dup of any thread
+              (link via pull_request_review_id)
+  diff    = pr_read("get_diff", pr)
+
+  for thread in threads:
+    emit Item(category=edit|reply|design,    # heuristic on suggestion type
+              dimension="reviewer",
+              file=thread.path, anchor=null,  # PR adapter doesn't anchor
+              pr_thread_id=thread.id,
+              reviewer=thread.user)
+
+  for body in bodies:
+    for bullet in split_into_suggestions(body.body):
+      emit Item(... review_body_id=body.id, reviewer=body.user)
+
+  if pr.mergeable_state == "dirty":
+    items += merge_items_for(pr)
+  if any check has conclusion="failure":
+    items += ci_items_for(pr)
+```
+
+The PR adapter does not anchor (no `anchor` hash). Items with
+`category=edit` and no anchor are emitted as-is; `/cure`'s apply router
+infers the location from the rationale at apply time.
+
+### `merge_items_for(pr)` — folded into the PR change-order (D5)
+
+```
+merge_items_for(pr) -> [Item]:
+  if pr.mergeable_state != "dirty": return []
+  for path in unmerged_paths:
+    emit Item(category=merge_fix, dimension=merge, stake=high,
+              file=path, anchor=null,
+              rationale="rebase/conflict block",
+              conflicting_paths=[path])
+```
+
+There is no `--merge` flag. Merge conflicts are a PR attribute and ride
+the same change-order as review feedback.
+
+### `ci_items_for(pr)` — folded into the PR change-order (D5)
+
+```
+ci_items_for(pr) -> [Item]:
+  failed = gh run list --branch <pr.head> --json + filter conclusion=failure
+  for run in failed:
+    log = gh run view <id> --log-failed
+    for parsed (file, line, msg) in log:
+      emit Item(category=ci_fix, dimension=build, stake=high,
+                file=file, anchor=null,
+                log_excerpt=msg, job_id=run.id)
+```
+
+There is no `--ci` flag. CI failures are a PR attribute and ride the
+same change-order as review feedback.
+
+## `from_manual() -> ChangeOrder`
+
+Manual adapter. Activates with `--manual` or auto-detect when no PR is on
+the branch.
+
+```
+from_manual() -> ChangeOrder(source=manual):
+  prompt user for free-form bullets (one item per bullet)
+  for each bullet:
+    emit Item(category=heuristic, dimension="reviewer",
+              file=parsed_path_or_null, anchor=null,
+              rationale=bullet_text)
+```
+
+Manual items have no anchor. The user's bullet text is the rationale; the
+classifier uses the bullet to assign a category and dimension.
+
+## Item heuristics
+
+| Bullet shape | category |
+|---|---|
+| Code change request with a file reference | `edit` |
+| Question or discussion only | `reply` |
+| Out-of-scope architectural suggestion | `design` |
+| "CI failed on X" | `ci_fix` |
+| "Merge conflict in Y" | `merge_fix` |
+
+When the heuristic is uncertain, default to `edit`; `/cure`'s user gate
+lets the user reclassify (`draft N`) or drop (`skip N`) the item later.

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -198,13 +198,13 @@ Age report: .cheese/age/<slug>.md
 Fixes:       .cheese/age/<slug>.fixes.json   (<N> entries)
 Suggestions: .cheese/age/<slug>.suggestions.json   (<M> entries)
 
-Next steps:
-  /cleanup <slug>                           — apply mechanical fixes
-  /fromage cook --suggestions <slug>        — act on judgment guidance
+Next step:
+  /cure <slug>                              — apply fixes, route suggestions, re-age
 ```
 
-Do NOT auto-invoke either skill. The amplifier-pure boundary forbids it
-(spec D-14-final). The report is the deliverable; action is the user's call.
+Do NOT auto-invoke /cure. The amplifier-pure boundary forbids it
+(spec D-14-final). The report is the deliverable; the user types the
+hand-off.
 
 ## Phase 5 — Cleanup
 

--- a/skills/age/references/report-template.md
+++ b/skills/age/references/report-template.md
@@ -87,4 +87,4 @@ Format per callout:
 ---
 
 *Report written to `.cheese/age/<slug>.md`. Fixes: <!-- placeholder: N -->. Suggestions: <!-- placeholder: N -->.*
-*To apply fixes: `/cleanup <slug>` -- To act on suggestions: `/fromage cook --suggestions <slug>`*
+*Next step: `/cure <slug>` — applies fixes, routes suggestions, and re-ages the touched paths.*

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -42,6 +42,13 @@ Validate schema: every entry must have all of
 If any entry fails validation, abort with a structured error listing the
 invalid `id` values. Do not apply any fixes from a malformed file.
 
+The validator is **additive** (v2): optional fields are tolerated. Any
+extra keys beyond the v1 required set above — including
+`pr_thread_id`, `review_body_id`, `reviewer`, `job_id`, `log_excerpt`,
+and `conflicting_paths` — are accepted and ignored by `/cleanup`. The
+required keys are not relaxed; the abort-on-missing behavior is
+preserved. See `skills/affine/references/schema.md` for the v2 shape.
+
 If the file does not exist, fail fast:
 
 ```

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -126,9 +126,9 @@ the prior items and emit only **new or changed** items as the next
 iteration. If empty, the loop exits cleanly.
 
 If non-empty, ask the user whether to continue into the next turn. The
-loop has a hard **3-turn cap** per invocation (`turn < 3`). After turn
-3, force-exit and surface remaining items as a one-line "next session"
-hand-off the user can run as `/cure <slug>` again. See
+loop has a hard **3-turn cap** per invocation (`turn <= 3`, 1-indexed).
+After turn 3, force-exit and surface remaining items as a one-line
+"next session" hand-off the user can run as `/cure <slug>` again. See
 `references/re-age.md` for the full diff semantics, the turn log, and
 the cap rationale.
 

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: cure
+description: Finish what /age started. Loads both sidecars (fixes + suggestions), renders a unified stake table, gates on user approval, routes each approved item to the right handler (/cleanup, cook sub-agent, cheez-write, /merge-resolve, /cook), then re-ages the touched paths up to a hard 3-turn cap.
+license: MIT
+metadata:
+  owner: cheese-flow
+  category: cleanup
+allowed-tools:
+  - read
+  - write
+  - bash
+  - subagent
+  - mcp
+---
+# Cure — Finish what `/age` started
+
+`/cure` is the *single* post-`/age` finisher. Where `/age` reviews and
+emits sidecars, `/cure` consumes them, gates on the user, applies items
+through the right handler, and re-ages the touched paths. In
+cheesemaking, curing follows aging — the verb is exact.
+
+The loop is intentional and bounded:
+
+```
+load → user gate → apply → re-age → (turn)
+```
+
+Nothing applies without explicit user approval. Replies are drafted to a
+file, never sent. The re-age verify step has a hard 3-turn cap per
+invocation.
+
+## Arguments
+
+```
+/cure <slug>                  # auto-detect source (age first, then affine)
+/cure <slug> --from age       # pin source to .cheese/age/<slug>.*
+/cure <slug> --from affine    # pin source to .cheese/affine/<slug>.*
+```
+
+`slug` is the same slug emitted by `/age` or `/affine`. Source
+disambiguates by directory: `.cheese/age/<slug>.fixes.json` (and
+companion `<slug>.suggestions.json`) vs `.cheese/affine/<slug>.fixes.json`.
+Auto-detect tries age first, then affine; explicit `--from` always
+overrides. See `references/sources.md` for the full resolution table and
+the missing-sidecar error contract.
+
+All harnesses share the project-root `.cheese/` runtime directory.
+
+## Phase 1 — Load
+
+Resolve the source per the auto-detect order or the explicit `--from`
+flag:
+
+1. `--from age` → `.cheese/age/<slug>.*`
+2. `--from affine` → `.cheese/affine/<slug>.*`
+3. Auto-detect: try `.cheese/age/<slug>.fixes.json` first, then
+   `.cheese/affine/<slug>.fixes.json`.
+
+Load `<dir>/<slug>.fixes.json` (required) and the optional companion
+`<dir>/<slug>.suggestions.json`. Merge their items into a single list.
+If neither sidecar exists, fail fast with the missing-sidecar error
+documented in `references/sources.md`.
+
+The schema is the v2 additive shape shared with `/age`, `/affine`, and
+`/cleanup` — see `skills/affine/references/schema.md`. v1 required keys
+(`id`, `dimension`, `file`, `anchor`, `content`, `rationale`,
+`category`) are required; v2 optional fields are tolerated.
+
+## Phase 2 — User gate
+
+Render the merged items as a stake-grouped table (high → medium → low),
+sorted by file within each group:
+
+```
+| id | stake | category | dim | location | summary |
+```
+
+Items are already pre-classified by `/age` (or `/affine`); `/cure` does
+not re-classify. The default selection is **empty** — nothing applies
+on a bare return. Recognized verbs:
+
+```
+1,3,5         (specific ids)
+all-high      (every high-stake item)
+none          (default; exit cleanly)
+draft N       (flip item N to category=reply, append to replies file)
+skip N        (drop item N from the change-order)
+```
+
+No item executes without an explicit selection. `/cure` always waits for
+the user to pick ids; the orchestrator does not run on the user's behalf
+and does not chain from `/age`.
+
+## Phase 3 — Apply
+
+Each approved item dispatches on `category` through the apply router
+(see `references/apply-router.md`):
+
+| category | handler |
+|---|---|
+| `edit` (with anchor) | `/cleanup <slug>` (single-item synthesized sidecar) |
+| `edit` (no anchor) | direct `cheez-write` (anchor inferred from rationale) |
+| `suggestion` | spawn one cook sub-agent per item with `agent_brief_for_cook` |
+| `ci_fix` | direct `cheez-write` informed by `log_excerpt` |
+| `merge_fix` | `/merge-resolve <file>` |
+| `design` | stub spec at `.cheese/specs/<slug>-followup.md`, then `/cook <spec-path>` |
+| `reply` | append draft to `.cheese/cure/<slug>.replies.md` — never posts |
+
+Cross-slice calls go through public skill entries only (`/cleanup`,
+`/age`, `/cook`, `/merge-resolve`). No reaching into sibling
+internals.
+
+For each non-`reply` item, record `touched_paths += item.file`. Replies
+do not contribute to the next re-age pass.
+
+## Phase 4 — Re-age
+
+If any paths were touched, run internally:
+
+```
+/age --scope <touched_paths>
+```
+
+Diff the resulting `.cheese/age/<slug>.{fixes,suggestions}.json` against
+the prior items and emit only **new or changed** items as the next
+iteration. If empty, the loop exits cleanly.
+
+If non-empty, ask the user whether to continue into the next turn. The
+loop has a hard **3-turn cap** per invocation (`turn < 3`). After turn
+3, force-exit and surface remaining items as a one-line "next session"
+hand-off the user can run as `/cure <slug>` again. See
+`references/re-age.md` for the full diff semantics, the turn log, and
+the cap rationale.
+
+## Replies file
+
+```
+.cheese/cure/<slug>.replies.md
+
+  ## #<thread_id> — <reviewer> on <file>:<line>
+  > [original comment]
+  Draft reply:
+  <body>
+```
+
+`reply` items are appended verbatim. The file is the deliverable; the
+user reads, edits, and posts manually (the dotfiles `/respond` post-only
+mode is a common follow-up). `/cure` never speaks to GitHub.
+
+## Rules
+
+- Default selection is empty. The user gate is the only path to apply.
+- `/cure` is invoked manually after `/age` (or `/affine`) prints the
+  hand-off; the orchestrator never chains it on the user's behalf.
+- Source resolution: explicit `--from age` / `--from affine` overrides
+  auto-detect; auto-detect tries age first, then affine.
+- Cross-slice calls go through `/cleanup`, `/cook`, `/age`, and
+  `/merge-resolve` only — no reaching into sibling internals.
+- Re-age cap is 3 turns per invocation. After 3, hand off remaining
+  items to the next invocation.
+- Replies never post to GitHub. `reply` items are drafted to
+  `.cheese/cure/<slug>.replies.md` and excluded from `touched_paths`.
+
+## References
+
+- `references/sources.md` — auto-detect order, `--from` override, the
+  missing-sidecar error contract.
+- `references/apply-router.md` — category → handler mapping, including
+  the `suggestion` → cook sub-agent path.
+- `references/re-age.md` — verify loop, diff semantics, 3-turn cap, turn
+  log file.

--- a/skills/cure/references/apply-router.md
+++ b/skills/cure/references/apply-router.md
@@ -1,0 +1,101 @@
+# Apply router — category to handler
+
+Each approved item is dispatched on `category` to a single handler. The
+handler is the only thing that touches production paths. Cross-slice
+calls go through public skill entries (`/cleanup`, `/cook`, `/age`,
+`/merge-resolve`); internals are not imported.
+
+## Mapping
+
+| category | handler |
+|---|---|
+| `edit` (with anchor) | `/cleanup <slug>` (single-item synthesized sidecar) |
+| `edit` (no anchor) | direct `cheez-write` (anchor inferred from rationale) |
+| `suggestion` | spawn one cook sub-agent per item with `agent_brief_for_cook` |
+| `ci_fix` | direct `cheez-write` informed by `log_excerpt` |
+| `merge_fix` | `/merge-resolve <file>` |
+| `design` | synthesize stub spec at `.cheese/specs/<slug>-followup.md`, delegate `/cook <spec-path>` |
+| `reply` | append draft to `.cheese/cure/<slug>.replies.md` — NEVER posts to GitHub |
+
+## Per-handler detail
+
+### `edit` (with anchor) → `/cleanup`
+
+Synthesize a minimal sidecar with a single item carrying the v1 required
+keys, write it to `.cheese/cure/<slug>.cure.fixes.json`, and call
+`/cleanup` with the slug. `/cleanup` runs its hash-anchored apply path;
+on hash mismatch the cleanup-wolf re-anchors via narrative match. The
+result feeds back into the loop's `touched_paths`.
+
+### `edit` (no anchor) → `cheez-write`
+
+`/affine`-sourced items often have no anchor (PR or manual provenance).
+Read the file at the location named in the rationale, use `cheez-search`
+to locate the target, then apply the edit with `cheez-write`. The
+rationale is the anchor proxy; record the resulting file in
+`touched_paths`.
+
+### `suggestion` → cook sub-agent
+
+`suggestion` items are judgment-shaped briefs from `/age` — narrative
+fixes that need an LLM to interpret and write. For each approved
+suggestion, spawn one cook sub-agent with the `agent_brief_for_cook`
+payload (item id, file, rationale, surrounding context). The sub-agent
+applies the change with `cheez-write`. Multiple suggestions targeting
+the same file are serialized so the second sub-agent reads the first's
+result; cross-file suggestions can run in parallel.
+
+After each sub-agent returns, record `touched_paths += item.file`.
+
+### `ci_fix` → `cheez-write` (informed by `log_excerpt`)
+
+Read `log_excerpt` for the failing line / file / message, locate the
+target with `cheez-search`, apply the fix with `cheez-write`. The
+`job_id` is recorded in the run report so the user can re-run only the
+failed job after the loop.
+
+### `merge_fix` → `/merge-resolve <file>`
+
+For each path in `conflicting_paths`, delegate to `/merge-resolve`. The
+merge-resolve skill owns mergiraf, git rerere, and kdiff3; `/cure` does
+not reach into its internals. After merge-resolve returns, the file path
+is added to `touched_paths`.
+
+### `design` → stub spec + `/cook`
+
+Architectural changes do not belong in the same loop as line-level
+fixes. Write a stub spec to `.cheese/specs/<slug>-followup.md` with the
+item's rationale as the problem statement, then delegate
+`/cook <spec-path>`. `/cook` runs its full red-green-refactor flow on
+the new spec. The original `/cure` invocation continues with the
+remaining items while `/cook` handles the design item out-of-band.
+
+### `reply` → append to replies file (NEVER posts)
+
+Append a draft entry to `.cheese/cure/<slug>.replies.md`:
+
+```
+## #<thread_id> — <reviewer> on <file>:<line>
+> [original comment]
+Draft reply:
+<body>
+```
+
+The replies file is the deliverable. `/cure` NEVER posts to GitHub; the
+user reads, edits, and sends manually (the dotfiles `/respond` post-only
+mode is a common follow-up). Reply items do **not** add to
+`touched_paths` and therefore do not trigger a re-age pass.
+
+## Touched paths
+
+Every handler except `reply` records the file it modified into
+`touched_paths`. The re-age phase reads this list and runs:
+
+```
+/age --scope <touched_paths>
+```
+
+The diff between the new sidecar and the prior items becomes the next
+iteration. The loop has a 3-turn cap; after the cap, remaining items
+hand off to the next `/cure` invocation. See `re-age.md` for the diff
+semantics and turn-log file.

--- a/skills/cure/references/apply-router.md
+++ b/skills/cure/references/apply-router.md
@@ -22,7 +22,7 @@ calls go through public skill entries (`/cleanup`, `/cook`, `/age`,
 ### `edit` (with anchor) → `/cleanup`
 
 Synthesize a minimal sidecar with a single item carrying the v1 required
-keys, write it to `.cheese/cure/<slug>.cure.fixes.json`, and call
+keys, write it to `.cheese/age/<slug>.fixes.json`, and call
 `/cleanup` with the slug. `/cleanup` runs its hash-anchored apply path;
 on hash mismatch the cleanup-wolf re-anchors via narrative match. The
 result feeds back into the loop's `touched_paths`.

--- a/skills/cure/references/re-age.md
+++ b/skills/cure/references/re-age.md
@@ -39,8 +39,9 @@ next turn. The user can stop the loop at any boundary by selecting
 
 ## 3-turn cap
 
-The loop has a hard cap of **3 turns per invocation** (`turn < 3`).
-After turn 3, force-exit even if the diff is non-empty. Surface the
+The loop has a hard cap of **3 turns per invocation** (`turn <= 3`,
+where turns are 1-indexed). After turn 3, force-exit even if the diff
+is non-empty. Surface the
 remaining items as a one-line "next session" hand-off:
 
 ```

--- a/skills/cure/references/re-age.md
+++ b/skills/cure/references/re-age.md
@@ -1,0 +1,83 @@
+# Re-age — verify loop, diff semantics, 3-turn cap
+
+After the apply phase touches files, `/cure` runs `/age` again, scoped
+to the touched paths, to verify the fixes did not introduce new
+findings. The result becomes the next iteration of the loop. The loop
+has a hard 3-turn cap per invocation.
+
+## Invocation
+
+```
+/age --scope <touched_paths>
+```
+
+`touched_paths` is the deduplicated union of every non-`reply` item's
+`item.file` from the prior apply phase. `reply` items do not contribute
+to `touched_paths` — they were drafted to a file, not committed to
+disk, so re-aging would find nothing useful and would waste tokens.
+
+The scoped `/age` writes the same sidecars `/age` always writes:
+`.cheese/age/<slug>.fixes.json` and `.cheese/age/<slug>.suggestions.json`.
+
+## Diff semantics
+
+After the scoped `/age` returns, `/cure` takes the diff between the new
+sidecars and the prior items, and emits **only new or changed** items
+as the next iteration:
+
+- An item with a new `id` is **new** → include.
+- An item whose `id` matched a prior item but whose `anchor`,
+  `rationale`, or `content` changed is **changed** → include.
+- An item that exactly matches a prior item is **unchanged** → drop.
+
+If the diff is empty, the loop exits cleanly. The user sees a one-line
+summary; no further turns run.
+
+If the diff is non-empty, ask the user whether to continue into the
+next turn. The user can stop the loop at any boundary by selecting
+`none` at the next user gate.
+
+## 3-turn cap
+
+The loop has a hard cap of **3 turns per invocation** (`turn < 3`).
+After turn 3, force-exit even if the diff is non-empty. Surface the
+remaining items as a one-line "next session" hand-off:
+
+```
+3-turn cap reached. <N> items remain — run /cure <slug> again to continue.
+```
+
+The cap value is a design choice and is **explicitly flagged for
+post-implementation review** per the spec. The intent is to bound
+oscillation when a fix re-introduces a finding; 3 is enough for a
+fix → verify → tweak cycle but small enough that runaway loops cannot
+quietly burn budget. Tune the value once we have real session data.
+
+## Turn log
+
+Every turn writes a row to `.cheese/cure/<slug>.turns.log.json` so the
+cap can be tuned from real data:
+
+```json
+{
+  "turn": 1,
+  "input_items": 12,
+  "approved": 7,
+  "applied": 6,
+  "skipped": 1,
+  "drafted_replies": 2,
+  "touched_paths": ["src/foo.ts", "src/bar.ts"],
+  "reage_new_or_changed": 2
+}
+```
+
+Each turn appends a row; the file is the basis for tuning the cap.
+`reply` items count toward `drafted_replies` and are excluded from
+`touched_paths` and from the re-age input.
+
+## Reply exclusion
+
+Replies are drafted to `.cheese/cure/<slug>.replies.md` and never touch
+production source. They do **not** add to `touched_paths` and therefore
+do not trigger a re-age pass. The user reads, edits, and posts the
+replies file manually after the loop exits.

--- a/skills/cure/references/sources.md
+++ b/skills/cure/references/sources.md
@@ -1,0 +1,78 @@
+# Sources — sidecar resolution for `/cure`
+
+`/cure` consumes the same v2 additive sidecar shape as `/age` and
+`/affine` (see `skills/affine/references/schema.md`). The only thing
+this reference adds is **which directory** the sidecar lives in and how
+`/cure` picks it.
+
+## Sidecar paths
+
+| Source | Fixes file | Suggestions file (optional) |
+|---|---|---|
+| `/age` | `.cheese/age/<slug>.fixes.json` | `.cheese/age/<slug>.suggestions.json` |
+| `/affine` | `.cheese/affine/<slug>.fixes.json` | `.cheese/affine/<slug>.suggestions.json` |
+
+`/age` always emits both files. `/affine` emits the fixes file; the
+companion `suggestions.json` is optional. `/cure` loads whichever is
+present and merges into a single item list — a missing
+`suggestions.json` is not an error.
+
+## Auto-detect
+
+When the user invokes `/cure <slug>` with no `--from` flag, resolve the
+source in this order:
+
+1. **age first** — if `.cheese/age/<slug>.fixes.json` exists, set
+   `source = age` and use `.cheese/age/<slug>.*`.
+2. **affine fallback** — else if `.cheese/affine/<slug>.fixes.json`
+   exists, set `source = affine` and use `.cheese/affine/<slug>.*`.
+3. **neither present** — fail with the missing-sidecar error below.
+
+The chosen source is announced in one line before any further work:
+
+```
+source: age (.cheese/age/<slug>.fixes.json + .cheese/age/<slug>.suggestions.json)
+```
+
+## Explicit `--from` override
+
+```
+/cure <slug> --from age       # pin to .cheese/age/<slug>.*
+/cure <slug> --from affine    # pin to .cheese/affine/<slug>.*
+```
+
+`--from` always overrides auto-detect. If the pinned directory has no
+`<slug>.fixes.json`, fail with the missing-sidecar error — `--from`
+never silently falls back to the other directory.
+
+## Missing-sidecar error
+
+When neither directory has `<slug>.fixes.json` (auto-detect) or the
+pinned directory has none (`--from`), abort with:
+
+```
+ERROR: no fixes sidecar found for slug "<slug>".
+
+  tried: .cheese/age/<slug>.fixes.json     (not found)
+  tried: .cheese/affine/<slug>.fixes.json  (not found)
+
+Run /age (or /affine) first to generate the sidecar.
+```
+
+`/cure` never invents items. If the sidecar is missing, the user runs
+the upstream skill and re-tries.
+
+## Schema
+
+The merged item list follows the v2 additive shape from
+`skills/affine/references/schema.md`. v1 required keys
+(`id`, `dimension`, `file`, `anchor`, `content`, `rationale`,
+`category`) are required on every item; v2 optional fields
+(`pr_thread_id`, `review_body_id`, `reviewer`, `job_id`, `log_excerpt`,
+`conflicting_paths`) are tolerated and pass through to the apply router
+when relevant (e.g. `log_excerpt` informs `ci_fix`).
+
+`/cleanup` validates the v1 required keys and aborts on missing fields.
+`/cure` delegates that validation to `/cleanup` for `edit (with anchor)`
+items; for other categories, the apply router enforces the keys it
+needs.

--- a/tests/affine-flow.test.ts
+++ b/tests/affine-flow.test.ts
@@ -1,0 +1,362 @@
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter } from "../src/lib/frontmatter.js";
+import {
+  parseCommandFrontmatter,
+  parseSkillFrontmatter,
+} from "../src/lib/schemas.js";
+
+const root = path.resolve(".");
+
+async function readSource(relativePath: string): Promise<string> {
+  return readFile(path.join(root, relativePath), "utf8");
+}
+
+async function pathExists(relativePath: string): Promise<boolean> {
+  try {
+    await stat(path.join(root, relativePath));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("/affine flow artifacts (revised: collector + classifier only)", () => {
+  // commands/affine.md — D1 (name), §Slice (points at skills/affine/SKILL.md).
+  it("ships a thin /affine command shim that points at the skill", async () => {
+    const source = await readSource("commands/affine.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    const command = parseCommandFrontmatter(parsed.data);
+
+    expect(command.name).toBe("affine");
+    expect(command.description).toMatch(/(collect|classif|sidecar|ingest)/iu);
+    // Body lists the revised loop phases and routes to the skill.
+    expect(parsed.body).toMatch(/collect/iu);
+    expect(parsed.body).toMatch(/classify/iu);
+    expect(parsed.body).toMatch(/emit|sidecar/iu);
+    expect(parsed.body).toMatch(/hand-?off|\/cure/iu);
+    expect(parsed.body).toContain("skills/affine/SKILL.md");
+  });
+
+  // D4 — no auto-execute / no auto-reply / no auto-post on the command shim.
+  it("commands/affine.md disclaims auto-execute / auto-reply / auto-post (D4)", async () => {
+    const source = await readSource("commands/affine.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).not.toMatch(/\bauto-execute\b/iu);
+    expect(parsed.body).not.toMatch(/\bauto-reply\b/iu);
+    expect(parsed.body).not.toMatch(/\bauto-post\b/iu);
+  });
+
+  // D8 — --age mode dropped from the command shim. Consuming /age sidecars
+  // moved to /cure --from age <slug>.
+  it("commands/affine.md drops the --age mode (D8)", async () => {
+    const source = await readSource("commands/affine.md");
+    expect(source).not.toMatch(/--age\b/u);
+  });
+
+  // skills/affine/SKILL.md — frontmatter shape (name + owner).
+  it("skills/affine/SKILL.md has cheese-flow skill frontmatter", async () => {
+    const source = await readSource("skills/affine/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    const frontmatter = parseSkillFrontmatter(parsed.data);
+
+    expect(frontmatter.name).toBe("affine");
+    expect(frontmatter.metadata?.owner).toBe("cheese-flow");
+  });
+
+  // §Approach — revised loop: collect → classify → emit → hand off to /cure.
+  // Apply, user gate, re-age all moved to /cure (D6).
+  it("skills/affine/SKILL.md describes the revised collector loop (D6)", async () => {
+    const source = await readSource("skills/affine/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    const ordered =
+      /collect[\s\S]*classify[\s\S]*(emit|sidecar)[\s\S]*(hand-?off|\/cure)/iu;
+    expect(parsed.body).toMatch(ordered);
+  });
+
+  // D6 — /affine does NOT own user gate, apply, or re-age. These belong to
+  // /cure. The skill must not document any of those phases as its own.
+  it("skills/affine/SKILL.md does not own user-gate / apply / re-age phases (D6)", async () => {
+    const source = await readSource("skills/affine/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).not.toMatch(/##\s*Phase\s*\d[^\n]*user\s*gate/iu);
+    expect(parsed.body).not.toMatch(/##\s*Phase\s*\d[^\n]*apply/iu);
+    expect(parsed.body).not.toMatch(/##\s*Phase\s*\d[^\n]*re-?age/iu);
+  });
+
+  // D6 — /affine does NOT invoke /age itself. The 3-turn cap belongs to /cure.
+  it("skills/affine/SKILL.md does not document a turn cap (D6, moved to /cure)", async () => {
+    const source = await readSource("skills/affine/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).not.toMatch(/\bcap\s*=\s*3\b/iu);
+    expect(parsed.body).not.toMatch(/\bturn\s*<\s*3\b/iu);
+    expect(parsed.body).not.toMatch(/\b3-turn\s+cap\b/iu);
+    expect(parsed.body).not.toMatch(/\b3\s+turns?\s+per\b/iu);
+  });
+
+  // §Approach Entry — auto-detect from PR or manual only. /age sidecar branch
+  // dropped (D8).
+  it("skills/affine/SKILL.md auto-detects PR / manual only — no /age branch (D8)", async () => {
+    const source = await readSource("skills/affine/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toMatch(/\bauto-?detect\b/iu);
+    expect(parsed.body).toMatch(/open\s+PR|PR\s+(present|exists|on)/iu);
+    expect(parsed.body).toMatch(/manual/iu);
+    // The legacy "/age sidecar" auto-detect branch is gone; the SKILL must not
+    // tell users to consume .cheese/age/<slug>.fixes.json — that's /cure's job.
+    expect(parsed.body).not.toMatch(/\.cheese\/age\/[^`\s]*\.fixes/u);
+  });
+
+  // D8 — argument forms: --from <pr>, --manual, auto-detect. No --age.
+  it("skills/affine/SKILL.md documents three argument forms (no --age) (D8)", async () => {
+    const source = await readSource("skills/affine/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toContain("--from");
+    expect(parsed.body).toContain("--manual");
+    expect(parsed.body).toMatch(/auto-?detect/iu);
+    // --age mode is dropped per D8.
+    expect(parsed.body).not.toMatch(/--age\b/u);
+  });
+
+  // D4 + D7 — hand-off line is literally `Run /cure --from affine <slug>`,
+  // pinned verbatim so /cure autocomplete and docs stay consistent.
+  it("skills/affine/SKILL.md prints the literal /cure --from affine handoff (D4/D7)", async () => {
+    const source = await readSource("skills/affine/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toMatch(/Run\s+\/cure\s+--from\s+affine\s+<slug>/u);
+  });
+
+  // D4 — no auto-execute / no auto-reply / no auto-post on the skill.
+  it("skills/affine/SKILL.md disclaims auto-actions (D4)", async () => {
+    const source = await readSource("skills/affine/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).not.toMatch(/\bauto-execute\b/iu);
+    expect(parsed.body).not.toMatch(/\bauto-reply\b/iu);
+    expect(parsed.body).not.toMatch(/\bauto-post\b/iu);
+  });
+
+  // D7 — Sliced Bread crust: /affine's only cross-slice hand-off is /cure via
+  // the v2 sidecar + the printed handoff. /affine does NOT internally invoke
+  // /cleanup or /merge-resolve — those are /cure's apply-router targets.
+  it("skills/affine/SKILL.md does not internally invoke apply handlers (D7)", async () => {
+    const source = await readSource("skills/affine/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    // The hand-off goes to /cure.
+    expect(parsed.body).toContain("/cure");
+    // Apply-handler cross-calls belong to /cure, not /affine.
+    expect(parsed.body).not.toMatch(/\/cleanup\b/u);
+    expect(parsed.body).not.toMatch(/\/merge-resolve\b/u);
+  });
+
+  // D4 — /affine emits its sidecar to .cheese/affine/<slug>.fixes.json. The
+  // exact path is the cross-slice contract /cure consumes.
+  it("skills/affine/SKILL.md emits to .cheese/affine/<slug>.fixes.json", async () => {
+    const source = await readSource("skills/affine/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toMatch(/\.cheese\/affine\/[^`\s]*\.fixes\.json/u);
+  });
+
+  // D4 — replies are no longer drafted by /affine. The replies file moved to
+  // /cure (.cheese/cure/<slug>.replies.md). /affine emits category=reply items
+  // into the sidecar but never drafts to a file or posts.
+  it("skills/affine/SKILL.md does not own the replies file (moved to /cure)", async () => {
+    const source = await readSource("skills/affine/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).not.toMatch(/\.cheese\/affine\/[^`\s]*replies\.md/u);
+    expect(parsed.body).not.toMatch(/##\s*Replies\s+file/iu);
+  });
+
+  // §Source adapters — sources.md covers PR + manual adapters and folds
+  // CI failures and merge conflicts into the PR change-order (D5).
+  it("references/sources.md documents PR / manual adapters and folds CI + merge into the PR change-order (D5)", async () => {
+    const source = await readSource("skills/affine/references/sources.md");
+    expect(source).toMatch(/from_pr\b|PR adapter|source\s*=\s*pr/iu);
+    expect(source).toMatch(
+      /from_manual\b|manual adapter|source\s*=\s*manual/iu,
+    );
+    expect(source).toMatch(/category\s*=\s*ci_fix|\bci_fix\b/u);
+    expect(source).toMatch(/category\s*=\s*merge_fix|\bmerge_fix\b/u);
+  });
+
+  // D8 — sources.md drops the from_age adapter. Consuming /age sidecars is
+  // /cure --from age <slug>'s job.
+  it("references/sources.md does not document a from_age adapter (D8)", async () => {
+    const source = await readSource("skills/affine/references/sources.md");
+    expect(source).not.toMatch(/from_age\b/u);
+    expect(source).not.toMatch(/age adapter/iu);
+    expect(source).not.toMatch(/source\s*=\s*age\b/iu);
+  });
+
+  // §Schema — schema.md documents v2 additive fields and preserves v1
+  // required keys. Schema is shared with /age, /cleanup, /cure.
+  it("references/schema.md documents the v2 additive sidecar fields", async () => {
+    const source = await readSource("skills/affine/references/schema.md");
+    // v2 additive fields
+    expect(source).toContain("pr_thread_id");
+    expect(source).toContain("review_body_id");
+    expect(source).toContain("reviewer");
+    expect(source).toContain("job_id");
+    expect(source).toContain("log_excerpt");
+    expect(source).toContain("conflicting_paths");
+    // v1 required keys are still required
+    for (const key of [
+      "id",
+      "dimension",
+      "file",
+      "anchor",
+      "content",
+      "rationale",
+      "category",
+    ]) {
+      expect(source).toContain(key);
+    }
+    // Explicitly notes additive / unchanged contract.
+    expect(source).toMatch(/additive|unchanged|no breaking change/iu);
+  });
+
+  // §Stake-weighted classify — classify.md inputs, rollup buckets, hard rules.
+  it("references/classify.md documents stake-weighted rollup with required constraints", async () => {
+    const source = await readSource("skills/affine/references/classify.md");
+    expect(source).toMatch(/\bseverity\b/iu);
+    expect(source).toMatch(/\bblast\b/iu);
+    expect(source).toMatch(/\bconsensus\b/iu);
+    expect(source).toMatch(/\bhigh\b[\s\S]*\bmedium\b[\s\S]*\blow\b/iu);
+    // Constraint: build/merge always high.
+    expect(source).toMatch(
+      /(build|merge)[\s\S]{0,60}\balways\b[\s\S]{0,40}\bhigh\b/iu,
+    );
+    // Constraint: pure style never high.
+    expect(source).toMatch(/style[\s\S]{0,40}\bnever\b[\s\S]{0,40}\bhigh\b/iu);
+    // Constraint: CHANGES_REQUESTED w/o code reference cannot exceed medium.
+    expect(source).toMatch(/CHANGES_REQUESTED/u);
+    expect(source).toMatch(
+      /CHANGES_REQUESTED[\s\S]*\bmedium\b|cannot exceed medium/iu,
+    );
+  });
+
+  // §Schema + D2 — /cleanup tolerates v2 additive entries while keeping v1 required.
+  it("skills/cleanup/SKILL.md tolerates v2 additive sidecar fields (D2)", async () => {
+    const source = await readSource("skills/cleanup/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    // v1 hard-error preserved: aborts on missing required fields.
+    expect(parsed.body).toMatch(/abort/iu);
+    for (const key of [
+      "id",
+      "dimension",
+      "file",
+      "anchor",
+      "content",
+      "rationale",
+      "category",
+    ]) {
+      expect(parsed.body).toContain(key);
+    }
+    // New v2 tolerance language: additional / optional fields tolerated.
+    expect(parsed.body).toMatch(
+      /(additional|optional|extra)\s+(fields|keys|properties)[\s\S]{0,80}(tolerat|accept|ignor|allow)/iu,
+    );
+    expect(parsed.body).toMatch(/additive|v2/iu);
+  });
+
+  // §Non-goals — branch rescue without a PR is /move-my-cheese, not /affine.
+  it("commands/affine.md disclaims branch rescue (defers to /move-my-cheese)", async () => {
+    const source = await readSource("commands/affine.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toContain("/move-my-cheese");
+  });
+
+  // D3 — stake-weighted, NOT 0-100 categorical. The negation: no numeric
+  // confidence scale should appear in user-facing classify documentation.
+  it("references/classify.md uses stake buckets only — no 0-100 numeric scoring (D3)", async () => {
+    const source = await readSource("skills/affine/references/classify.md");
+    expect(source).not.toMatch(/\b0\s*[-–to]+\s*100\b/iu);
+    expect(source).toMatch(/no\s+numbers|no\s+numeric/iu);
+  });
+
+  // D6 — apply-router moved to /cure. The legacy file under skills/affine/
+  // must NOT exist; cure's apply-router is the only one.
+  it("skills/affine/references/apply-router.md does not exist (apply moved to /cure)", async () => {
+    const exists = await pathExists("skills/affine/references/apply-router.md");
+    expect(exists).toBe(false);
+  });
+
+  it("skills/cure/references/apply-router.md exists (apply lives in /cure)", async () => {
+    const exists = await pathExists("skills/cure/references/apply-router.md");
+    expect(exists).toBe(true);
+  });
+
+  // §Schema — literal `version: 2` and the source enum.
+  it("references/schema.md pins version: 2 and the source enum literally", async () => {
+    const source = await readSource("skills/affine/references/schema.md");
+    expect(source).toMatch(/"version"\s*:\s*2\b/u);
+    // Shared schema documents both /age- and /affine-emitted sidecars; enum
+    // contains all three values.
+    expect(source).toMatch(/age\s*\|\s*pr\s*\|\s*manual/u);
+  });
+
+  // §Schema — file locations differ between /age and /affine emitters.
+  it("references/schema.md documents both sidecar paths (/age and /affine)", async () => {
+    const source = await readSource("skills/affine/references/schema.md");
+    expect(source).toMatch(/\.cheese\/age\/[^`\s]*\.fixes\.json/u);
+    expect(source).toMatch(/\.cheese\/affine\/[^`\s]*\.fixes\.json/u);
+  });
+
+  // §Source adapters — from_pr enforces !is_resolved && !is_outdated for threads.
+  it("references/sources.md filters out resolved/outdated PR threads", async () => {
+    const source = await readSource("skills/affine/references/sources.md");
+    expect(source).toMatch(/!is_resolved/u);
+    expect(source).toMatch(/!is_outdated/u);
+  });
+
+  // §Source adapters — merge_items_for activates only when mergeable_state == "dirty".
+  it("references/sources.md gates merge_items_for on mergeable_state == 'dirty'", async () => {
+    const source = await readSource("skills/affine/references/sources.md");
+    expect(source).toMatch(/mergeable_state\s*[!=]=\s*"dirty"/u);
+  });
+
+  // §Source adapters — ci_items_for filters on conclusion=failure.
+  it("references/sources.md filters CI runs on conclusion=failure", async () => {
+    const source = await readSource("skills/affine/references/sources.md");
+    expect(source).toMatch(/conclusion\s*=\s*"?failure"?/u);
+  });
+
+  // commands/affine.md routes the hand-off to /cure (user-facing alignment).
+  it("commands/affine.md routes the hand-off to /cure", async () => {
+    const source = await readSource("commands/affine.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toContain("/cure");
+  });
+});
+
+describe("/age Phase 4 hand-off (collapsed to /cure)", () => {
+  // Bundled with the /affine revision: collapse the legacy two-line menu
+  // (`/cleanup <slug>` + `/fromage cook --suggestions <slug>`) into a single
+  // `/cure <slug>` hand-off. /cure now consumes both fixes.json and
+  // suggestions.json in one pass, so the split menu is redundant.
+  it("skills/age/SKILL.md hands off to /cure (single-line menu)", async () => {
+    const source = await readSource("skills/age/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toMatch(/\/cure\s+<slug>/u);
+  });
+
+  it("skills/age/SKILL.md drops the legacy two-line cleanup/cook-suggestions menu", async () => {
+    const source = await readSource("skills/age/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    // The two-line menu offered /cleanup and /fromage cook --suggestions as
+    // separate next steps. After collapse, neither bullet should remain in the
+    // hand-off section.
+    expect(parsed.body).not.toMatch(/\/cleanup\s+<slug>/u);
+    expect(parsed.body).not.toMatch(/\/fromage\s+cook\s+--suggestions/u);
+  });
+
+  // D-14-final still applies: the report is the deliverable; /cure is not
+  // auto-invoked.
+  it("skills/age/SKILL.md does not auto-invoke /cure", async () => {
+    const source = await readSource("skills/age/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toMatch(
+      /(do\s+not\s+auto-invoke|no\s+auto-invoke|never\s+auto-invoke)/iu,
+    );
+  });
+});

--- a/tests/compiler-commands.test.ts
+++ b/tests/compiler-commands.test.ts
@@ -119,7 +119,7 @@ describe("copyCommands", () => {
 });
 
 describe("shipped command scaffolds", () => {
-  it("copies all six scaffolded top-level commands into each harness", async () => {
+  it("copies all eight scaffolded top-level commands into each harness", async () => {
     const projectRoot = await makeProjectRoot("cheese-flow-shipped-commands-");
     await seedAgentsAndSkills(projectRoot);
     await cp(path.resolve("commands"), path.join(projectRoot, "commands"), {
@@ -132,11 +132,13 @@ describe("shipped command scaffolds", () => {
     });
 
     const expected = [
+      "affine.md",
       "age.md",
       "briesearch.md",
       "cheese.md",
       "cook.md",
       "culture.md",
+      "cure.md",
       "mold.md",
     ];
     for (const root of [".claude", ".codex"]) {

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -322,12 +322,14 @@ describe("installHarnessArtifacts", () => {
       "press.md",
     ]);
     expect(manifest.skills).toEqual([
+      "affine",
       "age",
       "basic-skill",
       "cheez-read",
       "cheez-search",
       "cheez-write",
       "cleanup",
+      "cure",
       "gh",
       "merge-resolve",
       "milknado-execute",

--- a/tests/cure-flow.test.ts
+++ b/tests/cure-flow.test.ts
@@ -1,0 +1,319 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter } from "../src/lib/frontmatter.js";
+import {
+  parseCommandFrontmatter,
+  parseSkillFrontmatter,
+} from "../src/lib/schemas.js";
+
+const root = path.resolve(".");
+
+async function readSource(relativePath: string): Promise<string> {
+  return readFile(path.join(root, relativePath), "utf8");
+}
+
+describe("/cure flow artifacts", () => {
+  // commands/cure.md — D1 (name=cure), §Approach (loop phases),
+  // §Slice (points at skills/cure/SKILL.md).
+  it("ships a thin /cure command shim that points at the skill", async () => {
+    const source = await readSource("commands/cure.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    const command = parseCommandFrontmatter(parsed.data);
+
+    expect(command.name).toBe("cure");
+    expect(command.description).toMatch(/cure|apply/iu);
+    // Body lists the loop phases and routes to the skill.
+    expect(parsed.body).toMatch(/load/iu);
+    expect(parsed.body).toMatch(/user\s*gate|gate/iu);
+    expect(parsed.body).toMatch(/apply/iu);
+    expect(parsed.body).toMatch(/re-?age/iu);
+    expect(parsed.body).toContain("skills/cure/SKILL.md");
+  });
+
+  // D5 — no auto-execute / no auto-chain / no auto-post on the command shim.
+  it("commands/cure.md disclaims auto-execute / auto-chain / auto-post (D5)", async () => {
+    const source = await readSource("commands/cure.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).not.toMatch(/\bauto-execute\b/iu);
+    expect(parsed.body).not.toMatch(/\bauto-chain\b/iu);
+    expect(parsed.body).not.toMatch(/\bauto-post\b/iu);
+  });
+
+  // skills/cure/SKILL.md — frontmatter shape (name + owner).
+  it("skills/cure/SKILL.md has cheese-flow skill frontmatter", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    const frontmatter = parseSkillFrontmatter(parsed.data);
+
+    expect(frontmatter.name).toBe("cure");
+    expect(frontmatter.metadata?.owner).toBe("cheese-flow");
+  });
+
+  // §Approach — loop is `load → render table → user gate → apply → re-age`.
+  it("skills/cure/SKILL.md describes the ordered loop phases", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    // Ordered phrasing: load before user gate before apply before re-age.
+    const ordered = /load[\s\S]*user\s*gate[\s\S]*apply[\s\S]*re-?age/iu;
+    expect(parsed.body).toMatch(ordered);
+  });
+
+  // D6 — Source disambiguated by directory; auto-detect tries age first,
+  // then affine; explicit `--from <age|affine>` overrides.
+  it("skills/cure/SKILL.md documents --from age / --from affine and the auto-detect order (D6)", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toContain("--from age");
+    expect(parsed.body).toContain("--from affine");
+    expect(parsed.body).toMatch(/auto-?detect/iu);
+    // Ordered: age tried before affine in the auto-detect.
+    expect(parsed.body).toMatch(/\.cheese\/age\/[\s\S]*\.cheese\/affine\//u);
+  });
+
+  // D5 + D7 — user gate is the only path; default empty; no auto-execute.
+  it("skills/cure/SKILL.md enforces the user gate, default empty, and disclaims auto-execute (D5/D7)", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toMatch(/user\s*gate/iu);
+    expect(parsed.body).toMatch(
+      /default\s+(selection\s+)?(is\s+)?\*?\*?empty\*?\*?/iu,
+    );
+    expect(parsed.body).not.toMatch(/\bauto-execute\b/iu);
+    expect(parsed.body).not.toMatch(/\bauto-chain\b/iu);
+    expect(parsed.body).not.toMatch(/\bauto-post\b/iu);
+  });
+
+  // §Approach — cross-slice public skill seams.
+  it("skills/cure/SKILL.md references the public skill seams it calls", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toContain("/cleanup");
+    expect(parsed.body).toContain("/age");
+    expect(parsed.body).toContain("/cook");
+    expect(parsed.body).toContain("/merge-resolve");
+  });
+
+  // D3 — re-age cap = 3 turns; pin literal 3, deny drift to 2/4/5.
+  it("skills/cure/SKILL.md hard-codes the literal cap of 3 turns (D3)", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    // Literal "3-turn", "cap = 3", or "turn < 3" must appear.
+    expect(parsed.body).toMatch(
+      /\b3-turn\b|\bcap\s*=\s*3\b|\bturn\s*<\s*3\b|\b3\s*turns?\s+per\b/iu,
+    );
+    // No drift to other small integers as the cap.
+    expect(parsed.body).not.toMatch(/\bcap\s*=\s*[245]\b/iu);
+    expect(parsed.body).not.toMatch(/\bturn\s*<\s*[245]\b/iu);
+    expect(parsed.body).not.toMatch(/\b[245]-turn\b/iu);
+  });
+
+  // §User gate — verbs and empty default per spec.
+  it("skills/cure/SKILL.md documents the user-gate verbs and empty default", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toMatch(/\ball-high\b/u);
+    expect(parsed.body).toMatch(/\bnone\b/u);
+    expect(parsed.body).toMatch(/\bdraft\s+\d|draft\s+N\b/u);
+    expect(parsed.body).toMatch(/\bskip\s+\d|skip\s+N\b/u);
+    expect(parsed.body).toMatch(
+      /default\s+(selection\s+)?(is\s+)?\*?\*?empty\*?\*?/iu,
+    );
+  });
+
+  // §Approach Entry — loads BOTH fixes.json AND suggestions.json and merges.
+  it("skills/cure/SKILL.md loads fixes.json AND suggestions.json and merges into a unified table", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toContain("fixes.json");
+    expect(parsed.body).toContain("suggestions.json");
+    expect(parsed.body).toMatch(/merge|unified|merged/iu);
+  });
+
+  // §sources adapter — sidecar paths, auto-detect order, --from override,
+  // missing-sidecar error.
+  it("references/sources.md documents sidecar paths, auto-detect order, --from override, and missing-sidecar error", async () => {
+    const source = await readSource("skills/cure/references/sources.md");
+    expect(source).toMatch(/\.cheese\/age\/[^`\s]*\.fixes\.json/u);
+    expect(source).toMatch(/\.cheese\/affine\/[^`\s]*\.fixes\.json/u);
+    expect(source).toContain("suggestions.json");
+    // Auto-detect order: age first, then affine.
+    expect(source).toMatch(/auto-?detect/iu);
+    expect(source).toMatch(/\.cheese\/age\/[\s\S]*\.cheese\/affine\//u);
+    // Explicit --from override.
+    expect(source).toContain("--from age");
+    expect(source).toContain("--from affine");
+    // Missing-sidecar error language.
+    expect(source).toMatch(/missing|neither|error|not found/iu);
+  });
+
+  // §Apply router — apply-router.md maps every category to its handler.
+  it("references/apply-router.md maps every category to its handler", async () => {
+    const source = await readSource("skills/cure/references/apply-router.md");
+    // edit (with anchor) → /cleanup
+    expect(source).toMatch(/\bedit\b[\s\S]{0,80}\/cleanup/iu);
+    // edit (no anchor) → cheez-write
+    expect(source).toMatch(/\bedit\b[\s\S]{0,160}cheez-write/iu);
+    // suggestion → cook sub-agent
+    expect(source).toMatch(
+      /\bsuggestion\b[\s\S]{0,120}cook[\s\S]{0,40}sub-?agent/iu,
+    );
+    // ci_fix → cheez-write
+    expect(source).toMatch(/\bci_fix\b[\s\S]{0,80}cheez-write/iu);
+    // merge_fix → /merge-resolve
+    expect(source).toMatch(/\bmerge_fix\b[\s\S]{0,80}\/merge-resolve/iu);
+    // design → /cook (with stub spec)
+    expect(source).toMatch(/\bdesign\b[\s\S]{0,120}\/cook/iu);
+    // reply → append to .cheese/cure/<slug>.replies.md
+    expect(source).toMatch(/\.cheese\/cure\/[^`\s]*replies\.md/u);
+    // Reply NEVER posts.
+    expect(source).toMatch(/NEVER\s+(post|github)/u);
+  });
+
+  // §Re-age verify loop — 3-turn cap, /age --scope invocation, diff prior,
+  // only new/changed items, replies excluded from touched_paths.
+  it("references/re-age.md documents the 3-turn cap, /age --scope, diff semantics, and reply exclusion", async () => {
+    const source = await readSource("skills/cure/references/re-age.md");
+    // Literal cap of 3.
+    expect(source).toMatch(
+      /\b3-turn\b|\bcap\s*=\s*3\b|\bturn\s*<\s*3\b|\b3\s*turns?\b/iu,
+    );
+    // No drift to other small integers as the cap.
+    expect(source).not.toMatch(/\bcap\s*=\s*[245]\b/iu);
+    expect(source).not.toMatch(/\bturn\s*<\s*[245]\b/iu);
+    // /age --scope <touched_paths> invocation.
+    expect(source).toMatch(/\/age\s+--scope/u);
+    expect(source).toContain("touched_paths");
+    // Diff against prior items.
+    expect(source).toMatch(/\bdiff\b[\s\S]{0,80}\bprior\b/iu);
+    // Only new/changed items advance.
+    expect(source).toMatch(/\bnew\b\s+or\s+changed|only\s+new[/\s]/iu);
+    // Replies excluded from touched_paths.
+    const negation = "(do[\\s*]+not|never|skip|exclud)";
+    const replyExclusion = new RegExp(
+      `(repl(y|ies)[\\s\\S]{0,160}${negation}[\\s\\S]{0,80}touched_paths)|(${negation}[\\s\\S]{0,80}touched_paths[\\s\\S]{0,160}repl(y|ies))`,
+      "iu",
+    );
+    expect(source).toMatch(replyExclusion);
+  });
+
+  // §Re-age — turn-log file path per spec.
+  it("references/re-age.md mentions the turn-log file path", async () => {
+    const source = await readSource("skills/cure/references/re-age.md");
+    expect(source).toMatch(/\.cheese\/cure\/[^`\s]*turns\.log\.json/u);
+  });
+
+  // commands/cure.md — argument-hint frontmatter pins the CLI surface
+  // (slug + optional --from age|affine). Spec D6.
+  it("commands/cure.md argument-hint pins <slug> and --from age|affine", async () => {
+    const source = await readSource("commands/cure.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    const command = parseCommandFrontmatter(parsed.data);
+    expect(command["argument-hint"]).toBeDefined();
+    const hint = command["argument-hint"] ?? "";
+    expect(hint).toContain("<slug>");
+    expect(hint).toMatch(/--from\s+age\s*\|\s*affine/u);
+  });
+
+  // §User gate — comma-separated id verb literally documented as "1,3,5".
+  // Spec line: `1,3,5         (specific ids)`.
+  it("skills/cure/SKILL.md pins the comma-separated specific-ids verb 1,3,5", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toContain("1,3,5");
+  });
+
+  // §User gate — verbs `draft N` / `skip N` literally use the placeholder
+  // `N`, not just any digit. Strengthens the existing loose alternation.
+  it("skills/cure/SKILL.md uses the literal `draft N` and `skip N` placeholders", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toMatch(/\bdraft\s+N\b/u);
+    expect(parsed.body).toMatch(/\bskip\s+N\b/u);
+  });
+
+  // D2 — the unified-loop framing. Spec calls /cure the *single hand-off
+  // target*; SKILL.md must echo single/finisher framing somewhere.
+  it("skills/cure/SKILL.md frames /cure as the single post-/age finisher (D2)", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toMatch(
+      /\bsingle\b[^\n]{0,40}(hand-?off\s+target|finisher)/iu,
+    );
+  });
+
+  // D3 rationale — the spec explicitly flags the cap value for
+  // post-implementation review and ties the turn log to that review. The
+  // re-age reference must surface that rationale, not just the literal 3.
+  it("references/re-age.md captures the post-implementation review flag for the cap (D3)", async () => {
+    const source = await readSource("skills/cure/references/re-age.md");
+    expect(source).toMatch(/post-?implementation\s+review/iu);
+    // Turn-log purpose tied to tuning, per spec.
+    expect(source).toMatch(/tune|tuning/iu);
+  });
+
+  // §Apply router — `design` items emit a stub spec at a specific path.
+  // Spec line: `.cheese/specs/<slug>-followup.md`.
+  it("references/apply-router.md pins the design-item stub spec path", async () => {
+    const source = await readSource("skills/cure/references/apply-router.md");
+    expect(source).toMatch(/\.cheese\/specs\/[^`\s]*-followup\.md/u);
+  });
+
+  // §Apply router — suggestion items spawn a cook sub-agent with the
+  // `agent_brief_for_cook` payload. Pin the literal payload identifier.
+  it("references/apply-router.md names the agent_brief_for_cook payload (D4)", async () => {
+    const source = await readSource("skills/cure/references/apply-router.md");
+    expect(source).toContain("agent_brief_for_cook");
+  });
+
+  // §Apply router — replies do NOT add to touched_paths. The spec puts
+  // this rule in the apply-router section; pin it there too (re-age.md
+  // already pins the dual rule on the re-age side).
+  it("references/apply-router.md states reply items do not contribute to touched_paths", async () => {
+    const source = await readSource("skills/cure/references/apply-router.md");
+    const negation = "(do[\\s*]+not|never|skip|exclud)";
+    const replyExclusion = new RegExp(
+      `(repl(y|ies)[\\s\\S]{0,200}${negation}[\\s\\S]{0,80}touched_paths)|(${negation}[\\s\\S]{0,80}touched_paths[\\s\\S]{0,200}repl(y|ies))`,
+      "iu",
+    );
+    expect(source).toMatch(replyExclusion);
+  });
+
+  // §Replies file — the replies file format pins thread id, reviewer, and
+  // location. Spec lines 178-184 show the exact heading shape.
+  it("skills/cure/SKILL.md documents the replies-file heading shape", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    // Heading is "## #<thread_id> — <reviewer> on <file>:<line>".
+    expect(parsed.body).toMatch(
+      /##\s+#<thread_id>\s+—\s+<reviewer>\s+on\s+<file>:<line>/u,
+    );
+  });
+
+  // D5 reinforcement — SKILL.md must say `/cure` never speaks to GitHub
+  // and never posts. Strong literal pins, not just absence of strings.
+  it("skills/cure/SKILL.md positively asserts /cure never posts to GitHub", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    // Either "never speaks to GitHub" or "never post(s) to GitHub".
+    expect(parsed.body).toMatch(/never\s+(speaks?|posts?)\s+to\s+GitHub/iu);
+  });
+
+  // §Replies file — replies file path is owned by the SKILL.md too,
+  // not just apply-router.md. Pin it explicitly.
+  it("skills/cure/SKILL.md names the replies file at .cheese/cure/<slug>.replies.md", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toMatch(/\.cheese\/cure\/[^`\s]*replies\.md/u);
+  });
+
+  // §Approach Entry — the auto-detect order must be tried in this exact
+  // order in SKILL.md too (D6). Existing test only checks for the
+  // substring pair without intermediate guard; this also pins the
+  // auto-detect prose to age-then-affine ordering.
+  it("skills/cure/SKILL.md spells out auto-detect order: age first, then affine (D6)", async () => {
+    const source = await readSource("skills/cure/SKILL.md");
+    const parsed = parseFrontmatter<unknown>(source);
+    expect(parsed.body).toMatch(/age\s+first[\s\S]{0,40}then\s+affine/iu);
+  });
+});


### PR DESCRIPTION
## Summary

Splits post-`/age` finishing from external-feedback ingestion into two slices, and collapses `/age`'s two-line hand-off into a single `/cure` entry point.

- **`/cure` (new)** — single post-`/age` finisher. Loads both sidecars, renders a unified stake table, gates on the user, dispatches each item via the apply router (`/cleanup`, cook sub-agent, `cheez-write`, `/merge-resolve`, `/cook`), then re-ages touched paths up to a hard 3-turn cap.
- **`/affine` (revised)** — collector + classifier only. Drops user gate / apply / replies / re-age (now owned by `/cure`), drops `--age` mode and the `/age`-sidecar auto-detect branch, emits a v2 sidecar and prints `Run /cure --from affine <slug>`.
- **`/age` Phase 4 + `/cleanup`** — `/age` hand-off collapsed to a single `/cure <slug>` line; `/cleanup` validator now tolerates v2 additive fields while preserving v1 required-key abort behavior.

## Test plan

- [x] `npm run test` — 366/366 passed (65 new doc-tests across `cure-flow.test.ts` and `affine-flow.test.ts`)
- [x] `npm run typecheck` — clean
- [x] `npm run lint:skills` — 14 skills, no issues
- [x] `just build` — Functions 100% / Lines 100%, ruff clean, 154 pytest passed