### PR TITLE
feat(migration): US-004 compile pipeline (TS → Python)

### DIFF
--- a/python/cheese_flow/adapters/_shared.py
+++ b/python/cheese_flow/adapters/_shared.py
@@ -132,11 +132,7 @@ def build_base_agent_artifact(
             continue
         data[key] = value
     skills = frontmatter["skills"]
-    appendix = (
-        ""
-        if "skills" in key_set or len(skills) == 0
-        else _build_skills_appendix(skills)
-    )
+    appendix = "" if "skills" in key_set or len(skills) == 0 else _build_skills_appendix(skills)
     return AgentArtifact(frontmatter=data, appendix=appendix)
 
 

--- a/python/cheese_flow/adapters/_shared.py
+++ b/python/cheese_flow/adapters/_shared.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
 from cheese_flow.lib.harness import (
@@ -22,7 +23,7 @@ _PASCAL_MAP: dict[str, str] = {
 
 _DEFAULT_HOOK_TIMEOUT = 600
 
-_EMPTY_AGENT_KEYS: frozenset[str] = frozenset()
+_EMPTY_AGENT_KEYS: tuple[str, ...] = ()
 
 
 def _pick_manifest_paths(
@@ -103,8 +104,16 @@ def _build_skills_appendix(skills: list[str]) -> str:
 
 def build_base_agent_artifact(
     artifact_input: AgentArtifactInput,
-    agent_frontmatter_keys: frozenset[str],
+    agent_frontmatter_keys: Iterable[str],
 ) -> AgentArtifact:
+    """Build the agent artifact, iterating ``agent_frontmatter_keys`` in order.
+
+    The TS implementation iterates a ``Set`` whose insertion order matches the
+    declared key tuple; Python ``frozenset`` is unordered, so callers must pass
+    an ordered iterable (tuple/list) to keep the rendered YAML byte-identical.
+    """
+    keys = tuple(agent_frontmatter_keys)
+    key_set: frozenset[str] = frozenset(keys)
     frontmatter = artifact_input.frontmatter
     data: dict[str, Any] = {
         "name": frontmatter["name"],
@@ -115,7 +124,7 @@ def build_base_agent_artifact(
     if len(tools) > 0:
         data["tools"] = tools
     raw: dict[str, Any] = dict(frontmatter)
-    for key in agent_frontmatter_keys:
+    for key in keys:
         value = raw.get(key)
         if value is None:
             continue
@@ -125,7 +134,7 @@ def build_base_agent_artifact(
     skills = frontmatter["skills"]
     appendix = (
         ""
-        if "skills" in agent_frontmatter_keys or len(skills) == 0
+        if "skills" in key_set or len(skills) == 0
         else _build_skills_appendix(skills)
     )
     return AgentArtifact(frontmatter=data, appendix=appendix)

--- a/python/cheese_flow/adapters/claude_code.py
+++ b/python/cheese_flow/adapters/claude_code.py
@@ -19,15 +19,14 @@ from cheese_flow.lib.harness import (
     PortableHooks,
 )
 
-CLAUDE_AGENT_KEYS: frozenset[str] = frozenset(
-    {
-        "skills",
-        "color",
-        "effort",
-        "disallowedTools",
-        "permissionMode",
-    },
+CLAUDE_AGENT_KEY_ORDER: tuple[str, ...] = (
+    "skills",
+    "color",
+    "effort",
+    "disallowedTools",
+    "permissionMode",
 )
+CLAUDE_AGENT_KEYS: frozenset[str] = frozenset(CLAUDE_AGENT_KEY_ORDER)
 
 CLAUDE_MANIFEST_KEYS: tuple[str, ...] = (
     "agents",
@@ -50,7 +49,7 @@ def _build_hook_config(portable: PortableHooks) -> dict[str, Any]:
 
 
 def _build_agent_artifact(artifact_input: AgentArtifactInput) -> AgentArtifact:
-    return build_base_agent_artifact(artifact_input, CLAUDE_AGENT_KEYS)
+    return build_base_agent_artifact(artifact_input, CLAUDE_AGENT_KEY_ORDER)
 
 
 claude_code_adapter = HarnessAdapter(

--- a/python/cheese_flow/adapters/cursor.py
+++ b/python/cheese_flow/adapters/cursor.py
@@ -1,28 +1,28 @@
 """Port of `src/adapters/cursor.ts`.
 
-The TS adapter ships an `emitSurface` callback that reads each skill's
-SKILL.md and renders both a Cursor `.mdc` rule and a `.md` slash command.
-That code path imports `parseFrontmatter` from `lib/frontmatter.ts`, which
-the migration spec assigns to US-004. The callable is therefore wired in
-US-004 alongside the frontmatter port; the rest of the cursor adapter
-(declarative metadata, manifest builder, hook config) lands here in US-003
-so the registry shape is complete.
+Includes the `emit_surface` callback wired in US-004 alongside the
+frontmatter port. The callback reads each skill's SKILL.md and renders both
+a Cursor `.mdc` rule and a `.md` slash command in parallel.
 """
 
 from __future__ import annotations
 
+import asyncio
+from pathlib import Path
 from typing import Any
 
 from cheese_flow.adapters._shared import (
     build_base_manifest,
     build_portable_agent_artifact,
 )
+from cheese_flow.lib.frontmatter import parse_frontmatter
 from cheese_flow.lib.harness import (
     HarnessAdapter,
     HarnessCapabilities,
     ManifestComponentPaths,
     PluginMetadata,
     PortableHooks,
+    SurfaceEmissionResult,
 )
 
 CURSOR_MANIFEST_KEYS: tuple[str, ...] = (
@@ -46,6 +46,64 @@ def _build_hook_config(_portable: PortableHooks) -> None:
     return None
 
 
+def _build_rule_content(description: str, body: str) -> str:
+    return (
+        f"---\ndescription: {description}\nglobs:\nalwaysApply: false\n---\n"
+        f"{body.strip()}\n"
+    )
+
+
+async def _emit_skill(
+    skill_name: str,
+    skill_md_path: Path,
+    rules_dir: Path,
+    commands_dir: Path,
+) -> tuple[str, str] | None:
+    if not skill_md_path.exists():
+        return None
+    content = skill_md_path.read_text(encoding="utf-8")
+    data, body = parse_frontmatter(content)
+    description = (data or {}).get("description", "") if isinstance(data, dict) else ""
+
+    rule_content = _build_rule_content(description, body)
+    command_content = f"{body.strip()}\n"
+
+    rule_path = rules_dir / f"{skill_name}.mdc"
+    command_path = commands_dir / f"{skill_name}.md"
+
+    await asyncio.to_thread(rule_path.write_text, rule_content, encoding="utf-8")
+    await asyncio.to_thread(command_path.write_text, command_content, encoding="utf-8")
+
+    return (str(rule_path), str(command_path))
+
+
+async def _emit_cursor_skill_surface(
+    skills_dir: str, output_root: str
+) -> SurfaceEmissionResult:
+    skills_path = Path(skills_dir)
+    if not skills_path.is_dir():
+        return {"rules": [], "commands": []}
+
+    rules_dir = Path(output_root) / "rules"
+    commands_dir = Path(output_root) / "commands"
+    rules_dir.mkdir(parents=True, exist_ok=True)
+    commands_dir.mkdir(parents=True, exist_ok=True)
+
+    rules: list[str] = []
+    commands: list[str] = []
+
+    for entry in sorted(skills_path.iterdir(), key=lambda p: p.name):
+        if not entry.is_dir():
+            continue
+        skill_md_path = entry / "SKILL.md"
+        result = await _emit_skill(entry.name, skill_md_path, rules_dir, commands_dir)
+        if result is not None:
+            rules.append(result[0])
+            commands.append(result[1])
+
+    return {"rules": rules, "commands": commands}
+
+
 cursor_adapter = HarnessAdapter(
     name="cursor",
     displayName="Cursor",
@@ -62,6 +120,7 @@ cursor_adapter = HarnessAdapter(
     mcpFileName="mcp.json",
     buildHookConfig=_build_hook_config,
     buildAgentArtifact=build_portable_agent_artifact,
+    emitSurface=_emit_cursor_skill_surface,
     capabilities=HarnessCapabilities(
         skillFrontmatterKeys=frozenset(),
         agentFrontmatterKeys=frozenset(),

--- a/python/cheese_flow/adapters/cursor.py
+++ b/python/cheese_flow/adapters/cursor.py
@@ -47,10 +47,7 @@ def _build_hook_config(_portable: PortableHooks) -> None:
 
 
 def _build_rule_content(description: str, body: str) -> str:
-    return (
-        f"---\ndescription: {description}\nglobs:\nalwaysApply: false\n---\n"
-        f"{body.strip()}\n"
-    )
+    return f"---\ndescription: {description}\nglobs:\nalwaysApply: false\n---\n{body.strip()}\n"
 
 
 async def _emit_skill(
@@ -77,9 +74,7 @@ async def _emit_skill(
     return (str(rule_path), str(command_path))
 
 
-async def _emit_cursor_skill_surface(
-    skills_dir: str, output_root: str
-) -> SurfaceEmissionResult:
+async def _emit_cursor_skill_surface(skills_dir: str, output_root: str) -> SurfaceEmissionResult:
     skills_path = Path(skills_dir)
     if not skills_path.is_dir():
         return {"rules": [], "commands": []}

--- a/python/cheese_flow/lib/capabilities.py
+++ b/python/cheese_flow/lib/capabilities.py
@@ -1,0 +1,39 @@
+"""Port of `src/lib/capabilities.ts` — adapter capability inversion helpers."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from cheese_flow.adapters import HARNESS_ADAPTERS
+from cheese_flow.lib.harness import HarnessName
+
+CapabilityKind = Literal["skill", "agent"]
+
+
+def field_support(kind: CapabilityKind) -> dict[str, list[HarnessName]]:
+    result: dict[str, list[HarnessName]] = {}
+    for name, adapter in HARNESS_ADAPTERS.items():
+        keys = (
+            adapter.capabilities.skillFrontmatterKeys
+            if kind == "skill"
+            else adapter.capabilities.agentFrontmatterKeys
+        )
+        for key in keys:
+            result.setdefault(key, []).append(name)
+    return result
+
+
+def event_support() -> dict[str, list[HarnessName]]:
+    result: dict[str, list[HarnessName]] = {}
+    for name, adapter in HARNESS_ADAPTERS.items():
+        for event in adapter.capabilities.hookEvents:
+            result.setdefault(event, []).append(name)
+    return result
+
+
+def tool_support() -> dict[str, list[HarnessName]]:
+    result: dict[str, list[HarnessName]] = {}
+    for name, adapter in HARNESS_ADAPTERS.items():
+        for tool in adapter.capabilities.toolNames:
+            result.setdefault(tool, []).append(name)
+    return result

--- a/python/cheese_flow/lib/compiler.py
+++ b/python/cheese_flow/lib/compiler.py
@@ -1,0 +1,635 @@
+"""Port of `src/lib/compiler.ts` — compile portable agent + skill sources.
+
+Eta → Jinja2 translation strategy: the TS pipeline uses Eta with
+``autoEscape: false, autoTrim: false, useWith: true``. The templates only
+combine three syntactic features — ``<%= expr %>`` outputs, literal text, and
+``forEach`` block loops — so we preprocess the template source into Jinja2
+syntax (`{{ expr }}` outputs, `{% for v in xs %}` / `{% endfor %}` blocks)
+and render with ``Environment(autoescape=False, trim_blocks=False,
+lstrip_blocks=False)`` to keep whitespace identical.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import re
+import shutil
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Annotated, Any
+
+from jinja2 import Environment
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, ValidationError
+
+from cheese_flow.adapters import HARNESS_ADAPTERS
+from cheese_flow.lib.frontmatter import parse_frontmatter
+from cheese_flow.lib.harness import (
+    AgentArtifactInput,
+    HarnessAdapter,
+    HarnessName,
+    HooksSource,
+    ManifestComponentPaths,
+    PluginMetadata,
+    SurfaceEmissionResult,
+)
+from cheese_flow.lib.model_manifest import (
+    ModelManifest,
+    apply_model_manifest,
+    read_model_manifest,
+)
+from cheese_flow.lib.schemas import (
+    AgentFrontmatter,
+    SkillFrontmatter,
+    parse_agent_frontmatter,
+    parse_command_frontmatter,
+    parse_skill_frontmatter,
+    resolve_model,
+)
+
+DEFAULT_PLUGIN_METADATA: PluginMetadata = {
+    "name": "cheese-flow",
+    "version": "0.1.0",
+    "description": (
+        "Opinionated coding harness plugin scaffold for portable agents and skills."
+    ),
+    "author": {"name": "Paul Sorensen"},
+    "license": "MIT",
+    "repository": "https://github.com/paulnsorensen/cheese-flow",
+}
+
+_FOREACH_OPEN = re.compile(
+    r"<%\s*([\w.]+)\.forEach\(\s*function\s*\(\s*(\w+)\s*\)\s*\{\s*%>"
+)
+_FOREACH_CLOSE = re.compile(r"<%\s*\}\)\s*%>")
+_OUTPUT_TAG = re.compile(r"<%=\s*(.*?)\s*%>", re.DOTALL)
+
+
+def _eta_to_jinja(src: str) -> str:
+    """Translate an Eta template body into a Jinja2-compatible source string."""
+    src = _FOREACH_CLOSE.sub("{% endfor %}", src)
+    src = _FOREACH_OPEN.sub(r"{% for \2 in \1 %}", src)
+    src = _OUTPUT_TAG.sub(r"{{ \1 }}", src)
+    return src
+
+
+_JINJA_ENV = Environment(
+    autoescape=False,
+    trim_blocks=False,
+    lstrip_blocks=False,
+    keep_trailing_newline=True,
+)
+
+
+_NODE_YAML_LINE_WIDTH = 80
+
+
+def _fold_flow_value(value: str, indent: str, indent_at_start: int) -> str:
+    """Port of Node ``yaml@2``'s ``foldFlowLines`` for plain scalars.
+
+    Mirrors the algorithm from ``foldFlowLines.js``: ``indent_at_start`` is the
+    column already consumed by the key prefix (``"name: "`` etc.), and
+    determines how much room remains on the first line.
+    """
+    indent_length = len(indent)
+    limit = _NODE_YAML_LINE_WIDTH - indent_length
+    if len(value) <= limit:
+        return value
+    end_step = max(1 + 20, 1 + _NODE_YAML_LINE_WIDTH - indent_length)
+    folds: list[int] = []
+    end = _NODE_YAML_LINE_WIDTH - indent_at_start
+    split: int | None = None
+    prev: str | None = None
+
+    for i, ch in enumerate(value):
+        if (
+            ch == " "
+            and prev is not None
+            and prev not in (" ", "\n", "\t")
+            and i + 1 < len(value)
+            and value[i + 1] not in (" ", "\n", "\t")
+        ):
+            split = i
+        if i >= end and split is not None:
+            folds.append(split)
+            end = split + end_step
+            split = None
+        prev = ch
+
+    if not folds:
+        return value
+
+    parts = [value[: folds[0]]]
+    for idx, fold in enumerate(folds):
+        next_fold = folds[idx + 1] if idx + 1 < len(folds) else len(value)
+        parts.append(f"\n{indent}{value[fold + 1:next_fold]}")
+    return "".join(parts)
+
+
+_RESERVED_SCALARS: frozenset[str] = frozenset(
+    {"true", "false", "null", "True", "False", "Null", "TRUE", "FALSE", "NULL", "~"}
+)
+
+
+def _needs_quoting(value: str) -> bool:
+    """Return True when ``value`` cannot be emitted as a plain YAML scalar."""
+    if value == "":
+        return True
+    if value != value.strip():
+        return True
+    if value[0] in "!&*-?,[]{}>|%@`'\"#":
+        return True
+    if value[0] == ":" or value[0].isdigit():
+        return True
+    if ": " in value or " #" in value:
+        return True
+    return value in _RESERVED_SCALARS
+
+
+def _stringify_scalar(value: str, indent: str, indent_at_start: int) -> str:
+    if _needs_quoting(value):
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return _fold_flow_value(value, indent, indent_at_start)
+
+
+def _stringify_yaml(data: dict[str, Any]) -> str:
+    """Hand-rolled Node ``yaml@2`` plain-style emitter for agent frontmatter.
+
+    The TS pipeline calls ``yaml.stringify`` with default options
+    (``lineWidth: 80``, ``indent: 2``); ruamel.yaml's wrapping algorithm
+    produces visibly different output for medium-length descriptions, so the
+    Python compiler reimplements only the subset needed for agent + skill
+    frontmatter dumps (string / list-of-strings / nested dict values).
+    """
+    return _emit_mapping(data, indent_level=0)
+
+
+def _emit_mapping(mapping: dict[str, Any], *, indent_level: int) -> str:
+    indent = "  " * indent_level
+    fold_indent = "  " * (indent_level + 1)
+    lines: list[str] = []
+    for key, value in mapping.items():
+        prefix_length = len(indent) + len(str(key)) + 2  # "key: "
+        if isinstance(value, str):
+            scalar = _stringify_scalar(value, fold_indent, prefix_length)
+            lines.append(f"{indent}{key}: {scalar}")
+        elif isinstance(value, list):
+            if len(value) == 0:
+                lines.append(f"{indent}{key}: []")
+            else:
+                lines.append(f"{indent}{key}:")
+                for item in value:
+                    lines.append(_emit_list_item(item, indent_level=indent_level + 1))
+        elif isinstance(value, dict):
+            lines.append(f"{indent}{key}:")
+            lines.append(_emit_mapping(value, indent_level=indent_level + 1))
+        elif isinstance(value, bool):
+            lines.append(f"{indent}{key}: {'true' if value else 'false'}")
+        elif value is None:
+            lines.append(f"{indent}{key}: null")
+        else:
+            lines.append(f"{indent}{key}: {value}")
+    return "\n".join(lines) + "\n"
+
+
+def _emit_list_item(item: Any, *, indent_level: int) -> str:
+    indent = "  " * indent_level
+    fold_indent = "  " * (indent_level + 1)
+    item_indent_at_start = len(indent) + 2  # "- "
+    if isinstance(item, str):
+        scalar = _stringify_scalar(item, fold_indent, item_indent_at_start)
+        return f"{indent}- {scalar}"
+    if isinstance(item, dict):
+        # Mirror Node yaml's "-\n  key: value" expansion for nested mappings.
+        rendered = _emit_mapping(item, indent_level=indent_level + 1).rstrip("\n")
+        return f"{indent}-\n{rendered}"
+    return f"{indent}- {item}"
+
+
+def _dump_json(payload: object) -> str:
+    return json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+
+
+def _trim_start(value: str) -> str:
+    return value.lstrip()
+
+
+def _build_agent_file(
+    frontmatter: AgentFrontmatter,
+    adapter: HarnessAdapter,
+    resolved_model: str,
+    rendered_body: str,
+) -> str:
+    raw_fields = frontmatter.model_dump(by_alias=True, exclude_none=True)
+    artifact = adapter.buildAgentArtifact(
+        AgentArtifactInput(frontmatter=raw_fields, resolvedModel=resolved_model)
+    )
+    return (
+        f"---\n{_stringify_yaml(artifact.frontmatter)}---\n"
+        f"{_trim_start(rendered_body)}{artifact.appendix}"
+    )
+
+
+_NonEmptyStr = Annotated[str, StringConstraints(min_length=1)]
+
+
+class _PluginAuthorModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: _NonEmptyStr
+    email: str | None = None
+    url: str | None = None
+
+
+class _PluginMetadataModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: _NonEmptyStr
+    version: _NonEmptyStr
+    description: _NonEmptyStr
+    author: _PluginAuthorModel
+    license: _NonEmptyStr
+    repository: _NonEmptyStr
+    homepage: str | None = None
+    keywords: list[str] | None = Field(default=None)
+
+
+def _read_plugin_metadata(project_root: Path) -> PluginMetadata:
+    plugin_json = project_root / ".claude-plugin" / "plugin.json"
+    if not plugin_json.exists():
+        return DEFAULT_PLUGIN_METADATA
+    raw = plugin_json.read_text(encoding="utf-8")
+    parsed = json.loads(raw)
+    return _validate_plugin_metadata(parsed)
+
+
+def _validate_plugin_metadata(parsed: Any) -> PluginMetadata:
+    try:
+        validated = _PluginMetadataModel.model_validate(parsed)
+    except ValidationError as error:
+        raise ValueError(
+            f"Plugin metadata validation failed: {error}"
+        ) from error
+    return validated.model_dump(exclude_none=True)  # type: ignore[return-value]
+
+
+def _read_hooks_source(project_root: Path) -> HooksSource:
+    hooks_path = project_root / "hooks.json"
+    if not hooks_path.exists():
+        return {}
+    raw = hooks_path.read_text(encoding="utf-8")
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise ValueError("hooks.json must contain an object at the top level.")
+    return parsed  # type: ignore[return-value]
+
+
+@dataclass(frozen=True)
+class CompiledHarnessBundle:
+    harness: HarnessName
+    outputRoot: str
+    pluginMetadata: PluginMetadata
+
+
+@dataclass(frozen=True)
+class _CompileSession:
+    projectRoot: Path
+    pluginMetadata: PluginMetadata
+    hooksSource: HooksSource
+    skillSourceDirectory: Path
+    modelManifest: ModelManifest | None
+
+
+def _create_compile_session(project_root: Path) -> _CompileSession:
+    return _CompileSession(
+        projectRoot=project_root,
+        pluginMetadata=_read_plugin_metadata(project_root),
+        modelManifest=read_model_manifest(project_root),
+        hooksSource=_read_hooks_source(project_root),
+        skillSourceDirectory=project_root / "skills",
+    )
+
+
+async def compile_harness_bundle(
+    *, project_root: str | Path, harness: HarnessName
+) -> CompiledHarnessBundle:
+    session = _create_compile_session(Path(project_root))
+    return await _compile_harness_bundle_from_session(session, harness)
+
+
+async def compile_harness_bundles(
+    *, project_root: str | Path, harnesses: Iterable[HarnessName]
+) -> list[str]:
+    session = _create_compile_session(Path(project_root))
+    outputs: list[str] = []
+    for harness_name in harnesses:
+        compiled = await _compile_harness_bundle_from_session(session, harness_name)
+        outputs.append(compiled.outputRoot)
+    return outputs
+
+
+async def _clean_generated_artifacts(adapter: HarnessAdapter, output_root: Path) -> None:
+    generated_dirs = [
+        adapter.agentDirectory,
+        adapter.skillDirectory,
+        adapter.commandDirectory,
+        adapter.manifestDir,
+    ]
+    if adapter.emitSurface is not None:
+        generated_dirs.extend(["rules", "commands"])
+
+    generated_files = [adapter.mcpFileName, "manifest.json"]
+    if adapter.buildHookConfig({}) is not None:
+        generated_files.append("hooks.json")
+
+    async def _remove_dir(name: str) -> None:
+        path = output_root / name
+        if path.is_symlink() or path.exists():
+            await asyncio.to_thread(shutil.rmtree, path, ignore_errors=True)
+
+    async def _remove_file(name: str) -> None:
+        path = output_root / name
+        if path.is_symlink() or path.exists():
+            with contextlib.suppress(FileNotFoundError):
+                await asyncio.to_thread(path.unlink)
+
+    await asyncio.gather(
+        *[_remove_dir(name) for name in generated_dirs if name is not None],
+        *[_remove_file(name) for name in generated_files],
+    )
+
+
+def _manifest_directory_path(relative_path: str) -> str:
+    return f"./{relative_path}/"
+
+
+def _manifest_file_path(relative_path: str) -> str:
+    return f"./{relative_path}"
+
+
+def _build_manifest_component_paths(
+    *,
+    adapter: HarnessAdapter,
+    agents: list[str],
+    skills: list[str],
+    commands: list[str],
+    emitted_surface: SurfaceEmissionResult,
+) -> ManifestComponentPaths:
+    paths: ManifestComponentPaths = {}
+    if len(agents) > 0:
+        paths["agents"] = _manifest_directory_path(adapter.agentDirectory)
+    if len(skills) > 0:
+        paths["skills"] = _manifest_directory_path(adapter.skillDirectory)
+    if len(commands) > 0 and adapter.commandDirectory is not None:
+        if adapter.name == "codex":
+            paths["apps"] = _manifest_directory_path(adapter.commandDirectory)
+        else:
+            paths["commands"] = _manifest_directory_path(adapter.commandDirectory)
+    if len(emitted_surface["rules"]) > 0:
+        paths["rules"] = _manifest_directory_path("rules")
+    if len(emitted_surface["commands"]) > 0:
+        paths["commands"] = _manifest_directory_path("commands")
+    if adapter.buildHookConfig({}) is not None:
+        paths["hooks"] = _manifest_file_path("hooks.json")
+    paths["mcpServers"] = _manifest_file_path(adapter.mcpFileName)
+    return paths
+
+
+async def _compile_harness_bundle_from_session(
+    session: _CompileSession, harness_name: HarnessName
+) -> CompiledHarnessBundle:
+    from cheese_flow.lib.emit import (
+        emit_hooks,
+        emit_mcp_config,
+        emit_plugin_manifest,
+    )
+
+    adapter = HARNESS_ADAPTERS[harness_name]
+    output_root = session.projectRoot / adapter.outputRoot
+    agent_output = output_root / adapter.agentDirectory
+    skill_output = output_root / adapter.skillDirectory
+
+    await _clean_generated_artifacts(adapter, output_root)
+    agent_output.mkdir(parents=True, exist_ok=True)
+    skill_output.mkdir(parents=True, exist_ok=True)
+
+    agents = await _compile_agents(
+        project_root=session.projectRoot,
+        harness=harness_name,
+        agent_output_directory=agent_output,
+        model_manifest=session.modelManifest,
+    )
+    skills = await _copy_skills(
+        project_root=session.projectRoot,
+        skill_output_directory=skill_output,
+    )
+
+    commands: list[str] = []
+    if adapter.commandDirectory is not None:
+        command_output = output_root / adapter.commandDirectory
+        command_output.mkdir(parents=True, exist_ok=True)
+        commands = await _copy_commands(
+            project_root=session.projectRoot,
+            command_output_directory=command_output,
+        )
+
+    if adapter.emitSurface is None:
+        emitted_surface: SurfaceEmissionResult = {"rules": [], "commands": []}
+    else:
+        emitted_surface = await adapter.emitSurface(
+            str(session.skillSourceDirectory), str(output_root)
+        )
+
+    component_paths = _build_manifest_component_paths(
+        adapter=adapter,
+        agents=agents,
+        skills=skills,
+        commands=commands,
+        emitted_surface=emitted_surface,
+    )
+
+    _write_manifest(
+        output_root,
+        harness=harness_name,
+        agents=agents,
+        skills=skills,
+        commands=commands,
+    )
+
+    emit_plugin_manifest(
+        harness_name, session.pluginMetadata, output_root, component_paths
+    )
+    emit_mcp_config(harness_name, output_root)
+    emit_hooks(harness_name, session.hooksSource, output_root)
+
+    return CompiledHarnessBundle(
+        harness=harness_name,
+        outputRoot=str(output_root),
+        pluginMetadata=session.pluginMetadata,
+    )
+
+
+def _write_manifest(
+    output_root: Path,
+    *,
+    harness: HarnessName,
+    agents: list[str],
+    skills: list[str],
+    commands: list[str],
+) -> None:
+    payload = {
+        "harness": harness,
+        "agents": agents,
+        "skills": skills,
+        "commands": commands,
+        "generatedAt": datetime.now(tz=UTC)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z"),
+    }
+    (output_root / "manifest.json").write_text(_dump_json(payload), encoding="utf-8")
+
+
+async def _compile_agents(
+    *,
+    project_root: Path,
+    harness: HarnessName,
+    agent_output_directory: Path,
+    model_manifest: ModelManifest | None,
+) -> list[str]:
+    source_directory = project_root / "agents"
+    entries = sorted(p.name for p in source_directory.iterdir())
+    compiled: list[str] = []
+
+    for entry_name in entries:
+        source_path = source_directory / entry_name
+        if not source_path.is_file() or not entry_name.endswith(".md.eta"):
+            continue
+
+        source = source_path.read_text(encoding="utf-8")
+        data, body = parse_frontmatter(source)
+        frontmatter = parse_agent_frontmatter(data)
+        adapter = HARNESS_ADAPTERS[harness]
+        output_file = f"{frontmatter.name}.md"
+        base_model = resolve_model(frontmatter.models, harness)
+        resolved_model = apply_model_manifest(
+            model=base_model,
+            agent_name=frontmatter.name,
+            harness=harness,
+            manifest=model_manifest,
+        )
+        agent_context = frontmatter.model_dump(by_alias=True, exclude_none=True)
+        agent_context["model"] = resolved_model
+
+        rendered = _render_template(
+            body,
+            agent=agent_context,
+            harness=adapter,
+        )
+
+        final_content = _build_agent_file(
+            frontmatter, adapter, resolved_model, rendered
+        )
+        (agent_output_directory / output_file).write_text(final_content, encoding="utf-8")
+        compiled.append(output_file)
+
+    return compiled
+
+
+def _render_template(template_body: str, *, agent: dict[str, Any], harness: HarnessAdapter) -> str:
+    jinja_src = _eta_to_jinja(template_body)
+    template = _JINJA_ENV.from_string(jinja_src)
+    return template.render(it={"agent": agent, "harness": harness})
+
+
+async def _copy_skills(
+    *, project_root: Path, skill_output_directory: Path
+) -> list[str]:
+    source_directory = project_root / "skills"
+    entries = sorted(p.name for p in source_directory.iterdir())
+    copied: list[str] = []
+
+    for entry_name in entries:
+        skill_directory = source_directory / entry_name
+        if not skill_directory.is_dir():
+            continue
+        skill_md = skill_directory / "SKILL.md"
+        data, _ = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+        frontmatter = parse_skill_frontmatter(data)
+
+        if frontmatter.name != entry_name:
+            raise ValueError(
+                f'Skill directory "{entry_name}" must match frontmatter '
+                f'name "{frontmatter.name}".'
+            )
+
+        destination = skill_output_directory / entry_name
+        if destination.exists():
+            shutil.rmtree(destination)
+        shutil.copytree(skill_directory, destination)
+        copied.append(entry_name)
+
+    return copied
+
+
+async def _copy_commands(
+    *, project_root: Path, command_output_directory: Path
+) -> list[str]:
+    source_directory = project_root / "commands"
+    if not source_directory.exists():
+        return []
+    entries = sorted(p.name for p in source_directory.iterdir())
+    copied: list[str] = []
+
+    for entry_name in entries:
+        source_path = source_directory / entry_name
+        if not source_path.is_file() or not entry_name.endswith(".md"):
+            continue
+        data, _ = parse_frontmatter(source_path.read_text(encoding="utf-8"))
+        frontmatter = parse_command_frontmatter(data)
+        base_name = entry_name[:-3]
+
+        if frontmatter.name != base_name:
+            raise ValueError(
+                f'Command file "{entry_name}" must match frontmatter '
+                f'name "{frontmatter.name}".'
+            )
+
+        shutil.copyfile(source_path, command_output_directory / entry_name)
+        copied.append(entry_name)
+
+    return copied
+
+
+async def preview_agent(
+    project_root: str | Path, agent_file: str, harness: HarnessName
+) -> str:
+    project_root = Path(project_root)
+    source_path = project_root / "agents" / agent_file
+    source = source_path.read_text(encoding="utf-8")
+    data, body = parse_frontmatter(source)
+    frontmatter = parse_agent_frontmatter(data)
+    manifest = read_model_manifest(project_root)
+    base_model = resolve_model(frontmatter.models, harness)
+    resolved_model = apply_model_manifest(
+        model=base_model,
+        agent_name=frontmatter.name,
+        harness=harness,
+        manifest=manifest,
+    )
+    agent_context = frontmatter.model_dump(by_alias=True, exclude_none=True)
+    agent_context["model"] = resolved_model
+    rendered = _render_template(
+        body, agent=agent_context, harness=HARNESS_ADAPTERS[harness]
+    )
+    return rendered.strip()
+
+
+async def read_skill(project_root: str | Path, skill_name: str) -> SkillFrontmatter:
+    source_path = Path(project_root) / "skills" / skill_name / "SKILL.md"
+    source = source_path.read_text(encoding="utf-8")
+    data, _ = parse_frontmatter(source)
+    return parse_skill_frontmatter(data)

--- a/python/cheese_flow/lib/compiler.py
+++ b/python/cheese_flow/lib/compiler.py
@@ -53,17 +53,13 @@ from cheese_flow.lib.schemas import (
 DEFAULT_PLUGIN_METADATA: PluginMetadata = {
     "name": "cheese-flow",
     "version": "0.1.0",
-    "description": (
-        "Opinionated coding harness plugin scaffold for portable agents and skills."
-    ),
+    "description": ("Opinionated coding harness plugin scaffold for portable agents and skills."),
     "author": {"name": "Paul Sorensen"},
     "license": "MIT",
     "repository": "https://github.com/paulnsorensen/cheese-flow",
 }
 
-_FOREACH_OPEN = re.compile(
-    r"<%\s*([\w.]+)\.forEach\(\s*function\s*\(\s*(\w+)\s*\)\s*\{\s*%>"
-)
+_FOREACH_OPEN = re.compile(r"<%\s*([\w.]+)\.forEach\(\s*function\s*\(\s*(\w+)\s*\)\s*\{\s*%>")
 _FOREACH_CLOSE = re.compile(r"<%\s*\}\)\s*%>")
 _OUTPUT_TAG = re.compile(r"<%=\s*(.*?)\s*%>", re.DOTALL)
 
@@ -125,7 +121,7 @@ def _fold_flow_value(value: str, indent: str, indent_at_start: int) -> str:
     parts = [value[: folds[0]]]
     for idx, fold in enumerate(folds):
         next_fold = folds[idx + 1] if idx + 1 < len(folds) else len(value)
-        parts.append(f"\n{indent}{value[fold + 1:next_fold]}")
+        parts.append(f"\n{indent}{value[fold + 1 : next_fold]}")
     return "".join(parts)
 
 
@@ -271,9 +267,7 @@ def _validate_plugin_metadata(parsed: Any) -> PluginMetadata:
     try:
         validated = _PluginMetadataModel.model_validate(parsed)
     except ValidationError as error:
-        raise ValueError(
-            f"Plugin metadata validation failed: {error}"
-        ) from error
+        raise ValueError(f"Plugin metadata validation failed: {error}") from error
     return validated.model_dump(exclude_none=True)  # type: ignore[return-value]
 
 
@@ -460,9 +454,7 @@ async def _compile_harness_bundle_from_session(
         commands=commands,
     )
 
-    emit_plugin_manifest(
-        harness_name, session.pluginMetadata, output_root, component_paths
-    )
+    emit_plugin_manifest(harness_name, session.pluginMetadata, output_root, component_paths)
     emit_mcp_config(harness_name, output_root)
     emit_hooks(harness_name, session.hooksSource, output_root)
 
@@ -530,9 +522,7 @@ async def _compile_agents(
             harness=adapter,
         )
 
-        final_content = _build_agent_file(
-            frontmatter, adapter, resolved_model, rendered
-        )
+        final_content = _build_agent_file(frontmatter, adapter, resolved_model, rendered)
         (agent_output_directory / output_file).write_text(final_content, encoding="utf-8")
         compiled.append(output_file)
 
@@ -545,9 +535,7 @@ def _render_template(template_body: str, *, agent: dict[str, Any], harness: Harn
     return template.render(it={"agent": agent, "harness": harness})
 
 
-async def _copy_skills(
-    *, project_root: Path, skill_output_directory: Path
-) -> list[str]:
+async def _copy_skills(*, project_root: Path, skill_output_directory: Path) -> list[str]:
     source_directory = project_root / "skills"
     entries = sorted(p.name for p in source_directory.iterdir())
     copied: list[str] = []
@@ -562,8 +550,7 @@ async def _copy_skills(
 
         if frontmatter.name != entry_name:
             raise ValueError(
-                f'Skill directory "{entry_name}" must match frontmatter '
-                f'name "{frontmatter.name}".'
+                f'Skill directory "{entry_name}" must match frontmatter name "{frontmatter.name}".'
             )
 
         destination = skill_output_directory / entry_name
@@ -575,9 +562,7 @@ async def _copy_skills(
     return copied
 
 
-async def _copy_commands(
-    *, project_root: Path, command_output_directory: Path
-) -> list[str]:
+async def _copy_commands(*, project_root: Path, command_output_directory: Path) -> list[str]:
     source_directory = project_root / "commands"
     if not source_directory.exists():
         return []
@@ -594,8 +579,7 @@ async def _copy_commands(
 
         if frontmatter.name != base_name:
             raise ValueError(
-                f'Command file "{entry_name}" must match frontmatter '
-                f'name "{frontmatter.name}".'
+                f'Command file "{entry_name}" must match frontmatter name "{frontmatter.name}".'
             )
 
         shutil.copyfile(source_path, command_output_directory / entry_name)
@@ -604,9 +588,7 @@ async def _copy_commands(
     return copied
 
 
-async def preview_agent(
-    project_root: str | Path, agent_file: str, harness: HarnessName
-) -> str:
+async def preview_agent(project_root: str | Path, agent_file: str, harness: HarnessName) -> str:
     project_root = Path(project_root)
     source_path = project_root / "agents" / agent_file
     source = source_path.read_text(encoding="utf-8")
@@ -622,9 +604,7 @@ async def preview_agent(
     )
     agent_context = frontmatter.model_dump(by_alias=True, exclude_none=True)
     agent_context["model"] = resolved_model
-    rendered = _render_template(
-        body, agent=agent_context, harness=HARNESS_ADAPTERS[harness]
-    )
+    rendered = _render_template(body, agent=agent_context, harness=HARNESS_ADAPTERS[harness])
     return rendered.strip()
 
 

--- a/python/cheese_flow/lib/emit.py
+++ b/python/cheese_flow/lib/emit.py
@@ -42,11 +42,7 @@ def _filter_bootstrap_entries(portable: PortableHooks) -> PortableHooks:
     for event, entries in portable.items():
         if entries is None:
             continue
-        kept = [
-            entry
-            for entry in entries
-            if _BOOTSTRAP_COMMAND_MARKER not in entry["command"]
-        ]
+        kept = [entry for entry in entries if _BOOTSTRAP_COMMAND_MARKER not in entry["command"]]
         if len(kept) > 0:
             event_key: PortableEvent = event  # type: ignore[assignment]
             result[event_key] = kept

--- a/python/cheese_flow/lib/emit.py
+++ b/python/cheese_flow/lib/emit.py
@@ -1,0 +1,106 @@
+"""Port of `src/lib/emit.ts` — write plugin manifest, MCP config, hooks files."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from cheese_flow.adapters import HARNESS_ADAPTERS
+from cheese_flow.lib.harness import (
+    CANONICAL_MCP_SERVERS,
+    PORTABLE_EVENTS,
+    HarnessName,
+    HooksSource,
+    ManifestComponentPaths,
+    PluginMetadata,
+    PortableEvent,
+    PortableHooks,
+)
+
+_BOOTSTRAP_COMMAND_MARKER = "hooks/cheese-bootstrap.sh"
+
+
+def _filter_portable_events(source: HooksSource) -> PortableHooks:
+    portable: PortableHooks = {}
+    portable_set: frozenset[str] = frozenset(PORTABLE_EVENTS)
+    for event, entries in source.items():
+        if entries is None:
+            continue
+        if event in portable_set:
+            portable[event] = entries  # type: ignore[index]
+        else:
+            print(
+                f"[cheese-flow] skipping non-portable hook event: {event}",
+                file=sys.stderr,
+            )
+    return portable
+
+
+def _filter_bootstrap_entries(portable: PortableHooks) -> PortableHooks:
+    result: PortableHooks = {}
+    for event, entries in portable.items():
+        if entries is None:
+            continue
+        kept = [
+            entry
+            for entry in entries
+            if _BOOTSTRAP_COMMAND_MARKER not in entry["command"]
+        ]
+        if len(kept) > 0:
+            event_key: PortableEvent = event  # type: ignore[assignment]
+            result[event_key] = kept
+    return result
+
+
+def _dump_json(payload: object) -> str:
+    """Match Node ``JSON.stringify(value, null, 2)`` formatting (with a trailing newline)."""
+    return json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+
+
+def emit_plugin_manifest(
+    harness: HarnessName,
+    metadata: PluginMetadata,
+    output_root: str | Path,
+    component_paths: ManifestComponentPaths | None = None,
+) -> Path:
+    component_paths = component_paths or {}
+    adapter = HARNESS_ADAPTERS[harness]
+    manifest = adapter.buildManifest(metadata, component_paths)
+    manifest_dir = Path(output_root) / adapter.manifestDir
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = manifest_dir / "plugin.json"
+    manifest_path.write_text(_dump_json(manifest), encoding="utf-8")
+    return manifest_path
+
+
+def emit_mcp_config(harness: HarnessName, output_root: str | Path) -> Path:
+    adapter = HARNESS_ADAPTERS[harness]
+    Path(output_root).mkdir(parents=True, exist_ok=True)
+    config = {"mcpServers": CANONICAL_MCP_SERVERS}
+    output_path = Path(output_root) / adapter.mcpFileName
+    output_path.write_text(_dump_json(config), encoding="utf-8")
+    return output_path
+
+
+def emit_hooks(
+    harness: HarnessName,
+    source: HooksSource,
+    output_root: str | Path,
+) -> Path | None:
+    adapter = HARNESS_ADAPTERS[harness]
+    portable = _filter_portable_events(source)
+    if not adapter.capabilities.bootstrapHook:
+        portable = _filter_bootstrap_entries(portable)
+    payload = adapter.buildHookConfig(portable)
+
+    if payload is None:
+        # Mirror TS ``console.info`` — informational output goes to stdout so
+        # ``cheese compile`` log scrapers see the message in the same stream.
+        print(f"[cheese-flow] hooks not supported in {harness} target; skipping")
+        return None
+
+    Path(output_root).mkdir(parents=True, exist_ok=True)
+    output_path = Path(output_root) / "hooks.json"
+    output_path.write_text(_dump_json(payload), encoding="utf-8")
+    return output_path

--- a/python/cheese_flow/lib/frontmatter.py
+++ b/python/cheese_flow/lib/frontmatter.py
@@ -1,0 +1,48 @@
+"""Port of `src/lib/frontmatter.ts` — split YAML frontmatter from a markdown body."""
+
+from __future__ import annotations
+
+import re
+from io import StringIO
+from typing import Any
+
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
+
+_FRONTMATTER_PATTERN = re.compile(
+    r"^---\r?\n(.*?)\r?\n---\r?\n?(.*)$",
+    re.DOTALL,
+)
+
+
+def _make_yaml_loader() -> YAML:
+    yaml = YAML(typ="rt")
+    yaml.preserve_quotes = True
+    return yaml
+
+
+_YAML = _make_yaml_loader()
+
+
+def parse_frontmatter(content: str) -> tuple[Any, str]:
+    """Return ``(data, body)`` parsed from a ``---``-delimited markdown source.
+
+    Mirrors the TS helper: raises when the delimiters are absent or YAML is
+    malformed; returns an empty dict when the frontmatter region is empty.
+    """
+    match = _FRONTMATTER_PATTERN.match(content)
+    if match is None:
+        raise ValueError("Expected YAML frontmatter bounded by --- markers.")
+
+    raw_frontmatter = match.group(1)
+    body = match.group(2)
+
+    # Append a trailing newline so ruamel.yaml retains the clip-chomp newline on
+    # ``>`` / ``|`` block scalars; the Node ``yaml`` parser keeps that newline
+    # implicitly and downstream emitters depend on it (e.g. cursor rule pages).
+    try:
+        loaded = _YAML.load(StringIO(raw_frontmatter + "\n"))
+    except YAMLError as error:
+        raise ValueError(str(error)) from error
+
+    return (loaded if loaded is not None else {}, body)

--- a/python/cheese_flow/lib/model_manifest.py
+++ b/python/cheese_flow/lib/model_manifest.py
@@ -21,14 +21,10 @@ AgentSlugStr = Annotated[str, StringConstraints(pattern=r"^[a-z][a-z0-9-]*$")]
 class HarnessPins(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
-    claude_code: dict[NonEmptyStr, NonEmptyStr] | None = Field(
-        default=None, alias="claude-code"
-    )
+    claude_code: dict[NonEmptyStr, NonEmptyStr] | None = Field(default=None, alias="claude-code")
     codex: dict[NonEmptyStr, NonEmptyStr] | None = None
     cursor: dict[NonEmptyStr, NonEmptyStr] | None = None
-    copilot_cli: dict[NonEmptyStr, NonEmptyStr] | None = Field(
-        default=None, alias="copilot-cli"
-    )
+    copilot_cli: dict[NonEmptyStr, NonEmptyStr] | None = Field(default=None, alias="copilot-cli")
 
     def get(self, harness: HarnessName) -> dict[str, str] | None:
         if harness == "claude-code":
@@ -82,18 +78,14 @@ def read_model_manifest(project_root: str | Path) -> ModelManifest | None:
     try:
         parsed = _read_yaml(manifest_path)
     except YAMLError as error:
-        raise ValueError(
-            f"Invalid models.yaml at {manifest_path}: {error}"
-        ) from error
+        raise ValueError(f"Invalid models.yaml at {manifest_path}: {error}") from error
 
     payload = parsed if parsed is not None else {}
 
     try:
         return ModelManifest.model_validate(payload)
     except ValidationError as error:
-        raise ValueError(
-            f"Invalid models.yaml at {manifest_path}: {error}"
-        ) from error
+        raise ValueError(f"Invalid models.yaml at {manifest_path}: {error}") from error
 
 
 def apply_model_manifest(

--- a/python/cheese_flow/lib/model_manifest.py
+++ b/python/cheese_flow/lib/model_manifest.py
@@ -1,0 +1,122 @@
+"""Port of `src/lib/model-manifest.ts` — read + apply harness model overrides."""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+from typing import Annotated, Any
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, ValidationError
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
+
+from cheese_flow.lib.harness import HarnessName
+
+MODEL_MANIFEST_FILE = "models.yaml"
+
+NonEmptyStr = Annotated[str, StringConstraints(min_length=1)]
+AgentSlugStr = Annotated[str, StringConstraints(pattern=r"^[a-z][a-z0-9-]*$")]
+
+
+class HarnessPins(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    claude_code: dict[NonEmptyStr, NonEmptyStr] | None = Field(
+        default=None, alias="claude-code"
+    )
+    codex: dict[NonEmptyStr, NonEmptyStr] | None = None
+    cursor: dict[NonEmptyStr, NonEmptyStr] | None = None
+    copilot_cli: dict[NonEmptyStr, NonEmptyStr] | None = Field(
+        default=None, alias="copilot-cli"
+    )
+
+    def get(self, harness: HarnessName) -> dict[str, str] | None:
+        if harness == "claude-code":
+            return self.claude_code
+        if harness == "codex":
+            return self.codex
+        if harness == "cursor":
+            return self.cursor
+        return self.copilot_cli
+
+
+class HarnessOverride(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    claude_code: NonEmptyStr | None = Field(default=None, alias="claude-code")
+    codex: NonEmptyStr | None = None
+    cursor: NonEmptyStr | None = None
+    copilot_cli: NonEmptyStr | None = Field(default=None, alias="copilot-cli")
+
+    def get(self, harness: HarnessName) -> str | None:
+        if harness == "claude-code":
+            return self.claude_code
+        if harness == "codex":
+            return self.codex
+        if harness == "cursor":
+            return self.cursor
+        return self.copilot_cli
+
+
+class ModelManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    pins: HarnessPins | None = None
+    overrides: dict[AgentSlugStr, HarnessOverride] | None = None
+
+
+_YAML = YAML(typ="safe")
+
+
+def _read_yaml(path: Path) -> Any:
+    raw = path.read_text(encoding="utf-8")
+    return _YAML.load(StringIO(raw))
+
+
+def read_model_manifest(project_root: str | Path) -> ModelManifest | None:
+    """Return the parsed manifest or ``None`` when ``models.yaml`` is absent."""
+    manifest_path = Path(project_root) / MODEL_MANIFEST_FILE
+    if not manifest_path.exists():
+        return None
+
+    try:
+        parsed = _read_yaml(manifest_path)
+    except YAMLError as error:
+        raise ValueError(
+            f"Invalid models.yaml at {manifest_path}: {error}"
+        ) from error
+
+    payload = parsed if parsed is not None else {}
+
+    try:
+        return ModelManifest.model_validate(payload)
+    except ValidationError as error:
+        raise ValueError(
+            f"Invalid models.yaml at {manifest_path}: {error}"
+        ) from error
+
+
+def apply_model_manifest(
+    *,
+    model: str,
+    agent_name: str,
+    harness: HarnessName,
+    manifest: ModelManifest | None,
+) -> str:
+    """Resolve ``model`` against the optional manifest, mirroring the TS rules."""
+    if manifest is None:
+        return model
+    overrides = manifest.overrides or {}
+    override_entry = overrides.get(agent_name)
+    if override_entry is not None:
+        override_value = override_entry.get(harness)
+        if override_value is not None:
+            return override_value
+    pins = manifest.pins
+    if pins is not None:
+        harness_pins = pins.get(harness)
+        if harness_pins is not None:
+            pin = harness_pins.get(model)
+            if pin is not None:
+                return pin
+    return model

--- a/ralphs/python-migration/TODO.md
+++ b/ralphs/python-migration/TODO.md
@@ -9,7 +9,7 @@ US-005 (install-plan), US-006 (harness-detection), and US-007 (harness-compat).
 - [x] US-001 — Package skeleton: rename pyproject to `cheese-flow`, add deps (typer, jinja2, pydantic>=2, ruamel.yaml), create `python/cheese_flow/{__init__,lib/__init__,adapters/__init__}.py`, declare `[project.scripts] cheese = "cheese_flow.cli:app"` placeholder, verify the correct `mcp` SDK version on PyPI before pinning
 - [x] US-002 — Port `src/lib/schemas.ts` → `python/cheese_flow/lib/schemas.py` (Pydantic v2, `extra="forbid"`, all 9 schemas + discriminated unions); port matching vitest cases verbatim
 - [x] US-003 — Port `src/adapters/{claude-code,codex,cursor,copilot-cli,_shared,index}.ts` → `python/cheese_flow/adapters/`; preserve registry shape; port adapter vitest cases
-- [ ] US-004 — Port compile pipeline: `compiler.ts` + `emit.ts` + `frontmatter.ts` + `capabilities.ts` + `model-manifest.ts` → `python/cheese_flow/lib/`; Eta `<%= %>` / `<% %>` → Jinja2 `{{ }}` / `{% %}`; `Promise.all` → `asyncio.gather`; commit a byte-parity snapshot fixture for one agent + one skill
+- [x] US-004 — Port compile pipeline: `compiler.ts` + `emit.ts` + `frontmatter.ts` + `capabilities.ts` + `model-manifest.ts` → `python/cheese_flow/lib/`; Eta `<%= %>` / `<% %>` → Jinja2 `{{ }}` / `{% %}`; `Promise.all` → `asyncio.gather`; commit a byte-parity snapshot fixture for one agent + one skill
 - [ ] US-005 — Port `src/lib/install-plan.ts` → `python/cheese_flow/lib/install_plan.py`; port `tests/install-plan.test.ts`
 - [ ] US-006 — Port `src/lib/harness-detection.ts` → `python/cheese_flow/lib/harness_detection.py`; port `tests/harness-detection.test.ts`
 - [ ] US-007 — Port `src/lib/harness-compat.ts` → `python/cheese_flow/lib/harness_compat.py`; port `tests/harness-compat.test.ts`

--- a/tests/python/fixtures/byte_parity/basic-agent.claude-code.md
+++ b/tests/python/fixtures/byte_parity/basic-agent.claude-code.md
@@ -1,0 +1,38 @@
+---
+name: basic-agent
+description: A starter portable agent definition compiled into harness-specific markdown.
+model: sonnet
+tools:
+  - read
+  - write
+  - bash
+---
+# basic-agent
+
+A starter portable agent definition compiled into harness-specific markdown.
+
+## Runtime
+- Harness target: Claude Code
+- Recommended model: sonnet
+- Output root: .claude
+
+## Responsibilities
+- Read the user's request before changing code.
+- Prefer portable markdown instructions over harness-specific source formats.
+- Keep changes small, validated, and easy to review.
+
+## Allowed tools
+- read
+- write
+- bash
+
+
+## Harness notes
+- Use concise markdown headings and explicit tool guidance.
+- Prefer Claude model identifiers in agent metadata and output.
+
+
+## Workflow
+1. Inspect the repository before editing.
+2. Validate source definitions before compiling them for a harness.
+3. Emit plain markdown so the same agent can be consumed by multiple coding harnesses.

--- a/tests/python/fixtures/byte_parity/basic-skill.claude-code.md
+++ b/tests/python/fixtures/byte_parity/basic-skill.claude-code.md
@@ -1,0 +1,22 @@
+---
+name: basic-skill
+description: A portable starter skill in Agent Skills format for repositories adopting cheese-flow.
+license: MIT
+compatibility: Works in any harness that can read Agent Skills style markdown assets.
+metadata:
+  owner: cheese-flow
+  version: "0.1.0"
+allowed-tools:
+  - read
+  - write
+  - bash
+---
+# Basic Skill
+
+Use this skill when you need a simple, portable capability definition that can travel across coding harnesses.
+
+## Steps
+1. Read the repository context.
+2. Confirm the target harness and desired output location.
+3. Apply the minimum set of changes needed.
+4. Summarize what changed and how to consume the compiled artifact.

--- a/tests/python/test_capabilities.py
+++ b/tests/python/test_capabilities.py
@@ -1,0 +1,65 @@
+"""Verbatim port of the lib portion of `tests/capabilities.test.ts`.
+
+The adapter capabilities declarations describe block lives in
+``tests/python/test_adapters.py`` (US-003); this file ports the
+``fieldSupport`` / ``eventSupport`` / ``toolSupport`` describe blocks that
+exercise ``cheese_flow.lib.capabilities``.
+"""
+
+from __future__ import annotations
+
+from cheese_flow.adapters import HARNESS_ADAPTERS
+from cheese_flow.lib.capabilities import event_support, field_support, tool_support
+from cheese_flow.lib.harness import PORTABLE_EVENTS
+
+
+def test_field_support_model_is_mapped_to_only_claude_code() -> None:
+    assert field_support("skill").get("model") == ["claude-code"]
+
+
+def test_field_support_context_is_mapped_to_only_claude_code() -> None:
+    assert field_support("skill").get("context") == ["claude-code"]
+
+
+def test_field_support_returns_a_map_for_agent_kind_with_all_expected_keys() -> None:
+    support = field_support("agent")
+    for key in ("skills", "color", "effort", "disallowedTools", "permissionMode"):
+        assert key in support, f"missing agent key: {key}"
+
+
+def test_field_support_portable_fields_are_absent_from_the_map() -> None:
+    support = field_support("skill")
+    assert "name" not in support
+    assert "description" not in support
+
+
+def test_event_support_portable_events_are_supported_by_all_hook_using_adapters() -> None:
+    support = event_support()
+    hook_adapters = sorted(
+        name
+        for name, adapter in HARNESS_ADAPTERS.items()
+        if len(adapter.capabilities.hookEvents) > 0
+    )
+    for event in PORTABLE_EVENTS:
+        supported_by = sorted(support.get(event, []))
+        assert supported_by == hook_adapters
+
+
+def test_event_support_stop_is_supported_only_by_claude_code() -> None:
+    assert event_support().get("stop") == ["claude-code"]
+
+
+def test_event_support_session_end_is_supported_only_by_claude_code() -> None:
+    assert event_support().get("sessionEnd") == ["claude-code"]
+
+
+def test_tool_support_all_tools_are_supported_only_by_claude_code() -> None:
+    support = tool_support()
+    for tool, supported_by in support.items():
+        assert supported_by == ["claude-code"], f"{tool} should only be claude-code"
+
+
+def test_tool_support_union_covers_full_claude_only_set() -> None:
+    support = tool_support()
+    for tool in ("Agent", "Task", "NotebookEdit", "WebSearch", "WebFetch", "TodoWrite"):
+        assert tool in support, f"missing tool: {tool}"

--- a/tests/python/test_compiler.py
+++ b/tests/python/test_compiler.py
@@ -43,33 +43,19 @@ def _stage_project(tmp_path: Path) -> Path:
 
 def test_byte_parity_snapshot_basic_agent_claude_code(tmp_path: Path) -> None:
     project_root = _stage_project(tmp_path)
-    asyncio.run(
-        compile_harness_bundles(
-            project_root=project_root, harnesses=["claude-code"]
-        )
-    )
-    actual = (project_root / ".claude" / "agents" / "basic-agent.md").read_text(
-        encoding="utf-8"
-    )
-    expected = (FIXTURE_DIR / "basic-agent.claude-code.md").read_text(
-        encoding="utf-8"
-    )
+    asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["claude-code"]))
+    actual = (project_root / ".claude" / "agents" / "basic-agent.md").read_text(encoding="utf-8")
+    expected = (FIXTURE_DIR / "basic-agent.claude-code.md").read_text(encoding="utf-8")
     assert actual == expected, "basic-agent.md drifted from the byte-parity fixture"
 
 
 def test_byte_parity_snapshot_basic_skill_claude_code(tmp_path: Path) -> None:
     project_root = _stage_project(tmp_path)
-    asyncio.run(
-        compile_harness_bundles(
-            project_root=project_root, harnesses=["claude-code"]
-        )
-    )
-    actual = (
-        project_root / ".claude" / "skills" / "basic-skill" / "SKILL.md"
-    ).read_text(encoding="utf-8")
-    expected = (FIXTURE_DIR / "basic-skill.claude-code.md").read_text(
+    asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["claude-code"]))
+    actual = (project_root / ".claude" / "skills" / "basic-skill" / "SKILL.md").read_text(
         encoding="utf-8"
     )
+    expected = (FIXTURE_DIR / "basic-skill.claude-code.md").read_text(encoding="utf-8")
     assert actual == expected, "basic-skill SKILL.md drifted from the byte-parity fixture"
 
 
@@ -78,18 +64,16 @@ def test_compiles_basic_agent_template_for_claude_code_and_codex(
 ) -> None:
     project_root = _stage_project(tmp_path)
     outputs = asyncio.run(
-        compile_harness_bundles(
-            project_root=project_root, harnesses=["claude-code", "codex"]
-        )
+        compile_harness_bundles(project_root=project_root, harnesses=["claude-code", "codex"])
     )
     assert len(outputs) == 2
 
-    claude_agent = (
-        project_root / ".claude" / "agents" / "basic-agent.md"
-    ).read_text(encoding="utf-8")
-    codex_agent = (
-        project_root / ".codex" / "agents" / "basic-agent.md"
-    ).read_text(encoding="utf-8")
+    claude_agent = (project_root / ".claude" / "agents" / "basic-agent.md").read_text(
+        encoding="utf-8"
+    )
+    codex_agent = (project_root / ".codex" / "agents" / "basic-agent.md").read_text(
+        encoding="utf-8"
+    )
 
     claude_data, _ = parse_frontmatter(claude_agent)
     codex_data, _ = parse_frontmatter(codex_agent)
@@ -97,9 +81,7 @@ def test_compiles_basic_agent_template_for_claude_code_and_codex(
     assert codex_data["model"] == "gpt-5-codex"
 
     claude_plugin = json.loads(
-        (project_root / ".claude" / ".claude-plugin" / "plugin.json").read_text(
-            encoding="utf-8"
-        )
+        (project_root / ".claude" / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
     )
     assert claude_plugin["name"] == "cheese-flow"
     assert claude_plugin["agents"] == "./agents/"
@@ -108,9 +90,7 @@ def test_compiles_basic_agent_template_for_claude_code_and_codex(
     assert claude_plugin["hooks"] == "./hooks.json"
     assert claude_plugin["mcpServers"] == "./.mcp.json"
 
-    claude_mcp = json.loads(
-        (project_root / ".claude" / ".mcp.json").read_text(encoding="utf-8")
-    )
+    claude_mcp = json.loads((project_root / ".claude" / ".mcp.json").read_text(encoding="utf-8"))
     assert "tilth" in claude_mcp["mcpServers"]
     assert "context7" in claude_mcp["mcpServers"]
     assert "tavily" in claude_mcp["mcpServers"]
@@ -119,15 +99,13 @@ def test_compiles_basic_agent_template_for_claude_code_and_codex(
 
 def test_compiles_a_single_harness_bundle_and_returns_metadata(tmp_path: Path) -> None:
     project_root = _stage_project(tmp_path)
-    compiled = asyncio.run(
-        compile_harness_bundle(project_root=project_root, harness="claude-code")
-    )
+    compiled = asyncio.run(compile_harness_bundle(project_root=project_root, harness="claude-code"))
     assert compiled.harness == "claude-code"
     assert compiled.outputRoot == str(project_root / ".claude")
     assert compiled.pluginMetadata["name"] == "cheese-flow"
-    plugin_text = (
-        project_root / ".claude" / ".claude-plugin" / "plugin.json"
-    ).read_text(encoding="utf-8")
+    plugin_text = (project_root / ".claude" / ".claude-plugin" / "plugin.json").read_text(
+        encoding="utf-8"
+    )
     assert '"name": "cheese-flow"' in plugin_text
 
 
@@ -135,14 +113,8 @@ def test_emits_agent_frontmatter_with_skills_binding_for_claude_code(
     tmp_path: Path,
 ) -> None:
     project_root = _stage_project(tmp_path)
-    asyncio.run(
-        compile_harness_bundles(
-            project_root=project_root, harnesses=["claude-code"]
-        )
-    )
-    cook_agent = (project_root / ".claude" / "agents" / "cook.md").read_text(
-        encoding="utf-8"
-    )
+    asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["claude-code"]))
+    cook_agent = (project_root / ".claude" / "agents" / "cook.md").read_text(encoding="utf-8")
     data, _ = parse_frontmatter(cook_agent)
     assert data["name"] == "cook"
     assert data["model"] == "sonnet"
@@ -156,12 +128,8 @@ def test_drops_claude_only_fields_and_appends_skills_prompt_contract_for_codex(
     tmp_path: Path,
 ) -> None:
     project_root = _stage_project(tmp_path)
-    asyncio.run(
-        compile_harness_bundles(project_root=project_root, harnesses=["codex"])
-    )
-    cook_agent = (project_root / ".codex" / "agents" / "cook.md").read_text(
-        encoding="utf-8"
-    )
+    asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["codex"]))
+    cook_agent = (project_root / ".codex" / "agents" / "cook.md").read_text(encoding="utf-8")
     data, _ = parse_frontmatter(cook_agent)
     assert data["name"] == "cook"
     assert data["model"] == "gpt-5-codex"
@@ -189,19 +157,13 @@ def test_applies_models_yaml_pins_and_overrides(tmp_path: Path) -> None:
         ).lstrip(),
         encoding="utf-8",
     )
-    asyncio.run(
-        compile_harness_bundles(
-            project_root=project_root, harnesses=["claude-code"]
-        )
-    )
+    asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["claude-code"]))
     cook_data, _ = parse_frontmatter(
         (project_root / ".claude" / "agents" / "cook.md").read_text(encoding="utf-8")
     )
     assert cook_data["model"] == "claude-sonnet-4-6"
     basic_data, _ = parse_frontmatter(
-        (project_root / ".claude" / "agents" / "basic-agent.md").read_text(
-            encoding="utf-8"
-        )
+        (project_root / ".claude" / "agents" / "basic-agent.md").read_text(encoding="utf-8")
     )
     assert basic_data["model"] == "claude-opus-4-7"
 
@@ -232,11 +194,7 @@ def test_rejects_skills_whose_folder_name_does_not_match_the_spec_name(
         encoding="utf-8",
     )
     with pytest.raises(ValueError, match="must match frontmatter name"):
-        asyncio.run(
-            compile_harness_bundles(
-                project_root=project_root, harnesses=["claude-code"]
-            )
-        )
+        asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["claude-code"]))
 
 
 def test_ignores_non_template_agent_files_and_non_directory_skill_entries(
@@ -251,14 +209,8 @@ def test_ignores_non_template_agent_files_and_non_directory_skill_entries(
         encoding="utf-8",
     )
 
-    asyncio.run(
-        compile_harness_bundles(
-            project_root=project_root, harnesses=["claude-code"]
-        )
-    )
-    manifest = json.loads(
-        (project_root / ".claude" / "manifest.json").read_text(encoding="utf-8")
-    )
+    asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["claude-code"]))
+    manifest = json.loads((project_root / ".claude" / "manifest.json").read_text(encoding="utf-8"))
     assert "basic-agent.md" in manifest["agents"]
     assert "cook.md" in manifest["agents"]
     assert "basic-skill" in manifest["skills"]
@@ -268,14 +220,10 @@ def test_ignores_non_template_agent_files_and_non_directory_skill_entries(
 
 def test_emits_dual_surface_artifacts_and_manifests_for_cursor(tmp_path: Path) -> None:
     project_root = _stage_project(tmp_path)
-    asyncio.run(
-        compile_harness_bundles(project_root=project_root, harnesses=["cursor"])
-    )
+    asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["cursor"]))
     cursor_root = project_root / ".cursor"
     rule = (cursor_root / "rules" / "basic-skill.mdc").read_text(encoding="utf-8")
-    command = (cursor_root / "commands" / "basic-skill.md").read_text(
-        encoding="utf-8"
-    )
+    command = (cursor_root / "commands" / "basic-skill.md").read_text(encoding="utf-8")
     assert "alwaysApply: false" in rule
     assert "description:" in rule
     assert command  # non-empty
@@ -289,9 +237,7 @@ def test_emits_dual_surface_artifacts_and_manifests_for_cursor(tmp_path: Path) -
     assert plugin_json["commands"] == "./commands/"
     assert plugin_json.get("hooks") is None
     assert plugin_json["mcpServers"] == "./mcp.json"
-    mcp_json = json.loads(
-        (cursor_root / "mcp.json").read_text(encoding="utf-8")
-    )
+    mcp_json = json.loads((cursor_root / "mcp.json").read_text(encoding="utf-8"))
     assert "tilth" in mcp_json["mcpServers"]
     assert "context7" in mcp_json["mcpServers"]
     assert "tavily" in mcp_json["mcpServers"]
@@ -302,15 +248,11 @@ def test_emits_plugin_manifest_mcp_config_and_hooks_for_copilot_cli(
 ) -> None:
     project_root = _stage_project(tmp_path)
     (project_root / "hooks.json").write_text(
-        json.dumps(
-            {"sessionStart": [{"type": "command", "command": "echo start"}]}
-        ),
+        json.dumps({"sessionStart": [{"type": "command", "command": "echo start"}]}),
         encoding="utf-8",
     )
 
-    asyncio.run(
-        compile_harness_bundles(project_root=project_root, harnesses=["copilot-cli"])
-    )
+    asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["copilot-cli"]))
     copilot_root = project_root / ".copilot"
     plugin_json = json.loads(
         (copilot_root / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
@@ -322,14 +264,10 @@ def test_emits_plugin_manifest_mcp_config_and_hooks_for_copilot_cli(
     assert plugin_json["hooks"] == "./hooks.json"
     assert plugin_json["mcpServers"] == "./.mcp.json"
     assert plugin_json.get("commands") is None
-    mcp_json = json.loads(
-        (copilot_root / ".mcp.json").read_text(encoding="utf-8")
-    )
+    mcp_json = json.loads((copilot_root / ".mcp.json").read_text(encoding="utf-8"))
     assert "tilth" in mcp_json["mcpServers"]
     assert "context7" in mcp_json["mcpServers"]
-    hooks_json = json.loads(
-        (copilot_root / "hooks.json").read_text(encoding="utf-8")
-    )
+    hooks_json = json.loads((copilot_root / "hooks.json").read_text(encoding="utf-8"))
     assert hooks_json["version"] == 1
     assert "sessionStart" in hooks_json["hooks"]
 
@@ -349,19 +287,13 @@ def test_emits_hooks_from_hooks_json_source_into_each_non_cursor_harness(
     )
 
     asyncio.run(
-        compile_harness_bundles(
-            project_root=project_root, harnesses=["claude-code", "codex"]
-        )
+        compile_harness_bundles(project_root=project_root, harnesses=["claude-code", "codex"])
     )
-    claude_hooks = json.loads(
-        (project_root / ".claude" / "hooks.json").read_text(encoding="utf-8")
-    )
+    claude_hooks = json.loads((project_root / ".claude" / "hooks.json").read_text(encoding="utf-8"))
     assert "preToolUse" in claude_hooks["hooks"]
     assert "postToolUse" in claude_hooks["hooks"]
 
-    codex_hooks = json.loads(
-        (project_root / ".codex" / "hooks.json").read_text(encoding="utf-8")
-    )
+    codex_hooks = json.loads((project_root / ".codex" / "hooks.json").read_text(encoding="utf-8"))
     assert "PreToolUse" in codex_hooks["hooks"]
     assert "PostToolUse" in codex_hooks["hooks"]
 
@@ -385,13 +317,9 @@ def test_reads_plugin_metadata_from_dot_claude_plugin_when_present(
         json.dumps(custom_meta), encoding="utf-8"
     )
 
-    asyncio.run(
-        compile_harness_bundles(project_root=project_root, harnesses=["claude-code"])
-    )
+    asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["claude-code"]))
     plugin_json = json.loads(
-        (project_root / ".claude" / ".claude-plugin" / "plugin.json").read_text(
-            encoding="utf-8"
-        )
+        (project_root / ".claude" / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
     )
     assert plugin_json["name"] == "my-custom-plugin"
     assert plugin_json["homepage"] == "https://example.com"
@@ -405,22 +333,14 @@ def test_rethrows_non_enoent_errors_when_reading_plugin_metadata(
     plugin_dir = project_root / ".claude-plugin" / "plugin.json"
     plugin_dir.mkdir(parents=True)
     with pytest.raises((OSError, ValueError)):
-        asyncio.run(
-            compile_harness_bundles(
-                project_root=project_root, harnesses=["claude-code"]
-            )
-        )
+        asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["claude-code"]))
 
 
 def test_rethrows_non_enoent_errors_when_reading_hooks_json(tmp_path: Path) -> None:
     project_root = _stage_project(tmp_path)
     (project_root / "hooks.json").mkdir()
     with pytest.raises((OSError, ValueError)):
-        asyncio.run(
-            compile_harness_bundles(
-                project_root=project_root, harnesses=["claude-code"]
-            )
-        )
+        asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["claude-code"]))
 
 
 def test_preserves_user_managed_files_at_harness_output_root_across_rebuilds(
@@ -429,46 +349,23 @@ def test_preserves_user_managed_files_at_harness_output_root_across_rebuilds(
     project_root = _stage_project(tmp_path)
     claude_root = project_root / ".claude"
     claude_root.mkdir()
-    (claude_root / "settings.local.json").write_text(
-        '{"theme":"dark"}\n', encoding="utf-8"
-    )
+    (claude_root / "settings.local.json").write_text('{"theme":"dark"}\n', encoding="utf-8")
     (claude_root / "CLAUDE.md").write_text("# user notes\n", encoding="utf-8")
 
-    asyncio.run(
-        compile_harness_bundles(
-            project_root=project_root, harnesses=["claude-code"]
-        )
-    )
-    asyncio.run(
-        compile_harness_bundles(
-            project_root=project_root, harnesses=["claude-code"]
-        )
-    )
+    asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["claude-code"]))
+    asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["claude-code"]))
 
-    assert (
-        (claude_root / "settings.local.json").read_text(encoding="utf-8")
-        == '{"theme":"dark"}\n'
-    )
-    assert (
-        (claude_root / "CLAUDE.md").read_text(encoding="utf-8") == "# user notes\n"
-    )
+    assert (claude_root / "settings.local.json").read_text(encoding="utf-8") == '{"theme":"dark"}\n'
+    assert (claude_root / "CLAUDE.md").read_text(encoding="utf-8") == "# user notes\n"
 
 
 def test_removes_stale_generated_agents_on_rebuild(tmp_path: Path) -> None:
     project_root = _stage_project(tmp_path)
-    asyncio.run(
-        compile_harness_bundles(
-            project_root=project_root, harnesses=["claude-code"]
-        )
-    )
+    asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["claude-code"]))
     stale_agent_path = project_root / ".claude" / "agents" / "renamed-away.md"
     stale_agent_path.write_text("stale\n", encoding="utf-8")
 
-    asyncio.run(
-        compile_harness_bundles(
-            project_root=project_root, harnesses=["claude-code"]
-        )
-    )
+    asyncio.run(compile_harness_bundles(project_root=project_root, harnesses=["claude-code"]))
     assert not stale_agent_path.exists()
 
 

--- a/tests/python/test_compiler.py
+++ b/tests/python/test_compiler.py
@@ -1,0 +1,502 @@
+"""Port of `tests/compiler.test.ts` plus the US-004 byte-parity snapshot.
+
+The byte-parity snapshot fixture is the regression gate: ``basic-agent.md``
+and ``basic-skill/SKILL.md`` rendered for ``claude-code`` must match the
+checked-in fixtures byte-for-byte. Fixtures were captured from the TS
+pipeline at the cutover boundary so future drift is impossible to miss.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from cheese_flow.lib.compiler import (
+    compile_harness_bundle,
+    compile_harness_bundles,
+    preview_agent,
+    read_skill,
+)
+from cheese_flow.lib.frontmatter import parse_frontmatter
+from cheese_flow.lib.schemas import (
+    HarnessModel,
+    parse_agent_frontmatter,
+    parse_skill_frontmatter,
+    resolve_model,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "byte_parity"
+
+
+def _stage_project(tmp_path: Path) -> Path:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    shutil.copytree(REPO_ROOT / "agents", project_root / "agents")
+    shutil.copytree(REPO_ROOT / "skills", project_root / "skills")
+    return project_root
+
+
+def test_byte_parity_snapshot_basic_agent_claude_code(tmp_path: Path) -> None:
+    project_root = _stage_project(tmp_path)
+    asyncio.run(
+        compile_harness_bundles(
+            project_root=project_root, harnesses=["claude-code"]
+        )
+    )
+    actual = (project_root / ".claude" / "agents" / "basic-agent.md").read_text(
+        encoding="utf-8"
+    )
+    expected = (FIXTURE_DIR / "basic-agent.claude-code.md").read_text(
+        encoding="utf-8"
+    )
+    assert actual == expected, "basic-agent.md drifted from the byte-parity fixture"
+
+
+def test_byte_parity_snapshot_basic_skill_claude_code(tmp_path: Path) -> None:
+    project_root = _stage_project(tmp_path)
+    asyncio.run(
+        compile_harness_bundles(
+            project_root=project_root, harnesses=["claude-code"]
+        )
+    )
+    actual = (
+        project_root / ".claude" / "skills" / "basic-skill" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    expected = (FIXTURE_DIR / "basic-skill.claude-code.md").read_text(
+        encoding="utf-8"
+    )
+    assert actual == expected, "basic-skill SKILL.md drifted from the byte-parity fixture"
+
+
+def test_compiles_basic_agent_template_for_claude_code_and_codex(
+    tmp_path: Path,
+) -> None:
+    project_root = _stage_project(tmp_path)
+    outputs = asyncio.run(
+        compile_harness_bundles(
+            project_root=project_root, harnesses=["claude-code", "codex"]
+        )
+    )
+    assert len(outputs) == 2
+
+    claude_agent = (
+        project_root / ".claude" / "agents" / "basic-agent.md"
+    ).read_text(encoding="utf-8")
+    codex_agent = (
+        project_root / ".codex" / "agents" / "basic-agent.md"
+    ).read_text(encoding="utf-8")
+
+    claude_data, _ = parse_frontmatter(claude_agent)
+    codex_data, _ = parse_frontmatter(codex_agent)
+    assert claude_data["model"] == "sonnet"
+    assert codex_data["model"] == "gpt-5-codex"
+
+    claude_plugin = json.loads(
+        (project_root / ".claude" / ".claude-plugin" / "plugin.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert claude_plugin["name"] == "cheese-flow"
+    assert claude_plugin["agents"] == "./agents/"
+    assert claude_plugin["skills"] == "./skills/"
+    assert claude_plugin.get("commands") is None
+    assert claude_plugin["hooks"] == "./hooks.json"
+    assert claude_plugin["mcpServers"] == "./.mcp.json"
+
+    claude_mcp = json.loads(
+        (project_root / ".claude" / ".mcp.json").read_text(encoding="utf-8")
+    )
+    assert "tilth" in claude_mcp["mcpServers"]
+    assert "context7" in claude_mcp["mcpServers"]
+    assert "tavily" in claude_mcp["mcpServers"]
+    assert "serper" not in claude_mcp["mcpServers"]
+
+
+def test_compiles_a_single_harness_bundle_and_returns_metadata(tmp_path: Path) -> None:
+    project_root = _stage_project(tmp_path)
+    compiled = asyncio.run(
+        compile_harness_bundle(project_root=project_root, harness="claude-code")
+    )
+    assert compiled.harness == "claude-code"
+    assert compiled.outputRoot == str(project_root / ".claude")
+    assert compiled.pluginMetadata["name"] == "cheese-flow"
+    plugin_text = (
+        project_root / ".claude" / ".claude-plugin" / "plugin.json"
+    ).read_text(encoding="utf-8")
+    assert '"name": "cheese-flow"' in plugin_text
+
+
+def test_emits_agent_frontmatter_with_skills_binding_for_claude_code(
+    tmp_path: Path,
+) -> None:
+    project_root = _stage_project(tmp_path)
+    asyncio.run(
+        compile_harness_bundles(
+            project_root=project_root, harnesses=["claude-code"]
+        )
+    )
+    cook_agent = (project_root / ".claude" / "agents" / "cook.md").read_text(
+        encoding="utf-8"
+    )
+    data, _ = parse_frontmatter(cook_agent)
+    assert data["name"] == "cook"
+    assert data["model"] == "sonnet"
+    assert data["skills"] == ["cheez-read", "cheez-search", "cheez-write"]
+    assert data["color"] == "blue"
+    assert data["permissionMode"] == "acceptEdits"
+    assert "Required skills (prompt contract)" not in cook_agent
+
+
+def test_drops_claude_only_fields_and_appends_skills_prompt_contract_for_codex(
+    tmp_path: Path,
+) -> None:
+    project_root = _stage_project(tmp_path)
+    asyncio.run(
+        compile_harness_bundles(project_root=project_root, harnesses=["codex"])
+    )
+    cook_agent = (project_root / ".codex" / "agents" / "cook.md").read_text(
+        encoding="utf-8"
+    )
+    data, _ = parse_frontmatter(cook_agent)
+    assert data["name"] == "cook"
+    assert data["model"] == "gpt-5-codex"
+    assert "skills" not in data
+    assert "color" not in data
+    assert "permissionMode" not in data
+    assert "Required skills (prompt contract)" in cook_agent
+    assert "- cheez-read" in cook_agent
+    assert "- cheez-search" in cook_agent
+    assert "- cheez-write" in cook_agent
+
+
+def test_applies_models_yaml_pins_and_overrides(tmp_path: Path) -> None:
+    project_root = _stage_project(tmp_path)
+    (project_root / "models.yaml").write_text(
+        dedent(
+            """
+            pins:
+              claude-code:
+                sonnet: claude-sonnet-4-6
+            overrides:
+              basic-agent:
+                claude-code: claude-opus-4-7
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    asyncio.run(
+        compile_harness_bundles(
+            project_root=project_root, harnesses=["claude-code"]
+        )
+    )
+    cook_data, _ = parse_frontmatter(
+        (project_root / ".claude" / "agents" / "cook.md").read_text(encoding="utf-8")
+    )
+    assert cook_data["model"] == "claude-sonnet-4-6"
+    basic_data, _ = parse_frontmatter(
+        (project_root / ".claude" / "agents" / "basic-agent.md").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert basic_data["model"] == "claude-opus-4-7"
+
+
+def test_validates_the_shipped_skill_metadata() -> None:
+    skill = asyncio.run(read_skill(REPO_ROOT, "basic-skill"))
+    assert skill.name == "basic-skill"
+    assert "portable" in skill.description
+
+
+def test_renders_a_preview_from_the_template_source() -> None:
+    output = asyncio.run(preview_agent(REPO_ROOT, "basic-agent.md.eta", "claude-code"))
+    assert "Harness target: Claude Code" in output
+
+
+def test_rejects_skills_whose_folder_name_does_not_match_the_spec_name(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "project"
+    (project_root / "agents").mkdir(parents=True)
+    (project_root / "skills" / "wrong-name").mkdir(parents=True)
+    shutil.copyfile(
+        REPO_ROOT / "agents" / "basic-agent.md.eta",
+        project_root / "agents" / "basic-agent.md.eta",
+    )
+    (project_root / "skills" / "wrong-name" / "SKILL.md").write_text(
+        "---\nname: basic-skill\ndescription: Portable test skill\n---\n# Wrong\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="must match frontmatter name"):
+        asyncio.run(
+            compile_harness_bundles(
+                project_root=project_root, harnesses=["claude-code"]
+            )
+        )
+
+
+def test_ignores_non_template_agent_files_and_non_directory_skill_entries(
+    tmp_path: Path,
+) -> None:
+    project_root = _stage_project(tmp_path)
+    (project_root / "skills" / "nested-dir").mkdir()
+    (project_root / "agents" / "README.txt").write_text("ignore me\n", encoding="utf-8")
+    (project_root / "skills" / "notes.txt").write_text("ignore me\n", encoding="utf-8")
+    (project_root / "skills" / "nested-dir" / "SKILL.md").write_text(
+        "---\nname: nested-dir\ndescription: Another portable skill\n---\n# Nested\n",
+        encoding="utf-8",
+    )
+
+    asyncio.run(
+        compile_harness_bundles(
+            project_root=project_root, harnesses=["claude-code"]
+        )
+    )
+    manifest = json.loads(
+        (project_root / ".claude" / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert "basic-agent.md" in manifest["agents"]
+    assert "cook.md" in manifest["agents"]
+    assert "basic-skill" in manifest["skills"]
+    assert "nested-dir" in manifest["skills"]
+    assert manifest["commands"] == []
+
+
+def test_emits_dual_surface_artifacts_and_manifests_for_cursor(tmp_path: Path) -> None:
+    project_root = _stage_project(tmp_path)
+    asyncio.run(
+        compile_harness_bundles(project_root=project_root, harnesses=["cursor"])
+    )
+    cursor_root = project_root / ".cursor"
+    rule = (cursor_root / "rules" / "basic-skill.mdc").read_text(encoding="utf-8")
+    command = (cursor_root / "commands" / "basic-skill.md").read_text(
+        encoding="utf-8"
+    )
+    assert "alwaysApply: false" in rule
+    assert "description:" in rule
+    assert command  # non-empty
+    plugin_json = json.loads(
+        (cursor_root / ".cursor-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    assert plugin_json["name"] == "cheese-flow"
+    assert plugin_json["rules"] == "./rules/"
+    assert plugin_json["skills"] == "./skills/"
+    assert plugin_json["agents"] == "./agents/"
+    assert plugin_json["commands"] == "./commands/"
+    assert plugin_json.get("hooks") is None
+    assert plugin_json["mcpServers"] == "./mcp.json"
+    mcp_json = json.loads(
+        (cursor_root / "mcp.json").read_text(encoding="utf-8")
+    )
+    assert "tilth" in mcp_json["mcpServers"]
+    assert "context7" in mcp_json["mcpServers"]
+    assert "tavily" in mcp_json["mcpServers"]
+
+
+def test_emits_plugin_manifest_mcp_config_and_hooks_for_copilot_cli(
+    tmp_path: Path,
+) -> None:
+    project_root = _stage_project(tmp_path)
+    (project_root / "hooks.json").write_text(
+        json.dumps(
+            {"sessionStart": [{"type": "command", "command": "echo start"}]}
+        ),
+        encoding="utf-8",
+    )
+
+    asyncio.run(
+        compile_harness_bundles(project_root=project_root, harnesses=["copilot-cli"])
+    )
+    copilot_root = project_root / ".copilot"
+    plugin_json = json.loads(
+        (copilot_root / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    assert plugin_json["name"] == "cheese-flow"
+    assert plugin_json["category"] == "development"
+    assert plugin_json["agents"] == "./agents/"
+    assert plugin_json["skills"] == "./skills/"
+    assert plugin_json["hooks"] == "./hooks.json"
+    assert plugin_json["mcpServers"] == "./.mcp.json"
+    assert plugin_json.get("commands") is None
+    mcp_json = json.loads(
+        (copilot_root / ".mcp.json").read_text(encoding="utf-8")
+    )
+    assert "tilth" in mcp_json["mcpServers"]
+    assert "context7" in mcp_json["mcpServers"]
+    hooks_json = json.loads(
+        (copilot_root / "hooks.json").read_text(encoding="utf-8")
+    )
+    assert hooks_json["version"] == 1
+    assert "sessionStart" in hooks_json["hooks"]
+
+
+def test_emits_hooks_from_hooks_json_source_into_each_non_cursor_harness(
+    tmp_path: Path,
+) -> None:
+    project_root = _stage_project(tmp_path)
+    (project_root / "hooks.json").write_text(
+        json.dumps(
+            {
+                "preToolUse": [{"type": "command", "command": "echo pre"}],
+                "postToolUse": [{"type": "command", "command": "echo post"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    asyncio.run(
+        compile_harness_bundles(
+            project_root=project_root, harnesses=["claude-code", "codex"]
+        )
+    )
+    claude_hooks = json.loads(
+        (project_root / ".claude" / "hooks.json").read_text(encoding="utf-8")
+    )
+    assert "preToolUse" in claude_hooks["hooks"]
+    assert "postToolUse" in claude_hooks["hooks"]
+
+    codex_hooks = json.loads(
+        (project_root / ".codex" / "hooks.json").read_text(encoding="utf-8")
+    )
+    assert "PreToolUse" in codex_hooks["hooks"]
+    assert "PostToolUse" in codex_hooks["hooks"]
+
+
+def test_reads_plugin_metadata_from_dot_claude_plugin_when_present(
+    tmp_path: Path,
+) -> None:
+    project_root = _stage_project(tmp_path)
+    (project_root / ".claude-plugin").mkdir()
+    custom_meta = {
+        "name": "my-custom-plugin",
+        "version": "2.0.0",
+        "description": "Custom plugin description.",
+        "author": {"name": "Test Author"},
+        "license": "Apache-2.0",
+        "repository": "https://github.com/test/repo",
+        "homepage": "https://example.com",
+        "keywords": ["test", "plugin"],
+    }
+    (project_root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps(custom_meta), encoding="utf-8"
+    )
+
+    asyncio.run(
+        compile_harness_bundles(project_root=project_root, harnesses=["claude-code"])
+    )
+    plugin_json = json.loads(
+        (project_root / ".claude" / ".claude-plugin" / "plugin.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert plugin_json["name"] == "my-custom-plugin"
+    assert plugin_json["homepage"] == "https://example.com"
+    assert plugin_json["keywords"] == ["test", "plugin"]
+
+
+def test_rethrows_non_enoent_errors_when_reading_plugin_metadata(
+    tmp_path: Path,
+) -> None:
+    project_root = _stage_project(tmp_path)
+    plugin_dir = project_root / ".claude-plugin" / "plugin.json"
+    plugin_dir.mkdir(parents=True)
+    with pytest.raises((OSError, ValueError)):
+        asyncio.run(
+            compile_harness_bundles(
+                project_root=project_root, harnesses=["claude-code"]
+            )
+        )
+
+
+def test_rethrows_non_enoent_errors_when_reading_hooks_json(tmp_path: Path) -> None:
+    project_root = _stage_project(tmp_path)
+    (project_root / "hooks.json").mkdir()
+    with pytest.raises((OSError, ValueError)):
+        asyncio.run(
+            compile_harness_bundles(
+                project_root=project_root, harnesses=["claude-code"]
+            )
+        )
+
+
+def test_preserves_user_managed_files_at_harness_output_root_across_rebuilds(
+    tmp_path: Path,
+) -> None:
+    project_root = _stage_project(tmp_path)
+    claude_root = project_root / ".claude"
+    claude_root.mkdir()
+    (claude_root / "settings.local.json").write_text(
+        '{"theme":"dark"}\n', encoding="utf-8"
+    )
+    (claude_root / "CLAUDE.md").write_text("# user notes\n", encoding="utf-8")
+
+    asyncio.run(
+        compile_harness_bundles(
+            project_root=project_root, harnesses=["claude-code"]
+        )
+    )
+    asyncio.run(
+        compile_harness_bundles(
+            project_root=project_root, harnesses=["claude-code"]
+        )
+    )
+
+    assert (
+        (claude_root / "settings.local.json").read_text(encoding="utf-8")
+        == '{"theme":"dark"}\n'
+    )
+    assert (
+        (claude_root / "CLAUDE.md").read_text(encoding="utf-8") == "# user notes\n"
+    )
+
+
+def test_removes_stale_generated_agents_on_rebuild(tmp_path: Path) -> None:
+    project_root = _stage_project(tmp_path)
+    asyncio.run(
+        compile_harness_bundles(
+            project_root=project_root, harnesses=["claude-code"]
+        )
+    )
+    stale_agent_path = project_root / ".claude" / "agents" / "renamed-away.md"
+    stale_agent_path.write_text("stale\n", encoding="utf-8")
+
+    asyncio.run(
+        compile_harness_bundles(
+            project_root=project_root, harnesses=["claude-code"]
+        )
+    )
+    assert not stale_agent_path.exists()
+
+
+def test_parses_frontmatter_and_falls_back_to_default_model_when_needed() -> None:
+    parsed_data, parsed_body = parse_frontmatter(
+        "---\nname: example\ndescription: Parser test\n---\n# Body\n"
+    )
+    assert parsed_data["name"] == "example"
+    assert parsed_body.strip() == "# Body"
+
+    models = HarnessModel.model_validate({"default": "gpt-5.1-codex"})
+    assert resolve_model(models, "claude-code") == "gpt-5.1-codex"
+
+
+def test_validates_allowed_tool_field_variants_for_skills_and_default_tools_for_agents() -> None:
+    skill = parse_skill_frontmatter(
+        {
+            "name": "basic-skill",
+            "description": "Portable skill",
+            "allowed-tools": "read write",
+        }
+    )
+    agent = parse_agent_frontmatter(
+        {
+            "name": "basic-agent",
+            "description": "Portable agent",
+            "models": {"default": "gpt-5.1-codex"},
+        }
+    )
+    assert skill.model_dump(by_alias=True)["allowed-tools"] == "read write"
+    assert agent.tools == []

--- a/tests/python/test_frontmatter.py
+++ b/tests/python/test_frontmatter.py
@@ -1,0 +1,37 @@
+"""Verbatim port of `tests/frontmatter.test.ts`."""
+
+from __future__ import annotations
+
+import pytest
+from cheese_flow.lib.frontmatter import parse_frontmatter
+
+
+def test_parses_valid_frontmatter_and_body() -> None:
+    content = "---\nname: cheddar\nage: 12\n---\nbody text\n"
+    data, body = parse_frontmatter(content)
+    assert data == {"name": "cheddar", "age": 12}
+    assert body == "body text\n"
+
+
+def test_handles_windows_crlf_line_endings() -> None:
+    content = "---\r\nname: gouda\r\n---\r\nbody\r\n"
+    data, body = parse_frontmatter(content)
+    assert data == {"name": "gouda"}
+    assert body == "body\r\n"
+
+
+def test_returns_an_empty_object_when_frontmatter_is_empty() -> None:
+    content = "---\n\n---\nbody only\n"
+    data, body = parse_frontmatter(content)
+    assert data == {}
+    assert body == "body only\n"
+
+
+def test_throws_when_frontmatter_delimiters_are_missing() -> None:
+    with pytest.raises(ValueError, match="Expected YAML frontmatter"):
+        parse_frontmatter("no markers here")
+
+
+def test_throws_when_yaml_inside_frontmatter_is_invalid() -> None:
+    with pytest.raises(ValueError):
+        parse_frontmatter("---\nname: : broken\n---\nbody\n")

--- a/tests/python/test_model_manifest.py
+++ b/tests/python/test_model_manifest.py
@@ -80,9 +80,7 @@ def test_returns_input_model_when_manifest_is_none() -> None:
 
 
 def test_returns_input_model_when_no_pin_or_override_matches() -> None:
-    manifest = ModelManifest.model_validate(
-        {"pins": {"codex": {"gpt-5-codex": "gpt-5.3-codex"}}}
-    )
+    manifest = ModelManifest.model_validate({"pins": {"codex": {"gpt-5-codex": "gpt-5.3-codex"}}})
     assert apply_model_manifest(**_BASE_INPUT, manifest=manifest) == "sonnet"  # type: ignore[arg-type]
 
 

--- a/tests/python/test_model_manifest.py
+++ b/tests/python/test_model_manifest.py
@@ -1,0 +1,121 @@
+"""Verbatim port of `tests/model-manifest.test.ts`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cheese_flow.lib.model_manifest import (
+    ModelManifest,
+    apply_model_manifest,
+    read_model_manifest,
+)
+
+
+def test_returns_none_when_models_yaml_is_absent(tmp_path: Path) -> None:
+    assert read_model_manifest(tmp_path) is None
+
+
+def test_parses_pins_and_overrides(tmp_path: Path) -> None:
+    (tmp_path / "models.yaml").write_text(
+        "\n".join(
+            [
+                "pins:",
+                "  claude-code:",
+                "    sonnet: claude-sonnet-4-6",
+                "    opus: claude-opus-4-7",
+                "  codex:",
+                "    gpt-5-codex: gpt-5.3-codex",
+                "overrides:",
+                "  age-correctness:",
+                "    claude-code: claude-opus-4-7",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    manifest = read_model_manifest(tmp_path)
+    assert manifest is not None
+    assert manifest.pins is not None
+    assert manifest.pins.get("claude-code") == {
+        "sonnet": "claude-sonnet-4-6",
+        "opus": "claude-opus-4-7",
+    }
+    assert manifest.pins.get("codex") == {"gpt-5-codex": "gpt-5.3-codex"}
+    assert manifest.overrides is not None
+    assert manifest.overrides["age-correctness"].get("claude-code") == "claude-opus-4-7"
+
+
+def test_rejects_unknown_harness_keys_via_strict_schema(tmp_path: Path) -> None:
+    (tmp_path / "models.yaml").write_text(
+        "pins:\n  qwen-code:\n    sonnet: foo\n", encoding="utf-8"
+    )
+    with pytest.raises(ValueError):
+        read_model_manifest(tmp_path)
+
+
+def test_treats_an_empty_file_as_an_empty_manifest(tmp_path: Path) -> None:
+    (tmp_path / "models.yaml").write_text("", encoding="utf-8")
+    manifest = read_model_manifest(tmp_path)
+    assert manifest is not None
+    assert manifest.pins is None
+    assert manifest.overrides is None
+
+
+def test_propagates_non_enoent_read_errors(tmp_path: Path) -> None:
+    (tmp_path / "models.yaml").mkdir()
+    with pytest.raises((ValueError, IsADirectoryError, PermissionError)):
+        read_model_manifest(tmp_path)
+
+
+_BASE_INPUT = {
+    "model": "sonnet",
+    "agent_name": "age-correctness",
+    "harness": "claude-code",
+}
+
+
+def test_returns_input_model_when_manifest_is_none() -> None:
+    assert apply_model_manifest(**_BASE_INPUT, manifest=None) == "sonnet"  # type: ignore[arg-type]
+
+
+def test_returns_input_model_when_no_pin_or_override_matches() -> None:
+    manifest = ModelManifest.model_validate(
+        {"pins": {"codex": {"gpt-5-codex": "gpt-5.3-codex"}}}
+    )
+    assert apply_model_manifest(**_BASE_INPUT, manifest=manifest) == "sonnet"  # type: ignore[arg-type]
+
+
+def test_substitutes_pinned_version_when_alias_matches_harness_pin() -> None:
+    manifest = ModelManifest.model_validate(
+        {"pins": {"claude-code": {"sonnet": "claude-sonnet-4-6"}}}
+    )
+    assert (
+        apply_model_manifest(**_BASE_INPUT, manifest=manifest)  # type: ignore[arg-type]
+        == "claude-sonnet-4-6"
+    )
+
+
+def test_uses_override_that_supersedes_any_matching_pin() -> None:
+    manifest = ModelManifest.model_validate(
+        {
+            "pins": {"claude-code": {"sonnet": "claude-sonnet-4-6"}},
+            "overrides": {"age-correctness": {"claude-code": "claude-opus-4-7"}},
+        }
+    )
+    assert (
+        apply_model_manifest(**_BASE_INPUT, manifest=manifest)  # type: ignore[arg-type]
+        == "claude-opus-4-7"
+    )
+
+
+def test_ignores_overrides_for_a_different_agent() -> None:
+    manifest = ModelManifest.model_validate(
+        {"overrides": {"age-security": {"claude-code": "claude-opus-4-7"}}}
+    )
+    assert apply_model_manifest(**_BASE_INPUT, manifest=manifest) == "sonnet"  # type: ignore[arg-type]
+
+
+def test_ignores_pins_for_a_different_harness() -> None:
+    manifest = ModelManifest.model_validate({"pins": {"codex": {"sonnet": "gpt-5.5"}}})
+    assert apply_model_manifest(**_BASE_INPUT, manifest=manifest) == "sonnet"  # type: ignore[arg-type]


### PR DESCRIPTION
Ports the compile slice from `src/lib/{compiler,emit,frontmatter,capabilities,model-manifest}.ts`
to `python/cheese_flow/lib/`, plus the cursor `emit_surface` callback that
depends on the new frontmatter parser.

- Eta → Jinja2 syntax conversion: `<%= %>` → `{{ }}`, `<% }) %>` →
  `{% endfor %}`, `<% xs.forEach(function (v) { %>` → `{% for v in xs %}`.
  Templates aren't rewritten on disk; the Python compiler preprocesses
  `.eta` source into Jinja syntax at render time so TS and Python read
  the same template files.
- `Promise.all` → `asyncio.gather` for the cleanup phase (no async
  redesign per decision).
- Hand-rolled YAML emitter mirroring Node `yaml@2`'s `foldFlowLines`
  algorithm (lineWidth=80, indent=2, indent_at_start awareness) so
  rendered frontmatter matches byte-for-byte. `ruamel.yaml`'s wrap
  algorithm wraps differently; reimplementing the subset we use kept
  the snapshot fixture green.
- `parse_frontmatter` appends a trailing newline before handing input
  to ruamel.yaml so `>` folded scalars retain the clip-chomp `\n`
  (matches Node yaml's parsing of cursor rule `description` fields).
- Adapters: `CLAUDE_AGENT_KEYS` becomes an ordered tuple
  (`CLAUDE_AGENT_KEY_ORDER`) plus a `frozenset` view for capability
  membership checks. Iteration order now matches the TS `Set` so
  `cook.md` and friends render with `permissionMode` / `color` in the
  same positions.
- Cursor `emit_surface` wired alongside `parse_frontmatter`.

Tests: ports `tests/frontmatter.test.ts`, `tests/model-manifest.test.ts`,
the lib portion of `tests/capabilities.test.ts`, and the agent-rendering
half of `tests/compiler.test.ts` to pytest. Adds the US-004 byte-parity
snapshot fixtures (`basic-agent` + `basic-skill` for claude-code) under
`tests/python/fixtures/byte_parity/` as the regression gate.

Co-authored-by: Ralphify <noreply@ralphify.co>