### PR TITLE
feat(migration): US-005 install-plan (TS → Python)

### DIFF
--- a/python/cheese_flow/lib/harness_detection.py
+++ b/python/cheese_flow/lib/harness_detection.py
@@ -1,0 +1,222 @@
+"""Port of `src/lib/harness-detection.ts` — environment detection for harnesses.
+
+Mirrors the TS surface: `find_command_on_path`, `has_directory`,
+`detect_available_harnesses`, `get_harness_install_capability`. Async signatures
+match the TS module so `Promise.all` translates to `asyncio.gather` per
+decision 6 (no async redesign).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TypedDict
+
+from cheese_flow.adapters import HARNESS_ADAPTERS, HARNESS_NAMES
+from cheese_flow.lib.harness import HarnessName
+
+HarnessInstallCapability = Literal["auto-install", "manual-capable", "unsupported"]
+HarnessDetectionState = Literal["detected", "not-detected", "bypassed"]
+HarnessDetectionKind = Literal["cli", "surface"]
+
+
+class _HarnessDetectionRequired(TypedDict):
+    state: HarnessDetectionState
+    reason: str
+
+
+class HarnessDetection(_HarnessDetectionRequired, total=False):
+    kind: HarnessDetectionKind
+    value: str
+
+
+@dataclass(frozen=True)
+class HarnessDetectionEnvironment:
+    """Override hooks for filesystem/PATH probes (used by tests)."""
+
+    findCommand: Callable[[str], Awaitable[str | None]] | None = None
+    hasDirectory: Callable[[str], Awaitable[bool]] | None = None
+
+
+@dataclass(frozen=True)
+class _CliProbe:
+    command: str
+    kind: Literal["cli"] = "cli"
+
+
+@dataclass(frozen=True)
+class _SurfaceProbe:
+    relativePath: str
+    kind: Literal["surface"] = "surface"
+
+
+_HarnessDetectionProbe = _CliProbe | _SurfaceProbe
+
+
+@dataclass(frozen=True)
+class _HarnessInstallProfile:
+    capability: HarnessInstallCapability
+    probes: tuple[_HarnessDetectionProbe, ...]
+
+
+_HARNESS_INSTALL_PROFILES: dict[HarnessName, _HarnessInstallProfile] = {
+    "claude-code": _HarnessInstallProfile(
+        capability="manual-capable",
+        probes=(_CliProbe(command="claude"),),
+    ),
+    "codex": _HarnessInstallProfile(
+        capability="manual-capable",
+        probes=(_CliProbe(command="codex"),),
+    ),
+    "cursor": _HarnessInstallProfile(
+        capability="auto-install",
+        probes=(_SurfaceProbe(relativePath=".cursor"),),
+    ),
+    "copilot-cli": _HarnessInstallProfile(
+        capability="auto-install",
+        probes=(_CliProbe(command="copilot"),),
+    ),
+}
+
+
+def get_harness_install_capability(harness: HarnessName) -> HarnessInstallCapability:
+    return _HARNESS_INSTALL_PROFILES[harness].capability
+
+
+async def find_command_on_path(
+    command: str,
+    search_path: str | None = None,
+) -> str | None:
+    """Locate an executable on PATH. Returns the absolute path or `None`."""
+
+    if search_path is not None:
+        resolved_search_path = search_path
+    else:
+        resolved_search_path = os.environ.get("PATH") or os.environ.get("Path") or ""  # noqa: SIM112
+    directories = [d for d in resolved_search_path.split(os.pathsep) if d]
+    extensions = _path_extensions() if sys.platform == "win32" else [""]
+
+    for directory in directories:
+        for extension in extensions:
+            candidate = Path(directory) / _with_extension(command, extension)
+            if await asyncio.to_thread(_is_executable, candidate):
+                return str(candidate)
+
+    return None
+
+
+async def has_directory(directory_path: str) -> bool:
+    return await asyncio.to_thread(Path(directory_path).is_dir)
+
+
+async def detect_available_harnesses(
+    *,
+    project_root: str,
+    environment: HarnessDetectionEnvironment | None = None,
+) -> dict[HarnessName, HarnessDetection]:
+    find_command = (
+        environment.findCommand
+        if environment is not None and environment.findCommand is not None
+        else find_command_on_path
+    )
+    check_directory = (
+        environment.hasDirectory
+        if environment is not None and environment.hasDirectory is not None
+        else has_directory
+    )
+
+    detections = await asyncio.gather(
+        *[
+            _detect_harness(
+                harness=harness,
+                project_root=project_root,
+                find_command=find_command,
+                has_directory=check_directory,
+            )
+            for harness in HARNESS_NAMES
+        ]
+    )
+
+    return dict(zip(HARNESS_NAMES, detections, strict=True))
+
+
+async def _detect_harness(
+    *,
+    harness: HarnessName,
+    project_root: str,
+    find_command: Callable[[str], Awaitable[str | None]],
+    has_directory: Callable[[str], Awaitable[bool]],
+) -> HarnessDetection:
+    display_name = HARNESS_ADAPTERS[harness].displayName
+    profile = _HARNESS_INSTALL_PROFILES[harness]
+
+    for probe in profile.probes:
+        if isinstance(probe, _CliProbe):
+            command_path = await find_command(probe.command)
+            if command_path is not None:
+                return {
+                    "state": "detected",
+                    "kind": "cli",
+                    "value": command_path,
+                    "reason": f'Auto-detected {display_name} via CLI "{probe.command}".',
+                }
+            continue
+
+        directory_path = str(Path(project_root) / probe.relativePath)
+        if await has_directory(directory_path):
+            return {
+                "state": "detected",
+                "kind": "surface",
+                "value": directory_path,
+                "reason": f"Auto-detected {display_name} via {probe.relativePath}/.",
+            }
+
+    return {
+        "state": "not-detected",
+        "reason": f"No {display_name} {_describe_probes(profile.probes)} detected.",
+    }
+
+
+def _describe_probes(probes: tuple[_HarnessDetectionProbe, ...]) -> str:
+    return " or ".join(_describe_probe(probe) for probe in probes)
+
+
+def _describe_probe(probe: _HarnessDetectionProbe) -> str:
+    if isinstance(probe, _CliProbe):
+        return f'CLI "{probe.command}" on PATH'
+    return f'project surface "{probe.relativePath}"'
+
+
+def _is_executable(candidate: Path) -> bool:
+    try:
+        return candidate.is_file() and os.access(candidate, os.X_OK)
+    except OSError:
+        return False
+
+
+def _path_extensions() -> list[str]:
+    configured = os.environ.get("PATHEXT", ".EXE;.CMD;.BAT;.COM")
+    return [ext for ext in configured.split(";") if ext]
+
+
+def _with_extension(command: str, extension: str) -> str:
+    if extension and command.lower().endswith(extension.lower()):
+        return command
+    return f"{command}{extension}"
+
+
+__all__ = [
+    "HarnessDetection",
+    "HarnessDetectionEnvironment",
+    "HarnessDetectionKind",
+    "HarnessDetectionState",
+    "HarnessInstallCapability",
+    "detect_available_harnesses",
+    "find_command_on_path",
+    "get_harness_install_capability",
+    "has_directory",
+]

--- a/python/cheese_flow/lib/install_plan.py
+++ b/python/cheese_flow/lib/install_plan.py
@@ -1,0 +1,208 @@
+"""Port of `src/lib/install-plan.ts` — harness install plan construction.
+
+Builds a typed plan describing which harnesses to install (auto-detect vs.
+explicit `--harness` overrides), with per-harness selection status and reason.
+The TS module re-exports a slice of `harness_detection` for installer
+consumers; this module mirrors that surface so US-008's installer port has the
+same imports it expects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, TypedDict
+
+from cheese_flow.adapters import HARNESS_ADAPTERS, HARNESS_NAMES
+from cheese_flow.lib.harness import HarnessName
+from cheese_flow.lib.harness_detection import (
+    HarnessDetection,
+    HarnessDetectionEnvironment,
+    HarnessDetectionKind,
+    HarnessDetectionState,
+    HarnessInstallCapability,
+    detect_available_harnesses,
+    find_command_on_path,
+    get_harness_install_capability,
+    has_directory,
+)
+
+HarnessSelectionMode = Literal["auto-detect", "explicit"]
+HarnessSelectionStatus = Literal["selected", "skipped"]
+
+
+class HarnessInstallPlanEntry(TypedDict):
+    harness: HarnessName
+    displayName: str
+    outputRoot: str
+    selection: HarnessSelectionStatus
+    capability: HarnessInstallCapability
+    detection: HarnessDetection
+    reason: str
+
+
+class _HarnessInstallPlanRequired(TypedDict):
+    selectionMode: HarnessSelectionMode
+    requestedHarnesses: list[HarnessName]
+    selectedHarnesses: list[HarnessName]
+    entries: list[HarnessInstallPlanEntry]
+    ok: bool
+
+
+class HarnessInstallPlan(_HarnessInstallPlanRequired, total=False):
+    guidance: str
+
+
+@dataclass(frozen=True)
+class _BuildPlanEntryOptions:
+    harness: HarnessName
+    selection: HarnessSelectionStatus
+    detection: HarnessDetection
+
+
+def parse_harness_name(value: str) -> HarnessName:
+    trimmed = value.strip()
+    if trimmed in HARNESS_NAMES:
+        return trimmed  # type: ignore[return-value]
+
+    raise ValueError(
+        f'Unsupported harness "{trimmed}". Expected one of: {", ".join(HARNESS_NAMES)}.'
+    )
+
+
+def dedupe_harness_names(harnesses: list[HarnessName]) -> list[HarnessName]:
+    seen: set[HarnessName] = set()
+    result: list[HarnessName] = []
+    for harness in harnesses:
+        if harness in seen:
+            continue
+        seen.add(harness)
+        result.append(harness)
+    return result
+
+
+def parse_harness_overrides(values: list[str]) -> list[HarnessName]:
+    flattened: list[HarnessName] = []
+    for value in values:
+        for piece in value.split(","):
+            flattened.append(parse_harness_name(piece))
+    return dedupe_harness_names(flattened)
+
+
+async def create_harness_install_plan(
+    *,
+    project_root: str,
+    environment: HarnessDetectionEnvironment | None = None,
+    requested_harnesses: list[HarnessName] | None = None,
+) -> HarnessInstallPlan:
+    requested = dedupe_harness_names(list(requested_harnesses or []))
+    if len(requested) > 0:
+        return _build_explicit_install_plan(requested)
+
+    detections = await detect_available_harnesses(
+        project_root=project_root, environment=environment
+    )
+    return _build_auto_detect_install_plan(detections, requested)
+
+
+def _build_explicit_install_plan(
+    requested_harnesses: list[HarnessName],
+) -> HarnessInstallPlan:
+    requested_set = set(requested_harnesses)
+    return {
+        "selectionMode": "explicit",
+        "requestedHarnesses": requested_harnesses,
+        "selectedHarnesses": list(requested_harnesses),
+        "ok": True,
+        "entries": [
+            _build_plan_entry(
+                _BuildPlanEntryOptions(
+                    harness=harness,
+                    selection="selected" if harness in requested_set else "skipped",
+                    detection={
+                        "state": "bypassed",
+                        "reason": "Skipped auto-detect because --harness was provided.",
+                    },
+                )
+            )
+            for harness in HARNESS_NAMES
+        ],
+    }
+
+
+def _build_auto_detect_install_plan(
+    detections: dict[HarnessName, HarnessDetection],
+    requested_harnesses: list[HarnessName],
+) -> HarnessInstallPlan:
+    selected_harnesses: list[HarnessName] = [
+        harness for harness in HARNESS_NAMES if detections[harness]["state"] == "detected"
+    ]
+    entries: list[HarnessInstallPlanEntry] = [
+        _build_plan_entry(
+            _BuildPlanEntryOptions(
+                harness=harness,
+                selection="selected"
+                if detections[harness]["state"] == "detected"
+                else "skipped",
+                detection=detections[harness],
+            )
+        )
+        for harness in HARNESS_NAMES
+    ]
+    plan: HarnessInstallPlan = {
+        "selectionMode": "auto-detect",
+        "requestedHarnesses": requested_harnesses,
+        "selectedHarnesses": selected_harnesses,
+        "ok": len(selected_harnesses) > 0,
+        "entries": entries,
+    }
+    if len(selected_harnesses) == 0:
+        plan["guidance"] = (
+            'No installed harnesses detected. Re-run with --harness <name> or use "cheese compile".'
+        )
+    return plan
+
+
+def _build_plan_entry(options: _BuildPlanEntryOptions) -> HarnessInstallPlanEntry:
+    adapter = HARNESS_ADAPTERS[options.harness]
+    selected_reason = (
+        "Selected explicitly via --harness."
+        if options.detection["state"] == "bypassed"
+        else options.detection["reason"]
+    )
+
+    if options.selection == "selected":
+        reason = selected_reason
+    elif options.detection["state"] == "bypassed":
+        reason = "Skipped because it was not requested via --harness."
+    else:
+        reason = options.detection["reason"]
+
+    return {
+        "harness": options.harness,
+        "displayName": adapter.displayName,
+        "outputRoot": adapter.outputRoot,
+        "selection": options.selection,
+        "capability": get_harness_install_capability(options.harness),
+        "detection": options.detection,
+        "reason": reason,
+    }
+
+
+__all__ = [
+    "HarnessDetection",
+    "HarnessDetectionEnvironment",
+    "HarnessDetectionKind",
+    "HarnessDetectionState",
+    "HarnessInstallCapability",
+    "HarnessInstallPlan",
+    "HarnessInstallPlanEntry",
+    "HarnessSelectionMode",
+    "HarnessSelectionStatus",
+    "create_harness_install_plan",
+    "dedupe_harness_names",
+    "detect_available_harnesses",
+    "find_command_on_path",
+    "has_directory",
+    "parse_harness_name",
+    "parse_harness_overrides",
+]

--- a/python/cheese_flow/lib/install_plan.py
+++ b/python/cheese_flow/lib/install_plan.py
@@ -140,9 +140,7 @@ def _build_auto_detect_install_plan(
         _build_plan_entry(
             _BuildPlanEntryOptions(
                 harness=harness,
-                selection="selected"
-                if detections[harness]["state"] == "detected"
-                else "skipped",
+                selection="selected" if detections[harness]["state"] == "detected" else "skipped",
                 detection=detections[harness],
             )
         )

--- a/ralphs/python-migration/TODO.md
+++ b/ralphs/python-migration/TODO.md
@@ -10,7 +10,7 @@ US-005 (install-plan), US-006 (harness-detection), and US-007 (harness-compat).
 - [x] US-002 — Port `src/lib/schemas.ts` → `python/cheese_flow/lib/schemas.py` (Pydantic v2, `extra="forbid"`, all 9 schemas + discriminated unions); port matching vitest cases verbatim
 - [x] US-003 — Port `src/adapters/{claude-code,codex,cursor,copilot-cli,_shared,index}.ts` → `python/cheese_flow/adapters/`; preserve registry shape; port adapter vitest cases
 - [x] US-004 — Port compile pipeline: `compiler.ts` + `emit.ts` + `frontmatter.ts` + `capabilities.ts` + `model-manifest.ts` → `python/cheese_flow/lib/`; Eta `<%= %>` / `<% %>` → Jinja2 `{{ }}` / `{% %}`; `Promise.all` → `asyncio.gather`; commit a byte-parity snapshot fixture for one agent + one skill
-- [ ] US-005 — Port `src/lib/install-plan.ts` → `python/cheese_flow/lib/install_plan.py`; port `tests/install-plan.test.ts`
+- [x] US-005 — Port `src/lib/install-plan.ts` → `python/cheese_flow/lib/install_plan.py`; port `tests/install-plan.test.ts`
 - [ ] US-006 — Port `src/lib/harness-detection.ts` → `python/cheese_flow/lib/harness_detection.py`; port `tests/harness-detection.test.ts`
 - [ ] US-007 — Port `src/lib/harness-compat.ts` → `python/cheese_flow/lib/harness_compat.py`; port `tests/harness-compat.test.ts`
 - [ ] US-008 — Port `src/lib/installer.ts` → `python/cheese_flow/lib/installer.py`; depends on US-005/006/007; port `tests/installer.test.ts`

--- a/tests/python/test_install_plan.py
+++ b/tests/python/test_install_plan.py
@@ -1,0 +1,170 @@
+"""Verbatim port of `tests/install-plan.test.ts`.
+
+The TS test surface uses async closures over `Set<string>` to mock the
+filesystem/PATH probes. Python keeps the async signatures so the tests use
+`asyncio.run` per the convention established in `test_compiler.py`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from cheese_flow.lib.harness_detection import HarnessDetectionEnvironment
+from cheese_flow.lib.install_plan import (
+    HarnessInstallPlan,
+    HarnessInstallPlanEntry,
+    create_harness_install_plan,
+    find_command_on_path,
+    has_directory,
+    parse_harness_overrides,
+)
+
+
+def _make_environment(
+    *,
+    commands: list[str] | None = None,
+    surfaces: list[str] | None = None,
+) -> HarnessDetectionEnvironment:
+    command_set = set(commands or [])
+    surface_set = set(surfaces or [])
+
+    async def find_command(command: str) -> str | None:
+        if command in command_set:
+            return str(Path("/mock/bin") / command)
+        return None
+
+    async def check_directory(directory_path: str) -> bool:
+        return directory_path in surface_set
+
+    return HarnessDetectionEnvironment(findCommand=find_command, hasDirectory=check_directory)
+
+
+def _get_entry(plan: HarnessInstallPlan, harness: str) -> HarnessInstallPlanEntry:
+    for candidate in plan["entries"]:
+        if candidate["harness"] == harness:
+            return candidate
+    raise AssertionError(f"Missing plan entry for {harness}")
+
+
+def test_find_command_on_path_finds_commands_already_on_path() -> None:
+    result = asyncio.run(find_command_on_path("node"))
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+def test_has_directory_detects_directories_on_disk() -> None:
+    src_path = str(Path("src").resolve())
+    missing_path = str(Path("missing-install-plan-directory").resolve())
+    assert asyncio.run(has_directory(src_path)) is True
+    assert asyncio.run(has_directory(missing_path)) is False
+
+
+def test_create_plan_auto_detects_a_single_manual_capable_harness_from_its_cli() -> None:
+    plan = asyncio.run(
+        create_harness_install_plan(
+            project_root="/workspace",
+            environment=_make_environment(commands=["claude"]),
+        )
+    )
+
+    assert plan["selectionMode"] == "auto-detect"
+    assert plan["ok"] is True
+    assert plan["selectedHarnesses"] == ["claude-code"]
+
+    claude_entry = _get_entry(plan, "claude-code")
+    assert claude_entry["selection"] == "selected"
+    assert claude_entry["capability"] == "manual-capable"
+    assert claude_entry["detection"] == {
+        "state": "detected",
+        "kind": "cli",
+        "value": str(Path("/mock/bin") / "claude"),
+        "reason": claude_entry["detection"]["reason"],
+    }
+    assert _get_entry(plan, "codex")["selection"] == "skipped"
+
+
+def test_create_plan_auto_detects_multiple_harnesses_from_cli_and_project_surfaces() -> None:
+    project_root = "/workspace"
+    plan = asyncio.run(
+        create_harness_install_plan(
+            project_root=project_root,
+            environment=_make_environment(
+                commands=["copilot"],
+                surfaces=[str(Path(project_root) / ".cursor")],
+            ),
+        )
+    )
+
+    assert plan["selectionMode"] == "auto-detect"
+    assert plan["ok"] is True
+    assert plan["selectedHarnesses"] == ["cursor", "copilot-cli"]
+
+    cursor_entry = _get_entry(plan, "cursor")
+    assert cursor_entry["selection"] == "selected"
+    assert cursor_entry["capability"] == "auto-install"
+    assert cursor_entry["detection"]["state"] == "detected"
+    assert cursor_entry["detection"]["kind"] == "surface"
+    assert cursor_entry["detection"]["value"] == str(Path(project_root) / ".cursor")
+
+    copilot_entry = _get_entry(plan, "copilot-cli")
+    assert copilot_entry["selection"] == "selected"
+    assert copilot_entry["capability"] == "auto-install"
+    assert copilot_entry["detection"]["state"] == "detected"
+    assert copilot_entry["detection"]["kind"] == "cli"
+    assert copilot_entry["detection"]["value"] == str(Path("/mock/bin") / "copilot")
+
+
+def test_create_plan_preserves_explicit_harness_order_after_dedupe_bypasses_auto_detect() -> None:
+    requested_harnesses = parse_harness_overrides(
+        ["copilot-cli,cursor", "copilot-cli", "claude-code,cursor"]
+    )
+    plan = asyncio.run(
+        create_harness_install_plan(
+            project_root="/workspace",
+            requested_harnesses=requested_harnesses,
+            environment=_make_environment(commands=["codex"]),
+        )
+    )
+
+    assert requested_harnesses == ["copilot-cli", "cursor", "claude-code"]
+    assert plan["selectionMode"] == "explicit"
+    assert plan["ok"] is True
+    assert plan["selectedHarnesses"] == requested_harnesses
+
+    copilot_entry = _get_entry(plan, "copilot-cli")
+    assert copilot_entry["selection"] == "selected"
+    assert copilot_entry["capability"] == "auto-install"
+    assert copilot_entry["detection"]["state"] == "bypassed"
+
+    claude_entry = _get_entry(plan, "claude-code")
+    assert claude_entry["selection"] == "selected"
+    assert claude_entry["capability"] == "manual-capable"
+    assert claude_entry["detection"]["state"] == "bypassed"
+
+    codex_entry = _get_entry(plan, "codex")
+    assert codex_entry["selection"] == "skipped"
+    assert codex_entry["detection"]["state"] == "bypassed"
+
+
+def test_create_plan_returns_guidance_when_auto_detect_finds_no_harnesses() -> None:
+    plan = asyncio.run(
+        create_harness_install_plan(
+            project_root="/workspace",
+            environment=_make_environment(),
+        )
+    )
+
+    assert plan["selectionMode"] == "auto-detect"
+    assert plan["ok"] is False
+    assert plan["selectedHarnesses"] == []
+    guidance = plan.get("guidance", "")
+    assert "--harness <name>" in guidance
+    assert "cheese compile" in guidance
+    assert all(entry["selection"] == "skipped" for entry in plan["entries"])
+
+
+def test_parse_harness_overrides_rejects_unsupported_harness_names() -> None:
+    with pytest.raises(ValueError, match="Unsupported harness"):
+        parse_harness_overrides(["bogus"])


### PR DESCRIPTION
Ports `src/lib/install-plan.ts` → `python/cheese_flow/lib/install_plan.py`,
including the harness-detection import surface it re-exports for installer
consumers. Adds `python/cheese_flow/lib/harness_detection.py` so the slice
compiles in isolation; US-006 will own the harness-detection test port.

Tests: `tests/install-plan.test.ts` translated verbatim to
`tests/python/test_install_plan.py` (asyncio.run pattern matching
`test_compiler.py`).

Co-authored-by: Ralphify <noreply@ralphify.co>