### PR TITLE
fix(claude-code): make plugin install + load against current Claude Code

### DIFF
--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -1,8 +1,12 @@
-import type { HarnessAdapter } from "../domain/harness.js";
+import type {
+  HarnessAdapter,
+  HookEntry,
+  PortableHooks,
+} from "../domain/harness.js";
 import {
   buildBaseAgentArtifact,
   buildBaseManifest,
-  camelCaseHooks,
+  pascalMatcherHooks,
 } from "./_shared.js";
 
 const CLAUDE_AGENT_KEYS: ReadonlySet<string> = new Set([
@@ -14,12 +18,43 @@ const CLAUDE_AGENT_KEYS: ReadonlySet<string> = new Set([
 ]);
 
 const CLAUDE_MANIFEST_KEYS = [
-  "agents",
+  // "agents" intentionally omitted — Claude Code's plugin manifest validator
+  // rejects this key (see issue #58). Files under the bundle's default
+  // `./agents/` directory are auto-discovered at startup, so the conventional
+  // layout cheese-flow uses still works without it. Re-add when upstream
+  // accepts the field again.
   "skills",
   "commands",
   "hooks",
   "mcpServers",
 ] as const;
+
+// Hook command paths must resolve from the installed plugin root in Claude
+// Code, not the user's working directory. The portable `hooks.json` source
+// uses `bash hooks/cheese-bootstrap.sh`; rewrite that to reference
+// `${CLAUDE_PLUGIN_ROOT}` so the script is found wherever Claude Code installs
+// the plugin. Other commands pass through unchanged.
+const BOOTSTRAP_RELATIVE_PATH = "hooks/cheese-bootstrap.sh";
+
+function rewriteBootstrapCommand(entry: HookEntry): HookEntry {
+  if (!entry.command.includes(BOOTSTRAP_RELATIVE_PATH)) return entry;
+  return {
+    ...entry,
+    command: entry.command.replace(
+      BOOTSTRAP_RELATIVE_PATH,
+      `\${CLAUDE_PLUGIN_ROOT}/${BOOTSTRAP_RELATIVE_PATH}`,
+    ),
+  };
+}
+
+function rewriteBootstrapPaths(portable: PortableHooks): PortableHooks {
+  const result: PortableHooks = {};
+  for (const [event, entries] of Object.entries(portable)) {
+    if (entries === undefined) continue;
+    result[event as keyof PortableHooks] = entries.map(rewriteBootstrapCommand);
+  }
+  return result;
+}
 
 export const claudeCodeAdapter: HarnessAdapter = {
   name: "claude-code",
@@ -37,7 +72,9 @@ export const claudeCodeAdapter: HarnessAdapter = {
   buildManifest: (metadata, componentPaths) =>
     buildBaseManifest(metadata, componentPaths, CLAUDE_MANIFEST_KEYS),
   mcpFileName: ".mcp.json",
-  buildHookConfig: (portable) => ({ hooks: camelCaseHooks(portable) }),
+  buildHookConfig: (portable) => ({
+    hooks: pascalMatcherHooks(rewriteBootstrapPaths(portable)),
+  }),
   buildAgentArtifact: (input) =>
     buildBaseAgentArtifact(input, CLAUDE_AGENT_KEYS),
   capabilities: {

--- a/src/lib/compiler.ts
+++ b/src/lib/compiler.ts
@@ -1,5 +1,13 @@
 import type { Dirent } from "node:fs";
-import { cp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  cp,
+  mkdir,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 import { Eta } from "eta";
 import { stringify as stringifyYaml } from "yaml";
@@ -180,6 +188,13 @@ async function cleanGeneratedArtifacts(
     generatedFiles.push("hooks.json");
   }
 
+  // Bootstrap-hook harnesses also receive a `hooks/` directory containing the
+  // bootstrap script copy. Clean it so re-compiles don't accumulate stale
+  // copies if the source script is renamed or removed.
+  if (adapter.capabilities.bootstrapHook) {
+    generatedDirectories.push("hooks");
+  }
+
   await Promise.all([
     ...generatedDirectories.map((entry) =>
       rm(path.join(outputRoot, entry), { recursive: true, force: true }),
@@ -188,6 +203,28 @@ async function cleanGeneratedArtifacts(
       rm(path.join(outputRoot, entry), { force: true }),
     ),
   ]);
+}
+
+// Bootstrap-hook harnesses (Claude Code, Codex, Copilot CLI) reference
+// `hooks/cheese-bootstrap.sh` from their emitted hooks.json. The source script
+// lives at the project root in `hooks/cheese-bootstrap.sh`; copy it into the
+// bundle so the install surface is self-contained. Without this, the hook
+// runner can't find the script after the plugin is installed.
+async function copyBootstrapScript(
+  projectRoot: string,
+  outputRoot: string,
+): Promise<void> {
+  const sourcePath = path.join(projectRoot, "hooks", "cheese-bootstrap.sh");
+  try {
+    await stat(sourcePath);
+  } catch (error) {
+    if (isFileNotFound(error)) return;
+    throw error;
+  }
+  const targetDir = path.join(outputRoot, "hooks");
+  const targetPath = path.join(targetDir, "cheese-bootstrap.sh");
+  await mkdir(targetDir, { recursive: true });
+  await cp(sourcePath, targetPath, { preserveTimestamps: true });
 }
 
 function manifestDirectoryPath(relativePath: string): string {
@@ -294,6 +331,9 @@ async function compileHarnessBundleFromSession(
   );
   await emitMcpConfig(context.harnessName, outputRoot);
   await emitHooks(context.harnessName, context.hooksSource, outputRoot);
+  if (adapter.capabilities.bootstrapHook) {
+    await copyBootstrapScript(context.projectRoot, outputRoot);
+  }
 
   return {
     harness: context.harnessName,

--- a/tests/adversarial.test.ts
+++ b/tests/adversarial.test.ts
@@ -324,8 +324,9 @@ describe("emitHooks — chaos", () => {
     const content = await readFile(result as string, "utf8");
     const config = JSON.parse(content);
 
-    // Empty array is still a valid entry — should be present
-    expect(config.hooks.sessionStart).toBeDefined();
+    // Empty array is still a valid entry — should be present (Claude Code
+    // emits PascalCase event names; see issue #57).
+    expect(config.hooks.SessionStart).toBeDefined();
   });
 
   it("codex: entry with explicit timeout preserves it (not overridden by default)", async () => {
@@ -404,7 +405,8 @@ describe("emitHooks — chaos", () => {
     const content = await readFile(result as string, "utf8");
     const config = JSON.parse(content);
 
-    expect(config.hooks.sessionStart[0].command).toBe(longCommand);
+    // Claude Code wraps each entry in `{ matcher, hooks: [...] }`; see #57.
+    expect(config.hooks.SessionStart[0].hooks[0].command).toBe(longCommand);
   });
 });
 

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -102,7 +102,9 @@ describe("compileHarnessBundles", () => {
       mcpServers?: string;
     };
     expect(claudePlugin.name).toBe("cheese-flow");
-    expect(claudePlugin.agents).toBe("./agents/");
+    // Claude Code's plugin manifest validator rejects the `agents` key (see
+    // issue #58); rely on the default `./agents/` auto-discovery instead.
+    expect(claudePlugin.agents).toBeUndefined();
     expect(claudePlugin.skills).toBe("./skills/");
     expect(claudePlugin.commands).toBeUndefined();
     expect(claudePlugin.hooks).toBe("./hooks.json");
@@ -141,6 +143,58 @@ describe("compileHarnessBundles", () => {
     ) as { mcpServers: Record<string, unknown> };
     expect(codexMcp.mcpServers).toHaveProperty("tilth");
     expect(codexMcp.mcpServers).toHaveProperty("context7");
+  });
+
+  it("copies hooks/cheese-bootstrap.sh into the bundle for bootstrapHook harnesses", async () => {
+    // Regression test for issue #57: the emitted hooks.json references
+    // `${CLAUDE_PLUGIN_ROOT}/hooks/cheese-bootstrap.sh` (Claude Code) or the
+    // bare `hooks/cheese-bootstrap.sh` path (Codex/Copilot CLI), so the script
+    // must accompany the bundle on disk for the hook runner to find it.
+    const projectRoot = await mkdtemp(
+      path.join(os.tmpdir(), "cheese-flow-bootstrap-"),
+    );
+    createdDirectories.push(projectRoot);
+    await cp(path.resolve("agents"), path.join(projectRoot, "agents"), {
+      recursive: true,
+    });
+    await cp(path.resolve("skills"), path.join(projectRoot, "skills"), {
+      recursive: true,
+    });
+    await cp(path.resolve("hooks"), path.join(projectRoot, "hooks"), {
+      recursive: true,
+    });
+    await cp(path.resolve("hooks.json"), path.join(projectRoot, "hooks.json"));
+
+    await compileHarnessBundles({
+      projectRoot,
+      harnesses: ["claude-code", "codex", "copilot-cli"],
+    });
+
+    for (const bundle of [".claude", ".codex", ".copilot"]) {
+      const bootstrapPath = path.join(
+        projectRoot,
+        bundle,
+        "hooks",
+        "cheese-bootstrap.sh",
+      );
+      expect(
+        await pathExists(bootstrapPath),
+        `${bundle}/hooks/cheese-bootstrap.sh should exist`,
+      ).toBe(true);
+
+      const bundleHooks = JSON.parse(
+        await readFile(path.join(projectRoot, bundle, "hooks.json"), "utf8"),
+      ) as { hooks: Record<string, unknown> };
+
+      // The Claude Code bundle uses a literal hook-runner placeholder
+      // ({CLAUDE_PLUGIN_ROOT}); others reference the script path verbatim.
+      const flat = JSON.stringify(bundleHooks);
+      expect(flat).toContain("cheese-bootstrap.sh");
+      if (bundle === ".claude") {
+        const claudeRunRoot = "$" + "{CLAUDE_PLUGIN_ROOT}";
+        expect(flat).toContain(claudeRunRoot);
+      }
+    }
   });
 
   it("compiles a single harness bundle and returns its metadata", async () => {
@@ -580,12 +634,14 @@ describe("compileHarnessBundles", () => {
       harnesses: ["claude-code", "codex"],
     });
 
-    // claude-code: camelCase hooks
+    // claude-code: PascalCase + matcher wrapper (matches Claude Code's
+    // hooks.json schema; see issue #57)
     const claudeHooks = JSON.parse(
       await readFile(path.join(projectRoot, ".claude", "hooks.json"), "utf8"),
     ) as { hooks: Record<string, unknown> };
-    expect(claudeHooks.hooks).toHaveProperty("preToolUse");
-    expect(claudeHooks.hooks).toHaveProperty("postToolUse");
+    expect(claudeHooks.hooks).toHaveProperty("PreToolUse");
+    expect(claudeHooks.hooks).toHaveProperty("PostToolUse");
+    expect(claudeHooks.hooks).not.toHaveProperty("preToolUse");
 
     // codex: PascalCase hooks with matcher wrapper
     const codexHooks = JSON.parse(

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -30,7 +30,11 @@ describe("emitHooks", () => {
     expect(result).toBe(false);
   });
 
-  it("emits hooks.json with camelCase keys for claude-code", async () => {
+  it("emits hooks.json with PascalCase matcher-wrapped keys for claude-code", async () => {
+    // Claude Code's hooks.json schema requires PascalCase event names
+    // (SessionStart, PreToolUse, ...) and entries wrapped in matcher objects:
+    //   [{ matcher: "*", hooks: [{ type, command, timeout }] }]
+    // See issue #57.
     const outputRoot = await mkdtemp(path.join(os.tmpdir(), "cheese-flow-"));
     createdDirectories.push(outputRoot);
 
@@ -45,8 +49,12 @@ describe("emitHooks", () => {
     const content = await readFile(hooksPath, "utf8");
     const config = JSON.parse(content);
 
-    expect(config.hooks.sessionStart).toBeDefined();
-    expect(config.hooks.preToolUse).toBeDefined();
+    expect(config.hooks.SessionStart).toBeDefined();
+    expect(config.hooks.PreToolUse).toBeDefined();
+    expect(config.hooks.sessionStart).toBeUndefined();
+    expect(config.hooks.SessionStart[0].matcher).toBe("*");
+    expect(config.hooks.SessionStart[0].hooks[0].command).toBe("echo start");
+    expect(config.hooks.SessionStart[0].hooks[0].timeout).toBe(600);
   });
 
   it("emits hooks with PascalCase keys for codex", async () => {
@@ -103,8 +111,8 @@ describe("emitHooks", () => {
     const content = await readFile(hooksPath, "utf8");
     const config = JSON.parse(content);
 
-    expect(config.hooks.sessionStart).toBeDefined();
-    expect(config.hooks.preToolUse).toBeUndefined();
+    expect(config.hooks.SessionStart).toBeDefined();
+    expect(config.hooks.PreToolUse).toBeUndefined();
   });
 
   it("emits sessionStart bootstrap entry for every bootstrapHook=true harness", async () => {
@@ -152,12 +160,23 @@ describe("emitHooks", () => {
     const claudeConfig = JSON.parse(
       await readFile(path.join(claudeRoot, "hooks.json"), "utf8"),
     ) as {
-      hooks: { sessionStart: Array<{ type: string; command: string }> };
+      hooks: {
+        SessionStart: Array<{
+          matcher: string;
+          hooks: Array<{ type: string; command: string; timeout: number }>;
+        }>;
+      };
     };
-    expect(claudeConfig.hooks.sessionStart).toHaveLength(1);
-    expect(claudeConfig.hooks.sessionStart[0]?.type).toBe("command");
-    expect(claudeConfig.hooks.sessionStart[0]?.command).toBe(
-      "bash hooks/cheese-bootstrap.sh",
+    expect(claudeConfig.hooks.SessionStart).toHaveLength(1);
+    expect(claudeConfig.hooks.SessionStart[0]?.matcher).toBe("*");
+    expect(claudeConfig.hooks.SessionStart[0]?.hooks[0]?.type).toBe("command");
+    // Claude Code resolves bootstrap paths via the literal hook-runner
+    // placeholder (not a JS template) so the script is found regardless of
+    // the user's working directory. Constructed via concat to avoid a Biome
+    // false positive on `${...}` inside a string literal.
+    const claudeRunRoot = "$" + "{CLAUDE_PLUGIN_ROOT}";
+    expect(claudeConfig.hooks.SessionStart[0]?.hooks[0]?.command).toBe(
+      `bash ${claudeRunRoot}/hooks/cheese-bootstrap.sh`,
     );
 
     const codexRoot = await mkdtemp(path.join(os.tmpdir(), "cheese-flow-"));
@@ -285,7 +304,8 @@ describe("emitHooks", () => {
     const content = await readFile(hooksPath, "utf8");
     const config = JSON.parse(content);
 
-    expect(config.hooks.sessionStart).toBeDefined();
+    expect(config.hooks.SessionStart).toBeDefined();
     expect(config.hooks.sessionEnd).toBeUndefined();
+    expect(config.hooks.SessionEnd).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

The Claude Code adapter currently emits a bundle that `claude plugin install` rejects on Claude Code 2.1.131, and even when patched past install, the plugin fails to load because of hook-format and missing-script issues. This PR addresses both.

Closes #57, closes #58.

### What changes

- **Drop `agents` from the Claude Code plugin manifest.** Claude Code's validator rejects the field outright (`agents: Invalid input`) regardless of value (string, array, default path, custom path all rejected). Files under the bundle's default `./agents/` are auto-discovered at startup, so the conventional layout cheese-flow already uses works without it. Anthropic's own `superpowers@5.1.0` plugin's `.claude-plugin/plugin.json` ships without `agents`/`skills`/`commands` for the same reason, while its `.cursor-plugin/plugin.json` cousin does include them.
- **Switch Claude Code hook emission from `camelCaseHooks` to `pascalMatcherHooks`.** Claude Code's hooks.json schema requires PascalCase event names (`SessionStart`, `PreToolUse`, ...) with each entry wrapped in `{ matcher, hooks: [...] }` — matching the format the codex adapter already uses and the `openai-codex@1.0.4` reference plugin emits.
- **Rewrite the bootstrap command path.** The portable hook source uses `bash hooks/cheese-bootstrap.sh`; for Claude Code that gets rewritten to `bash ${CLAUDE_PLUGIN_ROOT}/hooks/cheese-bootstrap.sh` so the hook runner finds the script regardless of the user's working directory. Other harness adapters keep the bare path.
- **Copy the bootstrap script into every bootstrapHook bundle.** Previously the script lived only at the repo root in `hooks/cheese-bootstrap.sh` and was never bundled, so even the codex/copilot-cli bundles referenced a script that wasn't on disk. The compiler now copies it into `<bundle>/hooks/cheese-bootstrap.sh` whenever the adapter has `bootstrapHook: true`, and `cleanGeneratedArtifacts` removes the `hooks/` directory on re-compile.

### Tests

- `tests/hooks.test.ts`: existing assertions that encoded the buggy camelCase-no-matcher format for Claude Code now assert the corrected PascalCase + matcher shape, including the rewritten `${CLAUDE_PLUGIN_ROOT}` bootstrap command.
- `tests/compiler.test.ts`: existing assertion that `claude-plugin/plugin.json` contained `agents: \"./agents/\"` flipped to `agents: undefined`. New test verifies the bootstrap script gets copied into all three bootstrapHook bundles.
- `tests/adversarial.test.ts`: two Claude Code chaos tests updated to read from the corrected output shape.
- All 353 tests pass; lint and typecheck clean.

### End-to-end verification

```bash
npm install && npm run build && npm run install:auto
claude plugin marketplace add ./.claude
claude plugin install cheese-flow@cheese-flow-local
claude plugin list
# ❯ cheese-flow@cheese-flow-local
#   Version: 0.1.0
#   Status: ✔ enabled
```

### Notes / out of scope

- The codex and copilot-cli adapters also have `bootstrapHook: true` but emit bare-path commands (no harness-specific runner placeholder). Their bundles now contain the bootstrap script, but whether each runner needs a `${...}_PLUGIN_ROOT`-style prefix is a separate question — happy to extend if maintainers prefer a single PR. The current change is conservative: only Claude Code's command is rewritten.
- Trailing slashes in manifest paths (`./skills/` vs `./skills`) are unchanged. They were initially suspected as the cause of the `agents` rejection but tested fine; left alone to keep the diff focused.

### Environment

- Claude Code 2.1.131 (macOS arm64)
- Node v22.19.0
- cheese-flow @ 35908ac (main, 2026-05-03)