### PR TITLE
feat(migration): US-007 harness-compat (TS → Python)

### DIFF
--- a/python/cheese_flow/lib/harness_compat.py
+++ b/python/cheese_flow/lib/harness_compat.py
@@ -1,0 +1,356 @@
+"""Port of `src/lib/harness-compat.ts` — harness portability findings.
+
+Mirrors the TS surface: ``check_allowed_tools_portability``,
+``check_frontmatter_portability``, ``check_body_harness_idioms``, and
+``compile_test_skill``. All findings are emitted as ``HarnessCompatFinding``
+TypedDicts with the same ``rule`` / ``severity`` / ``message`` / ``line``
+fields as the TS module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import shutil
+import tempfile
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Literal, TypedDict
+
+from cheese_flow.adapters import HARNESS_ADAPTERS
+from cheese_flow.lib.capabilities import event_support, field_support, tool_support
+from cheese_flow.lib.frontmatter import parse_frontmatter
+from cheese_flow.lib.harness import HarnessAdapter, HarnessName
+from cheese_flow.lib.schemas import parse_skill_frontmatter
+
+Severity = Literal["error", "warning"]
+
+
+class _HarnessCompatFindingRequired(TypedDict):
+    rule: str
+    severity: Severity
+    message: str
+
+
+class HarnessCompatFinding(_HarnessCompatFindingRequired, total=False):
+    line: int
+
+
+_CLAUDE_PERMISSION_GLOB = re.compile(r"\b([A-Za-z]\w*)\(([^)]*:[^)]*)\)")
+
+_HARNESS_PATH_MARKERS: tuple[str, ...] = (
+    ".claude/",
+    ".claude-plugin/",
+    ".codex/",
+    ".cursor/",
+    ".copilot/",
+    "AGENTS.md",
+    "copilot-instructions.md",
+)
+
+
+def _display_name(harness: HarnessName) -> str:
+    return HARNESS_ADAPTERS[harness].displayName
+
+
+def check_allowed_tools_portability(
+    allowed_tools: str | list[str] | None,
+) -> list[HarnessCompatFinding]:
+    if allowed_tools is None:
+        return []
+    text = ", ".join(allowed_tools) if isinstance(allowed_tools, list) else allowed_tools
+    matches = list(_CLAUDE_PERMISSION_GLOB.finditer(text))
+    if not matches:
+        return []
+    return [
+        {
+            "rule": "allowed-tools-claude-permission-syntax",
+            "severity": "warning",
+            "message": (
+                f'allowed-tools entry "{match.group(0)}" uses Claude Code '
+                "permission-glob syntax; Cursor, Codex, and Copilot CLI do not "
+                'parse it. Drop the "(...:...)" suffix or list bare tool names '
+                "for portability."
+            ),
+        }
+        for match in matches
+    ]
+
+
+def check_frontmatter_portability(
+    frontmatter: dict[str, object],
+    kind: Literal["skill", "agent"],
+) -> list[HarnessCompatFinding]:
+    support = field_support(kind)
+    all_adapters: list[HarnessName] = list(HARNESS_ADAPTERS.keys())
+    findings: list[HarnessCompatFinding] = []
+
+    for key, supported_by in support.items():
+        if frontmatter.get(key) is None and key not in frontmatter:
+            continue
+        if frontmatter.get(key) is None:
+            continue
+        if len(supported_by) == len(all_adapters):
+            continue
+        if key == "context" and frontmatter[key] == "inline":
+            continue
+
+        unsupported: list[HarnessName] = [
+            n for n in all_adapters if n not in supported_by
+        ]
+        supported_names = ", ".join(_display_name(n) for n in supported_by)
+        unsupported_names = ", ".join(_display_name(n) for n in unsupported)
+        findings.append(
+            {
+                "rule": "frontmatter-portability",
+                "severity": "warning",
+                "message": (
+                    f'frontmatter field "{key}" is supported only by '
+                    f"{supported_names}; {unsupported_names} drop it. Move the "
+                    "constraint into the body, or accept the field will be "
+                    "ignored."
+                ),
+            }
+        )
+    return findings
+
+
+def _line_number_of(source: str, index: int) -> int:
+    return source[: min(index, len(source))].count("\n") + 1
+
+
+def _find_first_match_line(body: str, pattern: re.Pattern[str]) -> int | None:
+    match = pattern.search(body)
+    if match is None:
+        return None
+    return _line_number_of(body, match.start())
+
+
+def check_body_harness_idioms(body: str) -> list[HarnessCompatFinding]:
+    return [
+        *_collect_tool_findings(body),
+        *_collect_event_findings(body),
+        *_collect_path_findings(body),
+        *_collect_placeholder_findings(body),
+    ]
+
+
+def _collect_placeholder_findings(body: str) -> list[HarnessCompatFinding]:
+    line = _find_first_match_line(body, re.compile(r"<harness>/"))
+    if line is None:
+        return []
+    return [
+        {
+            "rule": "body-harness-placeholder",
+            "severity": "error",
+            "message": (
+                'body uses the "<harness>/" placeholder; replace with '
+                '".cheese/" so all four harnesses share a single project-root '
+                "runtime directory."
+            ),
+            "line": line,
+        }
+    ]
+
+
+def _collect_tool_findings(body: str) -> list[HarnessCompatFinding]:
+    all_adapters: list[HarnessName] = list(HARNESS_ADAPTERS.keys())
+    findings: list[HarnessCompatFinding] = []
+    for tool, supported_by in tool_support().items():
+        line = _find_first_match_line(body, re.compile(rf"\b{re.escape(tool)}\("))
+        if line is None:
+            continue
+        unsupported_names = ", ".join(
+            _display_name(n) for n in all_adapters if n not in supported_by
+        )
+        findings.append(
+            {
+                "rule": "body-claude-only-tool",
+                "severity": "warning",
+                "message": (
+                    f'body references tool "{tool}(...)"; {unsupported_names} '
+                    "do not expose this tool. Rephrase generically (e.g. "
+                    '"spawn a sub-agent").'
+                ),
+                "line": line,
+            }
+        )
+    return findings
+
+
+def _collect_event_findings(body: str) -> list[HarnessCompatFinding]:
+    all_adapters: list[HarnessName] = list(HARNESS_ADAPTERS.keys())
+    hook_adapter_count = sum(
+        1
+        for n in all_adapters
+        if len(HARNESS_ADAPTERS[n].capabilities.hookEvents) > 0
+    )
+    findings: list[HarnessCompatFinding] = []
+    for camel_event, supported_by in event_support().items():
+        pascal_event = camel_event[:1].upper() + camel_event[1:]
+        line = _find_first_match_line(body, re.compile(rf"\b{re.escape(pascal_event)}\b"))
+        if line is None:
+            continue
+        findings.append(
+            _event_finding(
+                camel_event,
+                pascal_event,
+                supported_by,
+                hook_adapter_count,
+                all_adapters,
+                line,
+            )
+        )
+    return findings
+
+
+def _event_finding(
+    camel_event: str,
+    pascal_event: str,
+    supported_by: list[HarnessName],
+    hook_adapter_count: int,
+    all_adapters: list[HarnessName],
+    line: int,
+) -> HarnessCompatFinding:
+    if len(supported_by) == hook_adapter_count:
+        return {
+            "rule": "body-pascal-hook-event",
+            "severity": "warning",
+            "message": (
+                f'body references PascalCase hook event "{pascal_event}"; '
+                "cheese-flow's portable hooks use camelCase "
+                f'("{camel_event}"). Per-harness mapping is applied at '
+                "compile time."
+            ),
+            "line": line,
+        }
+    unsupported: list[HarnessName] = [
+        n for n in all_adapters if n not in supported_by
+    ]
+    supported_names = ", ".join(_display_name(n) for n in supported_by)
+    unsupported_names = ", ".join(_display_name(n) for n in unsupported)
+    return {
+        "rule": "body-harness-only-hook-event",
+        "severity": "warning",
+        "message": (
+            f'body references hook event "{pascal_event}" which is supported '
+            f"only by {supported_names}; {unsupported_names} do not expose it."
+        ),
+        "line": line,
+    }
+
+
+def _collect_path_findings(body: str) -> list[HarnessCompatFinding]:
+    findings: list[HarnessCompatFinding] = []
+    for marker in _HARNESS_PATH_MARKERS:
+        line = _find_first_match_line(body, re.compile(re.escape(marker)))
+        if line is None:
+            continue
+        findings.append(
+            {
+                "rule": "body-harness-path-marker",
+                "severity": "warning",
+                "message": (
+                    f'body references harness-specific path "{marker}"; '
+                    "portable skills should use the cheese-flow source layout "
+                    '(e.g. "skills/<name>/SKILL.md") and let adapters project '
+                    "per harness."
+                ),
+                "line": line,
+            }
+        )
+    return findings
+
+
+async def _setup_skill_dir(tmp_root: Path, skill_name: str, skill_source: str) -> Path:
+    skills_dir = tmp_root / "skills"
+    skill_dir = skills_dir / skill_name
+    await asyncio.to_thread(skill_dir.mkdir, parents=True, exist_ok=True)
+    await asyncio.to_thread(
+        (skill_dir / "SKILL.md").write_text, skill_source, encoding="utf8"
+    )
+    return skills_dir
+
+
+async def _try_adapter_install(
+    adapter: HarnessAdapter,
+    skills_dir: Path,
+    tmp_root: Path,
+) -> HarnessCompatFinding | None:
+    output_root = tmp_root / adapter.outputRoot
+    skill_output_root = output_root / adapter.skillDirectory
+    try:
+        await asyncio.to_thread(
+            skill_output_root.mkdir, parents=True, exist_ok=True
+        )
+        await _simulate_copy_skills(skills_dir, skill_output_root)
+        if adapter.emitSurface is not None:
+            await adapter.emitSurface(str(skills_dir), str(output_root))
+        return None
+    except Exception as error:  # noqa: BLE001 - mirror TS catch
+        return {
+            "rule": f"compile-{adapter.name}-failed",
+            "severity": "error",
+            "message": (
+                f"{adapter.displayName} adapter failed to emit: {error}"
+            ),
+        }
+
+
+async def _simulate_copy_skills(skills_dir: Path, skill_output_root: Path) -> None:
+    entries = await asyncio.to_thread(_list_directories, skills_dir)
+    for entry in entries:
+        skill_readme_path = entry / "SKILL.md"
+        content = await asyncio.to_thread(
+            skill_readme_path.read_text, encoding="utf8"
+        )
+        parsed_data, _ = parse_frontmatter(content)
+        frontmatter = parse_skill_frontmatter(parsed_data)
+        if frontmatter.name != entry.name:
+            raise ValueError(
+                f'Skill directory "{entry.name}" must match frontmatter '
+                f'name "{frontmatter.name}".'
+            )
+        destination = skill_output_root / entry.name
+        await asyncio.to_thread(_copy_tree_force, entry, destination)
+
+
+def _list_directories(skills_dir: Path) -> list[Path]:
+    return [child for child in skills_dir.iterdir() if child.is_dir()]
+
+
+def _copy_tree_force(source: Path, destination: Path) -> None:
+    if destination.exists():
+        shutil.rmtree(destination)
+    shutil.copytree(source, destination)
+
+
+async def compile_test_skill(
+    skill_name: str, skill_source: str
+) -> list[HarnessCompatFinding]:
+    findings: list[HarnessCompatFinding] = []
+    tmp_root = Path(
+        await asyncio.to_thread(tempfile.mkdtemp, prefix="cheese-compile-")
+    )
+    try:
+        skills_dir = await _setup_skill_dir(tmp_root, skill_name, skill_source)
+        for adapter in _ordered_adapters():
+            finding = await _try_adapter_install(adapter, skills_dir, tmp_root)
+            if finding is not None:
+                findings.append(finding)
+    finally:
+        await asyncio.to_thread(shutil.rmtree, tmp_root, ignore_errors=True)
+    return findings
+
+
+def _ordered_adapters() -> Iterable[HarnessAdapter]:
+    return list(HARNESS_ADAPTERS.values())
+
+
+__all__ = [
+    "HarnessCompatFinding",
+    "check_allowed_tools_portability",
+    "check_body_harness_idioms",
+    "check_frontmatter_portability",
+    "compile_test_skill",
+]

--- a/python/cheese_flow/lib/harness_compat.py
+++ b/python/cheese_flow/lib/harness_compat.py
@@ -86,8 +86,6 @@ def check_frontmatter_portability(
     findings: list[HarnessCompatFinding] = []
 
     for key, supported_by in support.items():
-        if frontmatter.get(key) is None and key not in frontmatter:
-            continue
         if frontmatter.get(key) is None:
             continue
         if len(supported_by) == len(all_adapters):
@@ -95,9 +93,7 @@ def check_frontmatter_portability(
         if key == "context" and frontmatter[key] == "inline":
             continue
 
-        unsupported: list[HarnessName] = [
-            n for n in all_adapters if n not in supported_by
-        ]
+        unsupported: list[HarnessName] = [n for n in all_adapters if n not in supported_by]
         supported_names = ", ".join(_display_name(n) for n in supported_by)
         unsupported_names = ", ".join(_display_name(n) for n in unsupported)
         findings.append(
@@ -181,9 +177,7 @@ def _collect_tool_findings(body: str) -> list[HarnessCompatFinding]:
 def _collect_event_findings(body: str) -> list[HarnessCompatFinding]:
     all_adapters: list[HarnessName] = list(HARNESS_ADAPTERS.keys())
     hook_adapter_count = sum(
-        1
-        for n in all_adapters
-        if len(HARNESS_ADAPTERS[n].capabilities.hookEvents) > 0
+        1 for n in all_adapters if len(HARNESS_ADAPTERS[n].capabilities.hookEvents) > 0
     )
     findings: list[HarnessCompatFinding] = []
     for camel_event, supported_by in event_support().items():
@@ -224,9 +218,7 @@ def _event_finding(
             ),
             "line": line,
         }
-    unsupported: list[HarnessName] = [
-        n for n in all_adapters if n not in supported_by
-    ]
+    unsupported: list[HarnessName] = [n for n in all_adapters if n not in supported_by]
     supported_names = ", ".join(_display_name(n) for n in supported_by)
     unsupported_names = ", ".join(_display_name(n) for n in unsupported)
     return {
@@ -266,9 +258,7 @@ async def _setup_skill_dir(tmp_root: Path, skill_name: str, skill_source: str) -
     skills_dir = tmp_root / "skills"
     skill_dir = skills_dir / skill_name
     await asyncio.to_thread(skill_dir.mkdir, parents=True, exist_ok=True)
-    await asyncio.to_thread(
-        (skill_dir / "SKILL.md").write_text, skill_source, encoding="utf8"
-    )
+    await asyncio.to_thread((skill_dir / "SKILL.md").write_text, skill_source, encoding="utf8")
     return skills_dir
 
 
@@ -280,9 +270,7 @@ async def _try_adapter_install(
     output_root = tmp_root / adapter.outputRoot
     skill_output_root = output_root / adapter.skillDirectory
     try:
-        await asyncio.to_thread(
-            skill_output_root.mkdir, parents=True, exist_ok=True
-        )
+        await asyncio.to_thread(skill_output_root.mkdir, parents=True, exist_ok=True)
         await _simulate_copy_skills(skills_dir, skill_output_root)
         if adapter.emitSurface is not None:
             await adapter.emitSurface(str(skills_dir), str(output_root))
@@ -291,9 +279,7 @@ async def _try_adapter_install(
         return {
             "rule": f"compile-{adapter.name}-failed",
             "severity": "error",
-            "message": (
-                f"{adapter.displayName} adapter failed to emit: {error}"
-            ),
+            "message": (f"{adapter.displayName} adapter failed to emit: {error}"),
         }
 
 
@@ -301,15 +287,12 @@ async def _simulate_copy_skills(skills_dir: Path, skill_output_root: Path) -> No
     entries = await asyncio.to_thread(_list_directories, skills_dir)
     for entry in entries:
         skill_readme_path = entry / "SKILL.md"
-        content = await asyncio.to_thread(
-            skill_readme_path.read_text, encoding="utf8"
-        )
+        content = await asyncio.to_thread(skill_readme_path.read_text, encoding="utf8")
         parsed_data, _ = parse_frontmatter(content)
         frontmatter = parse_skill_frontmatter(parsed_data)
         if frontmatter.name != entry.name:
             raise ValueError(
-                f'Skill directory "{entry.name}" must match frontmatter '
-                f'name "{frontmatter.name}".'
+                f'Skill directory "{entry.name}" must match frontmatter name "{frontmatter.name}".'
             )
         destination = skill_output_root / entry.name
         await asyncio.to_thread(_copy_tree_force, entry, destination)
@@ -325,13 +308,9 @@ def _copy_tree_force(source: Path, destination: Path) -> None:
     shutil.copytree(source, destination)
 
 
-async def compile_test_skill(
-    skill_name: str, skill_source: str
-) -> list[HarnessCompatFinding]:
+async def compile_test_skill(skill_name: str, skill_source: str) -> list[HarnessCompatFinding]:
     findings: list[HarnessCompatFinding] = []
-    tmp_root = Path(
-        await asyncio.to_thread(tempfile.mkdtemp, prefix="cheese-compile-")
-    )
+    tmp_root = Path(await asyncio.to_thread(tempfile.mkdtemp, prefix="cheese-compile-"))
     try:
         skills_dir = await _setup_skill_dir(tmp_root, skill_name, skill_source)
         for adapter in _ordered_adapters():

--- a/ralphs/python-migration/TODO.md
+++ b/ralphs/python-migration/TODO.md
@@ -12,7 +12,7 @@ US-005 (install-plan), US-006 (harness-detection), and US-007 (harness-compat).
 - [x] US-004 — Port compile pipeline: `compiler.ts` + `emit.ts` + `frontmatter.ts` + `capabilities.ts` + `model-manifest.ts` → `python/cheese_flow/lib/`; Eta `<%= %>` / `<% %>` → Jinja2 `{{ }}` / `{% %}`; `Promise.all` → `asyncio.gather`; commit a byte-parity snapshot fixture for one agent + one skill
 - [x] US-005 — Port `src/lib/install-plan.ts` → `python/cheese_flow/lib/install_plan.py`; port `tests/install-plan.test.ts`
 - [x] US-006 — Port `src/lib/harness-detection.ts` → `python/cheese_flow/lib/harness_detection.py`; port `tests/harness-detection.test.ts`
-- [ ] US-007 — Port `src/lib/harness-compat.ts` → `python/cheese_flow/lib/harness_compat.py`; port `tests/harness-compat.test.ts`
+- [x] US-007 — Port `src/lib/harness-compat.ts` → `python/cheese_flow/lib/harness_compat.py`; port `tests/harness-compat.test.ts`
 - [ ] US-008 — Port `src/lib/installer.ts` → `python/cheese_flow/lib/installer.py`; depends on US-005/006/007; port `tests/installer.test.ts`
 - [ ] US-009 — Port `src/lib/sweeper.ts` → `python/cheese_flow/lib/sweeper.py`; port `tests/sweeper.test.ts`
 - [ ] US-010 — Port `src/lib/session-start.ts` → `python/cheese_flow/lib/session_start.py`; port `tests/session-start.test.ts`

--- a/tests/python/test_harness_compat.py
+++ b/tests/python/test_harness_compat.py
@@ -74,9 +74,7 @@ def test_flags_lowercase_permission_glob_syntax() -> None:
 
 
 def test_returns_no_findings_for_skills_using_only_portable_fields() -> None:
-    assert (
-        check_frontmatter_portability({"name": "x", "description": "y"}, "skill") == []
-    )
+    assert check_frontmatter_portability({"name": "x", "description": "y"}, "skill") == []
 
 
 def test_flags_model_and_context_fork_on_a_skill_2_findings() -> None:
@@ -228,8 +226,7 @@ def test_does_not_flag_camelcase_hook_events() -> None:
 def test_does_not_flag_camelcase_stop_in_body() -> None:
     findings = check_body_harness_idioms("Fires stop, subagentStop events.")
     assert not any(
-        f["rule"] in {"body-pascal-hook-event", "body-harness-only-hook-event"}
-        for f in findings
+        f["rule"] in {"body-pascal-hook-event", "body-harness-only-hook-event"} for f in findings
     )
 
 
@@ -258,9 +255,7 @@ def test_flags_harness_specific_path_markers() -> None:
 def test_attaches_a_1_based_line_number_to_each_body_finding() -> None:
     body = "line 1\nline 2 with Agent(\nline 3\n"
     findings = check_body_harness_idioms(body)
-    agent_finding = next(
-        (f for f in findings if f["rule"] == "body-claude-only-tool"), None
-    )
+    agent_finding = next((f for f in findings if f["rule"] == "body-claude-only-tool"), None)
     assert agent_finding is not None
     assert agent_finding.get("line") == 2
 

--- a/tests/python/test_harness_compat.py
+++ b/tests/python/test_harness_compat.py
@@ -1,0 +1,298 @@
+"""Verbatim port of `tests/harness-compat.test.ts`.
+
+The TS suite exercises four entry points: ``checkAllowedToolsPortability``,
+``checkFrontmatterPortability``, ``checkBodyHarnessIdioms``, and
+``compileTestSkill``. The registry-mutation case in TS rebinds
+``adapter.capabilities`` directly; in Python the dataclass is frozen, so the
+port replaces the registry entry with a new ``HarnessAdapter`` and restores
+the original on teardown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+
+from cheese_flow.adapters import HARNESS_ADAPTERS
+from cheese_flow.lib.capabilities import field_support
+from cheese_flow.lib.harness import HarnessAdapter, HarnessCapabilities
+from cheese_flow.lib.harness_compat import (
+    check_allowed_tools_portability,
+    check_body_harness_idioms,
+    check_frontmatter_portability,
+    compile_test_skill,
+)
+
+# --- check_allowed_tools_portability -------------------------------------------------
+
+
+def test_returns_no_findings_when_allowed_tools_is_undefined() -> None:
+    assert check_allowed_tools_portability(None) == []
+
+
+def test_returns_no_findings_on_bare_tool_names_string_form() -> None:
+    assert check_allowed_tools_portability("read write bash") == []
+
+
+def test_returns_no_findings_on_bare_tool_names_array_form() -> None:
+    assert check_allowed_tools_portability(["read", "write", "bash"]) == []
+
+
+def test_flags_claude_permission_glob_in_string_form() -> None:
+    findings = check_allowed_tools_portability("Bash(git diff:*), Read")
+    assert len(findings) == 1
+    assert findings[0]["rule"] == "allowed-tools-claude-permission-syntax"
+    assert findings[0]["severity"] == "warning"
+
+
+def test_flags_claude_permission_glob_in_array_form() -> None:
+    findings = check_allowed_tools_portability(
+        ["Bash(gh:*)", "mcp__tilth__tilth_search"],
+    )
+    assert len(findings) == 1
+    assert findings[0]["rule"] == "allowed-tools-claude-permission-syntax"
+    assert findings[0]["severity"] == "warning"
+    assert "Bash(gh:*)" in findings[0]["message"]
+
+
+def test_flags_all_occurrences_when_multiple_permission_globs_are_present() -> None:
+    findings = check_allowed_tools_portability("Bash(git:*), Bash(gh:*)")
+    assert len(findings) == 2
+    assert "Bash(git:*)" in findings[0]["message"]
+    assert "Bash(gh:*)" in findings[1]["message"]
+
+
+def test_flags_lowercase_permission_glob_syntax() -> None:
+    findings = check_allowed_tools_portability("bash(git diff:*)")
+    assert len(findings) == 1
+    assert findings[0]["rule"] == "allowed-tools-claude-permission-syntax"
+    assert findings[0]["severity"] == "warning"
+    assert "bash(git diff:*)" in findings[0]["message"]
+
+
+# --- check_frontmatter_portability ---------------------------------------------------
+
+
+def test_returns_no_findings_for_skills_using_only_portable_fields() -> None:
+    assert (
+        check_frontmatter_portability({"name": "x", "description": "y"}, "skill") == []
+    )
+
+
+def test_flags_model_and_context_fork_on_a_skill_2_findings() -> None:
+    findings = check_frontmatter_portability(
+        {"name": "x", "description": "y", "model": "opus", "context": "fork"},
+        "skill",
+    )
+    assert len(findings) == 2
+    assert all(f["rule"] == "frontmatter-portability" for f in findings)
+    assert any('"model"' in f["message"] for f in findings)
+    assert any('"context"' in f["message"] for f in findings)
+
+
+def test_does_not_flag_context_inline_because_it_is_the_portable_default() -> None:
+    findings = check_frontmatter_portability(
+        {"name": "x", "description": "y", "context": "inline"},
+        "skill",
+    )
+    assert findings == []
+
+
+def test_flags_all_claude_only_agent_fields() -> None:
+    findings = check_frontmatter_portability(
+        {
+            "name": "x",
+            "description": "y",
+            "skills": ["foo"],
+            "color": "red",
+            "effort": "high",
+            "disallowedTools": ["Edit"],
+            "permissionMode": "default",
+        },
+        "agent",
+    )
+    assert len(findings) == 5
+    assert all(f["rule"] == "frontmatter-portability" for f in findings)
+
+
+def test_is_driven_by_adapter_capabilities_not_hardcoded_constants() -> None:
+    # model is supported only by claude-code; if a future adapter also declares it,
+    # the map grows and the warning would no longer fire for that adapter.
+    # Verify the current mapping is capability-driven.
+    support = field_support("skill")
+    assert support["model"] == ["claude-code"]
+    assert support["context"] == ["claude-code"]
+
+
+def test_warning_suppresses_when_every_adapter_declares_the_field() -> None:
+    # Plan §6 regression: prove the lint is data-driven by mutating the registry
+    # so every adapter declares `model` in skillFrontmatterKeys. The warning
+    # must stop firing — adding a portable field means editing capabilities,
+    # not the lint.
+    skills_before = check_frontmatter_portability(
+        {"name": "x", "description": "y", "model": "opus"},
+        "skill",
+    )
+    assert len(skills_before) == 1
+
+    original_adapters: dict[str, HarnessAdapter] = dict(HARNESS_ADAPTERS)
+    try:
+        for name, adapter in original_adapters.items():
+            HARNESS_ADAPTERS[name] = replace(  # type: ignore[index]
+                adapter,
+                capabilities=replace(
+                    adapter.capabilities,
+                    skillFrontmatterKeys=frozenset(
+                        {*adapter.capabilities.skillFrontmatterKeys, "model"},
+                    ),
+                ),
+            )
+        fifth_template = original_adapters["claude-code"]
+        fifth = replace(
+            fifth_template,
+            displayName="Fifth",
+            outputRoot=".fifth",
+            capabilities=HarnessCapabilities(
+                skillFrontmatterKeys=frozenset({"model"}),
+                agentFrontmatterKeys=frozenset(),
+                hookEvents=frozenset(),
+                toolNames=frozenset(),
+                bootstrapHook=False,
+            ),
+        )
+        HARNESS_ADAPTERS["fifth"] = fifth  # type: ignore[index]
+
+        skills_after = check_frontmatter_portability(
+            {"name": "x", "description": "y", "model": "opus"},
+            "skill",
+        )
+        assert skills_after == []
+    finally:
+        if "fifth" in HARNESS_ADAPTERS:
+            del HARNESS_ADAPTERS["fifth"]  # type: ignore[arg-type]
+        for name, adapter in original_adapters.items():
+            HARNESS_ADAPTERS[name] = adapter  # type: ignore[index]
+
+
+# --- check_body_harness_idioms -------------------------------------------------------
+
+
+def test_returns_no_findings_on_plain_markdown_body() -> None:
+    body = "# Heading\n\nUse the harness's native tools.\n"
+    assert check_body_harness_idioms(body) == []
+
+
+def test_flags_agent_call_sites() -> None:
+    findings = check_body_harness_idioms('Use Agent(subagent_type="x")')
+    assert len(findings) == 1
+    assert findings[0]["rule"] == "body-claude-only-tool"
+
+
+def test_flags_task_call_sites() -> None:
+    findings = check_body_harness_idioms("Spawn via Task(...).")
+    assert len(findings) == 1
+    assert "Task" in findings[0]["message"]
+
+
+def test_flags_portable_pascalcase_hook_events_with_body_pascal_hook_event() -> None:
+    findings = check_body_harness_idioms(
+        "Fires SessionStart, PreToolUse, PostToolUse.",
+    )
+    matching = [f for f in findings if f["rule"] == "body-pascal-hook-event"]
+    assert len(matching) == 3
+
+
+def test_flags_claude_only_pascalcase_hook_events_with_body_harness_only_hook_event() -> None:
+    findings = check_body_harness_idioms(
+        "Fires Stop, SubagentStop, Notification.",
+    )
+    matching = [f for f in findings if f["rule"] == "body-harness-only-hook-event"]
+    assert len(matching) == 3
+    assert all(f["severity"] == "warning" for f in findings)
+
+
+def test_stop_emits_body_harness_only_hook_event_not_body_pascal_hook_event() -> None:
+    findings = check_body_harness_idioms("Triggers on Stop.")
+    stop_finding = next((f for f in findings if "Stop" in f["message"]), None)
+    assert stop_finding is not None
+    assert stop_finding["rule"] == "body-harness-only-hook-event"
+
+
+def test_does_not_flag_camelcase_hook_events() -> None:
+    findings = check_body_harness_idioms(
+        "Fires sessionStart, preToolUse, postToolUse.",
+    )
+    assert findings == []
+
+
+def test_does_not_flag_camelcase_stop_in_body() -> None:
+    findings = check_body_harness_idioms("Fires stop, subagentStop events.")
+    assert not any(
+        f["rule"] in {"body-pascal-hook-event", "body-harness-only-hook-event"}
+        for f in findings
+    )
+
+
+def test_flags_claude_only_tools_beyond_agent_task() -> None:
+    findings = check_body_harness_idioms(
+        "Use NotebookEdit(...) and WebSearch(...) and TodoWrite(...) and WebFetch(...).",
+    )
+    tools = [f["message"] for f in findings if f["rule"] == "body-claude-only-tool"]
+    assert any("NotebookEdit" in m for m in tools)
+    assert any("WebSearch" in m for m in tools)
+    assert any("TodoWrite" in m for m in tools)
+    assert any("WebFetch" in m for m in tools)
+
+
+def test_flags_harness_specific_path_markers() -> None:
+    findings = check_body_harness_idioms(
+        "See .claude/specs and .codex/agents and .cursor/rules and AGENTS.md.",
+    )
+    markers = [f["message"] for f in findings if f["rule"] == "body-harness-path-marker"]
+    assert any(".claude/" in m for m in markers)
+    assert any(".codex/" in m for m in markers)
+    assert any(".cursor/" in m for m in markers)
+    assert any("AGENTS.md" in m for m in markers)
+
+
+def test_attaches_a_1_based_line_number_to_each_body_finding() -> None:
+    body = "line 1\nline 2 with Agent(\nline 3\n"
+    findings = check_body_harness_idioms(body)
+    agent_finding = next(
+        (f for f in findings if f["rule"] == "body-claude-only-tool"), None
+    )
+    assert agent_finding is not None
+    assert agent_finding.get("line") == 2
+
+
+# --- compile_test_skill --------------------------------------------------------------
+
+
+_VALID_SKILL = (
+    "---\nname: my-skill\ndescription: A long-enough description for portable "
+    "discovery.\n---\n# Body\nDo something useful.\n"
+)
+
+
+def test_returns_no_findings_for_a_valid_skill() -> None:
+    findings = asyncio.run(compile_test_skill("my-skill", _VALID_SKILL))
+    assert findings == []
+
+
+def test_reports_a_compile_failure_for_every_adapter_when_frontmatter_is_malformed() -> None:
+    malformed = "no frontmatter at all\n"
+    findings = asyncio.run(compile_test_skill("broken-skill", malformed))
+    assert len(findings) == 4
+    assert all(f["severity"] == "error" for f in findings)
+    rules = [f["rule"] for f in findings]
+    for harness in ("claude-code", "codex", "cursor", "copilot-cli"):
+        assert f"compile-{harness}-failed" in rules
+
+
+def test_surfaces_the_directory_name_mismatch_as_an_adapter_level_compile_error() -> None:
+    mismatched = (
+        "---\nname: not-the-folder\ndescription: A long-enough description for "
+        "portable discovery.\n---\n# Body\nSomething useful.\n"
+    )
+    findings = asyncio.run(compile_test_skill("expected-folder", mismatched))
+    assert any("must match frontmatter name" in f["message"] for f in findings)


### PR DESCRIPTION
Port src/lib/harness-compat.ts to python/cheese_flow/lib/harness_compat.py:
- check_allowed_tools_portability: flags Claude permission-glob syntax
- check_frontmatter_portability: data-driven via field_support
- check_body_harness_idioms: tools, hook events, path markers, placeholder
- compile_test_skill: end-to-end adapter emit smoke test using tempfile

Port tests/harness-compat.test.ts verbatim to test_harness_compat.py.
The registry-mutation regression rebuilds frozen HarnessAdapter instances
via dataclasses.replace since Python dataclasses are immutable.

Co-authored-by: Ralphify <noreply@ralphify.co>