### PR TITLE
[codex] Add canonical briesearch research workflow

### DIFF
--- a/commands/briesearch.md
+++ b/commands/briesearch.md
@@ -1,21 +1,23 @@
 ---
 name: briesearch
-description: Multi-source research orchestrator. Routes a question across Tavily, Context7 library docs, GitHub, and in-repo tools, writes findings to .cheese/research/<slug>.md, and returns a compact synthesis to the main context.
+description: Multi-source research orchestrator. Scans the canonical project .cheese/research knowledge base, routes a question across Tavily, Context7 library docs, GitHub, and in-repo tools, writes frontmatter-backed findings to .cheese/research/<slug>.md, and returns a compact synthesis to the main context.
 argument-hint: "<question | library | API | dependency>"
 ---
 
 # /briesearch
 
-`/briesearch` is the research orchestrator. It routes a question across
+`/briesearch` is the research orchestrator. It first scans the canonical
+project `.cheese/research` knowledge base, then routes a question across
 multiple information sources in parallel, writes full findings to
-`.cheese/research/<slug>.md`, and returns a compact synthesis back to the
-main context so it does not pollute the caller's window.
+`.cheese/research/<slug>.md`, and returns a compact synthesis back to the main
+context so it does not pollute the caller's window.
 
 ## Execution
 
-Invoke the `research` skill with `$ARGUMENTS`. The skill owns source routing,
-scratch-file handling, synthesis, confidence scoring, optional report writing,
-and cleanup.
+Invoke the `research` skill with `$ARGUMENTS`. The skill owns canonical
+`.cheese` root resolution, knowledge-base scanning, source routing,
+scratch-file handling, synthesis, confidence scoring, report frontmatter, and
+cleanup.
 
 Do not reimplement the fetcher workflow in this command. This command is the
 user-facing alias and contract for research; `skills/research/SKILL.md` is the
@@ -29,6 +31,7 @@ implementation source of truth.
 | Library docs | Context7 | API reference, configuration, migration notes |
 | In-repo context | tilth, ripgrep, LSP | How the target codebase already handles related concerns |
 | Open-source examples | GitHub | How public projects solve similar problems |
+| Prior project research | `.cheese/research` scanner sub-agents | Existing findings, freshness, supersession, and revalidation targets |
 
 Each source runs in parallel where possible. Overlapping findings are
 merged; conflicts are flagged in the synthesis.
@@ -36,9 +39,12 @@ merged; conflicts are flagged in the synthesis.
 ## Output contract
 
 - **Full report** written to `.cheese/research/<slug>.md`:
+  - YAML frontmatter with `created_at`, `updated_at`,
+    `last_validated_at`, `confidence`, freshness, relevance, tags,
+    sources, and related reports.
   - Question and scope.
   - Source-by-source findings with inline citations.
-  - Conflicts, caveats, and freshness notes.
+  - Conflicts, caveats, freshness notes, and revalidation status.
   - Recommended next step (e.g. "adopt library X", "build in-house",
     "invoke `/mold` to spec this out").
 - **Synthesis** returned to the caller:

--- a/commands/mold.md
+++ b/commands/mold.md
@@ -15,8 +15,8 @@ generator: the dialogue is the point, the artifact is the by-product.
 
 Invoke the `mold` skill with `$ARGUMENTS`. The skill owns mode routing,
 Validate Cycle dispatch, interface lockdown via pseudocode, the two-key
-handshake, and atomic artifact extraction to `.cheese/specs/<slug>.md`
-and `.cheese/issues/<slug>-NNN.md`.
+handshake, and atomic artifact extraction to the canonical project
+`.cheese/specs/<slug>.md` and `.cheese/issues/<slug>-NNN.md`.
 
 Do not reimplement the dialogue or extraction logic in this command.
 This file is the user-facing alias and contract; `skills/mold/SKILL.md`
@@ -27,15 +27,16 @@ is the implementation source of truth.
 | Skill | Boundary |
 | --- | --- |
 | `/culture` | Same dialogue feel; **never writes**. Use it when there is no artifact intent. |
-| `/briesearch` | External evidence dispatcher. `/mold` calls it through the Validate Cycle. |
+| `/briesearch` | Evidence dispatcher. `/mold` calls it through the Validate Cycle; it scans prior project research before external sources. |
 | `/cook` | Implements a curdled spec. `/mold` ends with a hand-off offer, never an auto-invoke. |
 
 ## What you get
 
-- **Spec** — rich container, written to `.cheese/specs/<slug>.md`.
+- **Spec** — rich container, written to canonical
+  `.cheese/specs/<slug>.md`.
   Always present unless the dialogue produced only standalone bug
   tickets.
-- **Issues** — separate, GitHub-flavored, written to
+- **Issues** — separate, GitHub-flavored, written to canonical
   `.cheese/issues/<slug>-NNN.md`. Present when the dialogue surfaced
   side-channel actionables (out-of-scope bugs, follow-ups, parking-lot
   work).

--- a/commands/nih-audit.md
+++ b/commands/nih-audit.md
@@ -28,7 +28,7 @@ implementation source of truth.
 | --- | --- |
 | `/age` (`nih` dim) | **Diff-scoped**. Flags newly introduced NIH in a single PR. Use for review gating. |
 | `/mold` (Sketch NIH probe) | **Pre-implementation**. Catches NIH before a signature is locked. Use during design. |
-| `/research` | Library discovery dispatcher. `/nih-audit` calls it once per category group. |
+| `/briesearch` | Library discovery dispatcher. `/nih-audit` calls it once per category group. |
 
 ## What you get
 

--- a/references/README.md
+++ b/references/README.md
@@ -8,6 +8,12 @@ Long-form architectural and engineering references that ship alongside cheese-fl
 |---|---|
 | [tilth/tilth-mcp.md](./tilth/tilth-mcp.md) | **Always when using tilth tools.** Complete reference for tilth_search, tilth_read, tilth_files, tilth_deps, and tilth_edit. Hash anchor format, session deduplication, tree-sitter languages. |
 
+## Runtime Artifact Directories
+
+| Document | When to load |
+|---|---|
+| [canonical-cheese.md](./canonical-cheese.md) | When a skill writes durable research, specs, or issues under `.cheese/`, especially from a linked Git worktree or Conductor workspace. |
+
 ## Sliced Bread Architecture
 
 | Document | When to load |

--- a/references/canonical-cheese.md
+++ b/references/canonical-cheese.md
@@ -1,0 +1,54 @@
+# Canonical `.cheese` Directories
+
+Most cheese-flow runtime artifacts use a project-root `.cheese/` directory.
+For durable knowledge artifacts, "project root" means the canonical main Git
+worktree when the current checkout is a linked worktree.
+
+## Active Worktree Root
+
+The active root is the checkout the agent is currently operating in:
+
+```bash
+git rev-parse --show-toplevel
+```
+
+Use this root for code edits, builds, tests, and branch-local runtime state.
+
+## Canonical Project Root
+
+The canonical project root is used for durable research and spec knowledge that
+should survive branch worktrees. Resolve it from the first record in
+`git worktree list --porcelain`, falling back to the active root:
+
+```bash
+ACTIVE_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+CANONICAL_ROOT="$(
+  git -C "$ACTIVE_ROOT" worktree list --porcelain 2>/dev/null \
+    | awk 'BEGIN { RS=""; FS="\n" } NR == 1 { sub(/^worktree /, "", $1); print $1 }'
+)"
+CANONICAL_ROOT="${CANONICAL_ROOT:-$ACTIVE_ROOT}"
+```
+
+In Conductor, this prevents research and specs from being stranded in disposable
+linked worktree directories.
+
+## Artifact Policy
+
+Write durable knowledge here:
+
+- `<canonical-project-root>/.cheese/research/`
+- `<canonical-project-root>/.cheese/specs/`
+- `<canonical-project-root>/.cheese/issues/`
+
+Keep branch-local operational reports in the active worktree unless a skill says
+otherwise:
+
+- `.cheese/age/`
+- `.cheese/cure/`
+- `.cheese/cleanup/`
+
+## Gitignored by Design
+
+Both active and canonical `.cheese/` directories are local and gitignored. They
+are for agent/user collaboration, not versioned source.
+

--- a/references/dotfiles-takeover-inventory.md
+++ b/references/dotfiles-takeover-inventory.md
@@ -49,7 +49,7 @@ personal paths or Claude-only behavior.
 | `init` | `plugins/local/cheese-flow/commands/init.md` | Already cheese-flow branded; should live in the repo as source of truth. |
 | `explore` | `plugins/local/cheese-flow/commands/explore.md` | Core cheese-flow value proposition. |
 | `hello` | `plugins/local/cheese-flow/commands/hello.md` | Cheap install smoke test. |
-| `research` | `commands/research.md` | Thin wrapper around the `research` skill. |
+| `briesearch` | `commands/briesearch.md` | Thin wrapper around the `research` skill. |
 | `diff` | `commands/diff.md` | Thin wrapper around the `diff` skill. |
 | `respond` | `commands/respond.md` | Useful PR-review workflow once GitHub tooling is modeled. |
 | `worktree` | `commands/worktree.md` | Thin wrapper around the `worktree` skill. |

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -32,7 +32,7 @@ dialogue actually produced — never more, never less.
 | Companion | Boundary |
 | --- | --- |
 | `/culture` | Same dialogue feel; **never writes**. Use it when there is no artifact intent. |
-| `/briesearch` | External evidence dispatcher. `/mold` calls it through the Validate Cycle. |
+| `/briesearch` | Evidence dispatcher. `/mold` calls it through the Validate Cycle; it scans prior project research before external sources. |
 | `/nih-audit` | Whole-repo build-vs-buy sweep. `/mold` calls it from Sketch when multiple library-shaped categories are in play, or offers it at Curdle for migration-style specs. |
 | `/cook` | Implements a curdled spec. `/mold` ends with a hand-off offer, never an auto-invoke. |
 
@@ -63,7 +63,7 @@ dialogue actually produced — never more, never less.
 | Input shape | Start mode | Heuristic |
 | --- | --- | --- |
 | Stack trace, "X is broken/slow/flaky" | Diagnose | error markers, `file:line` refs, symptom verbs |
-| File path, PR ref, existing spec under `.cheese/specs/` | Ground | concrete artifact exists; read it first |
+| File path, PR ref, existing spec under canonical `.cheese/specs/` | Ground | concrete artifact exists; read it first |
 | Half-baked design doc with signatures or schemas | Sketch | already has interfaces; refine them |
 | "I want to add X" with concrete nouns | Shape | named the thing → jump to options |
 | "Should we do X? thinking about Y" | Grill | tentative plan exists → stress-test it |
@@ -285,6 +285,11 @@ Output paths (relative to the project root):
 | Issues only | `.cheese/issues/<slug>-001.md`, `-002.md`, ... |
 | Spec + Issues | spec at `.cheese/specs/<slug>.md`; issues at `.cheese/issues/<slug>-001.md`, ... |
 
+Resolve "project root" with `references/canonical-cheese.md`: specs and
+issues are durable knowledge artifacts, so linked worktrees write them to the
+canonical main worktree's `.cheese/` unless the user explicitly gives another
+path.
+
 Slug derivation: lowercase the working problem statement, drop stopwords,
 kebab-case, cap at 5 words. Honour user-passed slugs verbatim.
 
@@ -309,7 +314,7 @@ After writing, offer the next step inline. Never auto-invoke.
 
 | Artifact | Suggested next step |
 | --- | --- |
-| Spec | `/cook .cheese/specs/<slug>.md` |
+| Spec | `/cook <canonical-project-root>/.cheese/specs/<slug>.md` |
 | Migration-shaped spec (≥1 NIH probe verdict of `accept` or `revise`) | `/nih-audit <scope>` first, then `/cook` |
 | Issues | `gh issue create --body-file <path>` (per file) |
 

--- a/skills/mold/references/issue.md
+++ b/skills/mold/references/issue.md
@@ -150,9 +150,9 @@ offers:
 
 ```
 Filed:
-  - .cheese/specs/<slug>.md       (1 spec)
-  - .cheese/issues/<slug>-001.md  (1 issue)
-  - .cheese/issues/<slug>-002.md  (1 issue)
+  - <canonical-project-root>/.cheese/specs/<slug>.md       (1 spec)
+  - <canonical-project-root>/.cheese/issues/<slug>-001.md  (1 issue)
+  - <canonical-project-root>/.cheese/issues/<slug>-002.md  (1 issue)
 
 File these as GitHub issues now? (y/N)
 ```

--- a/skills/mold/references/routing.md
+++ b/skills/mold/references/routing.md
@@ -15,7 +15,7 @@ Walk the heuristics top-down. The **first** match wins.
 2. **Ground** — the input is, or points at, a concrete artifact:
    - File path that exists in the repo, OR
    - PR or issue reference (URL, `#1234`), OR
-   - A spec path under the active harness root, OR
+   - A spec path under canonical `.cheese/specs/`, OR
    - "Read X and tell me ..." style requests.
 3. **Sketch** — the input contains existing structure to refine:
    - Fenced code blocks containing function signatures or schemas, OR
@@ -50,7 +50,7 @@ considered, and explicitly invite a knob redirect.
 | Input | Mode | Reason |
 | --- | --- | --- |
 | `TypeError: cannot read property 'foo' of undefined at app.ts:142` | Diagnose | error keyword + file:line |
-| `.cheese/specs/dark-mode.md` | Ground | spec path; read first |
+| `.cheese/specs/dark-mode.md` | Ground | canonical spec path; read first |
 | `def dispatch(...): ... # what should the return type be?` | Sketch | existing signature with question |
 | `I want to add idempotency to the dispatcher` | Shape | concrete noun, additive verb |
 | `Should we extract the dedup layer into its own slice?` | Grill | tentative verb on a plan |

--- a/skills/mold/references/sketch-mode.md
+++ b/skills/mold/references/sketch-mode.md
@@ -135,7 +135,7 @@ Launching a validate cycle on hypothesis:
 
 Plan:
   cheez-search — confirm we don't already depend on X (depManifest check).
-  /research    — fetch the canonical library for this category in <language>;
+  /briesearch  — fetch the canonical library for this category in <language>;
                  prefer stdlib answers; capture downloads + licence + maintenance.
   Judge        — does the library cover the contract we're about to sketch?
   Settle       — accept (use library, drop sketch), revise (sketch wraps lib),
@@ -143,7 +143,7 @@ Plan:
 ```
 
 Cap: at most **one** NIH probe per Sketch session (in addition to the
-shared 2-`/research` budget). Use the probe only for library-shaped
+shared 2-`/briesearch` budget). Use the probe only for library-shaped
 categories — pure business-domain signatures (an Order, a Pricing rule)
 do not need it.
 

--- a/skills/mold/references/spec.md
+++ b/skills/mold/references/spec.md
@@ -256,7 +256,9 @@ silent overwrite.
 
 ## Atomic write
 
-Stage to `.cheese/.mold-staging-<run_id>/` (a sibling of the destination,
-guaranteed same filesystem) and `mv` into place. This ensures `mv` is an
+Resolve the canonical project `.cheese/` location using
+`references/canonical-cheese.md`. Stage to
+`.cheese/.mold-staging-<run_id>/` as a sibling of the destination,
+guaranteed same filesystem, and `mv` into place. This ensures `mv` is an
 atomic rename rather than a cross-filesystem copy+delete. On failure, the
 staging directory is removed and no partial files exist in `.cheese/`.

--- a/skills/mold/references/state-schema.md
+++ b/skills/mold/references/state-schema.md
@@ -1,7 +1,8 @@
 # State file schema
 
-`/mold` keeps one scratch state file per run. The path mirrors `/briesearch`'s
-scratch convention so cleanup is predictable.
+`/mold` keeps one scratch state file per run. This mirrors `/briesearch`'s
+temporary fetcher scratch convention, not `/briesearch`'s persistent
+canonical `.cheese/research` report store.
 
 ## Path
 
@@ -127,4 +128,3 @@ Explore (1-3) → Ground (4-5) → Shape (6-8) → [validate cycle 1] → Sketch
 - **Cleanup** — after a successful Curdle *and* the user accepts the
   hand-off offer, the run directory is removed. Otherwise it stays for the
   OS to evict.
-

--- a/skills/mold/references/validate-cycle.md
+++ b/skills/mold/references/validate-cycle.md
@@ -9,7 +9,8 @@ come back" patterns.
 
 1. **State the hypothesis.** Single declarative sentence. Falsifiable. The
    anchor for the rest of the cycle.
-2. **Dispatch evidence.** Usually `/briesearch`. Sometimes `cheez-search`
+2. **Dispatch evidence.** Usually `/briesearch`, which scans the project
+   research knowledge base before external sources. Sometimes `cheez-search`
    or `cheez-read` is enough. Sometimes both run in parallel.
 3. **Judge.** Three outcomes — **SUPPORTED**, **CONTRADICTED**, **REFINED**.
 4. **Settle.** Continue from the mode that invoked the cycle. The mode
@@ -56,7 +57,8 @@ or accept the refined form.
 
 ## Validate Cycle vs. bare `/briesearch`
 
-A bare `/briesearch` is a research dispatch. The Validate Cycle adds:
+A bare `/briesearch` is a research dispatch with prior `.cheese/research`
+context and freshness checks. The Validate Cycle adds:
 
 - The **stated hypothesis** (commitment to an assertion).
 - The **judgment step** (verdict tag, not just a summary).

--- a/skills/nih-audit/SKILL.md
+++ b/skills/nih-audit/SKILL.md
@@ -2,7 +2,7 @@
 name: nih-audit
 description: Scan a codebase for custom code that duplicates what open-source libraries already do, then recommend which libraries to adopt. Detects hand-rolled utility functions, custom retry logic, manual validation, DIY date handling, home-grown argument parsers, and other reinvented wheels. Cross-checks against installed dependencies and open specs. Returns scored migration recommendations with effort estimates. Use when the user mentions reinventing the wheel, asks if there is a library for something they built, wants a build-vs-buy audit, asks "should we just use lodash for this", or wants to find dependency opportunities.
 license: MIT
-compatibility: Requires tilth MCP for AST-aware search. Library discovery delegates to /research; if /research is unavailable, the audit reports candidates without library recommendations.
+compatibility: Requires tilth MCP for AST-aware search. Library discovery delegates to /briesearch; if /briesearch is unavailable, the audit reports candidates without library recommendations.
 metadata:
   owner: cheese-flow
   category: review
@@ -67,21 +67,21 @@ The scanner returns a JSON candidate list inline plus a one-paragraph
 summary. Parse the candidates from the response. If 0 candidates, report
 clean and stop.
 
-## Phase 2 — Library discovery (parallel, /research)
+## Phase 2 — Library discovery (parallel, /briesearch)
 
 Group candidates by `category` (RETRY, UUID, VALIDATION, DATE, DEBOUNCE,
 CLONE, ARGPARSE, STRING, HTTP, SERIALIZATION, ERROR, CRYPTO, SECURITY,
 FORMAT, COMPARE).
 
-For each category, dispatch `/research` with a focused question shape:
+For each category, dispatch `/briesearch` with a focused question shape:
 
 ```
-/research "best <category> library for <language>; must be MIT/Apache/BSD;
+/briesearch "best <category> library for <language>; must be MIT/Apache/BSD;
 list weekly downloads or crates.io downloads, GitHub stars, last commit
 date, contributor count; flag if functionality is in the standard library"
 ```
 
-Cap: max 5 parallel research dispatches. If `/research` is unavailable,
+Cap: max 5 parallel research dispatches. If `/briesearch` is unavailable,
 emit candidates with `recommendation: null` and a note.
 
 For each library returned, capture:

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -28,11 +28,14 @@ Run the orchestration inline, but keep raw evidence out of the main context:
 
 1. Route sources once and state the committed routing decision.
 2. Spawn fetchers in parallel where the harness supports it.
-3. Have fetchers write findings to scratch files under `$TMPDIR`.
-4. Have one synthesis sub-agent read those scratch files and return the final
+3. Resolve the canonical project `.cheese` root, then spawn knowledge-base
+   scanner sub-agents against `<canonical-project-root>/.cheese/research`.
+4. Have fetchers write findings to scratch files under `$TMPDIR`.
+5. Have one synthesis sub-agent read those scratch files and return the final
    answer.
-5. Write the full report to `.cheese/research/<slugified-topic>.md`.
-6. Delete the scratch directory after the report is written.
+6. Write the full report to
+   `<canonical-project-root>/.cheese/research/<slugified-topic>.md`.
+7. Delete the scratch directory after the report is written.
 
 The caller should see only the routing decision, fetcher status, synthesis,
 and the report path.
@@ -52,6 +55,108 @@ mkdir -p "$RUN_DIR"
 
 Use a 4-6 word kebab-case slug derived from the topic.
 
+## Canonical `.cheese` Resolution
+
+Research reports are durable project knowledge. Do not strand them in a
+throwaway linked worktree's `.cheese/`.
+
+Resolve the canonical project root before reading or writing research:
+
+```bash
+ACTIVE_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+CANONICAL_ROOT="$(
+  git -C "$ACTIVE_ROOT" worktree list --porcelain 2>/dev/null \
+    | awk 'BEGIN { RS=""; FS="\n" } NR == 1 { sub(/^worktree /, "", $1); print $1 }'
+)"
+CANONICAL_ROOT="${CANONICAL_ROOT:-$ACTIVE_ROOT}"
+CHEESE_ROOT="$CANONICAL_ROOT/.cheese"
+RESEARCH_DIR="$CHEESE_ROOT/research"
+mkdir -p "$RESEARCH_DIR"
+```
+
+In a normal checkout, `CANONICAL_ROOT` and `ACTIVE_ROOT` are the same. In a
+Conductor or Git linked worktree, `CANONICAL_ROOT` is the main worktree path.
+
+When a user explicitly provides another output path, honor it. Otherwise all
+research reports go under `$RESEARCH_DIR`.
+
+## Persistent Report Frontmatter
+
+Every report written to `.cheese/research/` must start with YAML frontmatter:
+
+```yaml
+---
+title: "<human title>"
+slug: "<kebab-case-slug>"
+question: "<original user question>"
+created_at: "YYYY-MM-DDTHH:mm:ssZ"
+updated_at: "YYYY-MM-DDTHH:mm:ssZ"
+last_validated_at: "YYYY-MM-DDTHH:mm:ssZ"
+status: "active"
+confidence: 0
+freshness:
+  status: "fresh"
+  source_volatility: "low"
+  half_life_days: 180
+  next_review_at: "YYYY-MM-DDTHH:mm:ssZ"
+  revalidation_reason: ""
+relevance:
+  status: "direct"
+  score: 100
+  matched_terms: []
+tags: []
+sources: []
+related: []
+---
+```
+
+Allowed values:
+
+- `status`: `draft`, `active`, `superseded`, `archived`.
+- `freshness.status`: `fresh`, `stale`, `needs_revalidation`,
+  `unverified`.
+- `freshness.source_volatility`: `low`, `medium`, `high`.
+- `relevance.status`: `direct`, `partial`, `background`, `unrelated`.
+
+When updating an existing report, preserve `created_at`, set `updated_at` and
+`last_validated_at` to the current time, and append any superseded report paths
+to `related`.
+
+## Freshness and Relevance Algorithm
+
+The knowledge-base scan is advisory, but it must judge whether prior research
+can be reused.
+
+For each candidate report:
+
+1. Parse frontmatter. If missing, treat it as `unverified`.
+2. Compute relevance:
+   - `direct` (90-100): same decision, library, API, architecture, or spec.
+   - `partial` (60-89): same domain but different question.
+   - `background` (30-59): useful context only.
+   - `unrelated` (0-29): ignore for synthesis.
+3. Compute volatility:
+   - `high`: model docs, vendor APIs, prices, laws, schedules, benchmarks,
+     package versions, security posture, product features.
+   - `medium`: framework guidance, library usage, current OSS maintenance,
+     local code architecture.
+   - `low`: durable architecture principles, historical explanations,
+     internal decisions that have not been reversed.
+4. Assign freshness half-life:
+   - high: 14 days.
+   - medium: 45 days.
+   - low: 180 days.
+5. Mark `needs_revalidation` when any is true:
+   - age since `last_validated_at` exceeds half-life,
+   - report has no frontmatter or no sources,
+   - relevant local file refs changed since the report date,
+   - cited vendor/library/model docs are likely current-sensitive,
+   - confidence is below 70,
+   - current routed sources contradict the prior report.
+
+Use judgment. A stale but still relevant report can guide search queries, but it
+cannot be the sole evidence for current facts.
+
 ## Phase 1: Classify
 
 Identify:
@@ -60,6 +165,44 @@ Identify:
 - Question type: factual lookup, how-to, comparison, pattern search, API usage
 - Complexity: simple fact, focused question, comparison, or deep analysis
 - Constraints: version, language, framework, performance, license, architecture
+
+## Phase 1.5: Knowledge-Base Scan
+
+Always inspect existing research before external fetching.
+
+Spawn knowledge-base scanner sub-agents against `$RESEARCH_DIR`:
+
+- If the directory is empty, write `<RUN_DIR>/knowledge-base.md` with
+  `Status: unavailable` and reason `no existing research`.
+- If there are 1-20 reports, spawn one scanner.
+- If there are more than 20 reports, spawn up to three scanners sharded by
+  filename or topic. Each scanner writes one scratch file; the synthesis agent
+  reads all completed shard files.
+
+Scanner prompt shape:
+
+```text
+You are scanning the project research knowledge base.
+
+Question: <question>
+Research dir: <RESEARCH_DIR>
+
+Steps:
+1. Read filenames and YAML frontmatter first.
+2. Rank candidate reports by relevance to the question.
+3. For direct or partial matches, read the body enough to extract the prior
+   finding, sources, confidence, freshness status, and revalidation needs.
+4. Apply the freshness and relevance algorithm from the research skill.
+5. Write findings to <RUN_DIR>/knowledge-base-<shard>.md using the scratch
+   schema plus a "Revalidation" section.
+6. Return only: done: <RUN_DIR>/knowledge-base-<shard>.md
+
+Do not browse the web. Do not edit reports. Do not treat stale reports as
+current evidence.
+```
+
+An empty knowledge base does not cap confidence. A relevant but stale or
+contradicted report should lower confidence until revalidated.
 
 ## Phase 2: Route Sources
 
@@ -90,6 +233,7 @@ Source guide:
 | Tavily | Current facts, technical articles, vendor docs, best practices | Use basic for factual lookups, advanced for analysis. |
 | Codebase | Local conventions, existing usage, constraints | Use repository search and reads. |
 | GitHub | Real-world OSS usage patterns | Use `gh` or the harness GitHub integration. |
+| Knowledge Base | Prior `.cheese/research` reports and specs | Always scan before external fetches; revalidate stale direct matches. |
 
 Emit a compact routing block:
 
@@ -99,6 +243,7 @@ ROUTING DECISION:
 - Tavily: YES (query: "<natural-language question>", depth: basic|advanced)
 - Codebase: NO (external-only question)
 - GitHub: NO (not looking for OSS usage patterns)
+- Knowledge Base: YES (always scan project-root .cheese/research)
 ```
 
 ## Phase 3: Execute Fetchers
@@ -196,6 +341,15 @@ Write findings to <RUN_DIR>/codebase.md and return only:
 done: <RUN_DIR>/codebase.md
 ```
 
+### Knowledge-Base Fetcher
+
+The knowledge-base scan runs in Phase 1.5 before source routing completes. If it
+found direct or partial matches, include them as a committed Phase 3 source and
+use the findings to shape external queries.
+
+Do not use prior research as current evidence unless freshness is `fresh` or the
+current run revalidates its load-bearing claims.
+
 ### GitHub Fetcher
 
 Use GitHub for real-world open-source patterns.
@@ -225,8 +379,10 @@ Synthesis task:
 1. Build one evidence row per routed source:
    `Source | Finding | Score | Notes`.
 2. Apply the mechanical confidence cap:
-   - Any unavailable, failed, skipped, or not-spawned source caps overall
-     confidence at 49.
+   - Any unavailable, failed, skipped, or not-spawned committed source caps
+     overall confidence at 49.
+   - Exception: an empty knowledge base with no prior reports does not cap
+     confidence; it is absence of prior evidence, not a failed source.
    - 3+ agreeing sources: 85-100.
    - 2 agreeing sources: 60-84.
    - Disagreement: cap at 49 and explain why.
@@ -252,9 +408,9 @@ Synthesis task:
 ```
 
 After the synthesis block, append a fenced `report-body` block containing a
-full markdown report with source URLs, file refs, and repo links. The
-orchestration layer writes that report body verbatim to
-`.cheese/research/<slug>.md`.
+full markdown report with YAML frontmatter, source URLs, file refs, and repo
+links. The orchestration layer writes that report body verbatim to
+`<canonical-project-root>/.cheese/research/<slug>.md`.
 
 ## Cleanup
 

--- a/tests/compiler-commands.test.ts
+++ b/tests/compiler-commands.test.ts
@@ -146,4 +146,17 @@ describe("shipped command scaffolds", () => {
       expect([...manifest.commands].sort()).toEqual(expected);
     }
   });
+
+  it("documents the briesearch knowledge-base and frontmatter contract", async () => {
+    const source = await readFile(
+      path.resolve("commands/briesearch.md"),
+      "utf8",
+    );
+
+    expect(source).toContain("canonical");
+    expect(source).toContain("project `.cheese/research`");
+    expect(source).toContain("scanner sub-agents");
+    expect(source).toContain("created_at");
+    expect(source).toContain("updated_at");
+  });
 });


### PR DESCRIPTION
Teaches /briesearch to resolve the canonical project .cheese directory, scan existing .cheese/research via sub-agent guidance, and write reports with created/updated/freshness frontmatter. Aligns /mold durable specs/issues and /nih-audit library discovery with that canonical research flow. Adds a canonical .cheese reference doc plus command coverage for the briesearch contract. Validation: `just test -t briesearch`; `just build`.
