### PR TITLE
feat(migration): US-008 installer (TS → Python)

### DIFF
--- a/python/cheese_flow/lib/installer.py
+++ b/python/cheese_flow/lib/installer.py
@@ -136,9 +136,7 @@ async def default_command_executor(
     stdout = stdout_bytes.decode("utf-8", errors="replace")
     stderr = stderr_bytes.decode("utf-8", errors="replace")
     if process.returncode != 0:
-        error = RuntimeError(
-            f"{command} {' '.join(args)} exited with code {process.returncode}"
-        )
+        error = RuntimeError(f"{command} {' '.join(args)} exited with code {process.returncode}")
         error.stdout = stdout  # type: ignore[attr-defined]
         error.stderr = stderr  # type: ignore[attr-defined]
         raise error
@@ -363,8 +361,7 @@ async def _install_copilot_cli_bundle(
         return {
             "state": "failed",
             "reason": (
-                'GitHub Copilot CLI requires the "copilot" command on PATH to '
-                "finish installation."
+                'GitHub Copilot CLI requires the "copilot" command on PATH to finish installation.'
             ),
             "nextSteps": [f"Install GitHub Copilot CLI, then run {install_command}."],
         }
@@ -397,9 +394,7 @@ async def _install_claude_code_bundle(
         context.bundle.pluginMetadata,
     )
     claude_path = await context.findCommand("claude")
-    add_command = (
-        f"claude plugin marketplace add {_shell_quote(context.bundle.outputRoot)}"
-    )
+    add_command = f"claude plugin marketplace add {_shell_quote(context.bundle.outputRoot)}"
     reason = (
         'Claude Code still requires manual installation, and the "claude" CLI is not '
         "on PATH for the marketplace-add step."
@@ -427,9 +422,7 @@ async def _install_codex_bundle(
         context.bundle.pluginMetadata,
     )
     codex_path = await context.findCommand("codex")
-    add_command = (
-        f"codex plugin marketplace add {_shell_quote(context.bundle.outputRoot)}"
-    )
+    add_command = f"codex plugin marketplace add {_shell_quote(context.bundle.outputRoot)}"
     reason = (
         'Codex still requires manual installation, and the "codex" CLI is not on '
         "PATH for the marketplace-add step."

--- a/python/cheese_flow/lib/installer.py
+++ b/python/cheese_flow/lib/installer.py
@@ -1,0 +1,464 @@
+"""Port of `src/lib/installer.ts` — harness install orchestration.
+
+Mirrors the TS surface: ``install_harnesses`` consumes ``install_plan``,
+``harness_detection``, and (for the CLI capability tables it consults)
+``harness_compat`` neighbours. Per-harness phase-1 actions:
+
+* ``cursor`` — bundle root is the install surface; nothing else to do.
+* ``copilot-cli`` — invoke ``copilot plugin install`` via ``execute_command``.
+* ``claude-code`` — emit a Claude marketplace JSON; manual finish from CLI.
+* ``codex`` — emit a Codex marketplace JSON; manual finish from CLI.
+
+The TS module mocks ``execFile`` via the ``executeCommand`` field on the
+detection environment; the Python port does the same with an ``execute_command``
+async callable hung off ``InstallEnvironment``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TypedDict
+
+from cheese_flow.adapters import HARNESS_ADAPTERS
+from cheese_flow.lib.compiler import CompiledHarnessBundle, compile_harness_bundle
+from cheese_flow.lib.harness import HarnessName
+from cheese_flow.lib.harness_detection import (
+    HarnessDetectionEnvironment,
+    find_command_on_path,
+)
+from cheese_flow.lib.install_plan import (
+    HarnessInstallPlan,
+    HarnessSelectionMode,
+    create_harness_install_plan,
+    dedupe_harness_names,
+)
+from cheese_flow.lib.local_marketplaces import (
+    write_claude_marketplace,
+    write_codex_marketplace,
+)
+
+
+class CommandExecutionResult(TypedDict):
+    stdout: str
+    stderr: str
+
+
+CommandExecutor = Callable[[str, list[str], str], Awaitable[CommandExecutionResult]]
+
+
+@dataclass(frozen=True)
+class InstallEnvironment:
+    """Override hooks for filesystem/PATH/exec probes (used by tests)."""
+
+    findCommand: Callable[[str], Awaitable[str | None]] | None = None
+    hasDirectory: Callable[[str], Awaitable[bool]] | None = None
+    executeCommand: CommandExecutor | None = None
+
+
+HarnessInstallState = Literal["installed", "manual", "skipped", "failed"]
+
+
+class _HarnessInstallReportEntryRequired(TypedDict):
+    harness: HarnessName
+    displayName: str
+    state: HarnessInstallState
+    reason: str
+    nextSteps: list[str]
+
+
+class HarnessInstallReportEntry(_HarnessInstallReportEntryRequired, total=False):
+    outputRoot: str
+
+
+class _InstallReportRequired(TypedDict):
+    selectionMode: HarnessSelectionMode
+    results: list[HarnessInstallReportEntry]
+    ok: bool
+
+
+class InstallReport(_InstallReportRequired, total=False):
+    guidance: str
+
+
+class _Phase1InstallResult(TypedDict):
+    state: Literal["installed", "manual", "failed"]
+    reason: str
+    nextSteps: list[str]
+
+
+@dataclass(frozen=True)
+class _SelectedInstallContext:
+    bundle: CompiledHarnessBundle
+    findCommand: Callable[[str], Awaitable[str | None]]
+    executeCommand: CommandExecutor
+
+
+def _shell_quote(value: str) -> str:
+    return json.dumps(value)
+
+
+def _error_message(error: BaseException) -> str:
+    return str(error) if str(error) else type(error).__name__
+
+
+def _command_failure_message(error: BaseException) -> str:
+    stderr = getattr(error, "stderr", None)
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode("utf-8", errors="replace")
+    if isinstance(stderr, str) and stderr.strip():
+        return stderr.strip()
+
+    stdout = getattr(error, "stdout", None)
+    if isinstance(stdout, bytes):
+        stdout = stdout.decode("utf-8", errors="replace")
+    if isinstance(stdout, str) and stdout.strip():
+        return stdout.strip()
+
+    return _error_message(error)
+
+
+async def default_command_executor(
+    command: str, args: list[str], cwd: str
+) -> CommandExecutionResult:
+    process = await asyncio.create_subprocess_exec(
+        command,
+        *args,
+        cwd=cwd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout_bytes, stderr_bytes = await process.communicate()
+    stdout = stdout_bytes.decode("utf-8", errors="replace")
+    stderr = stderr_bytes.decode("utf-8", errors="replace")
+    if process.returncode != 0:
+        error = RuntimeError(
+            f"{command} {' '.join(args)} exited with code {process.returncode}"
+        )
+        error.stdout = stdout  # type: ignore[attr-defined]
+        error.stderr = stderr  # type: ignore[attr-defined]
+        raise error
+    return {"stdout": stdout, "stderr": stderr}
+
+
+def _build_skipped_entry(
+    project_root: str, harness: HarnessName, reason: str
+) -> HarnessInstallReportEntry:
+    adapter = HARNESS_ADAPTERS[harness]
+    return {
+        "harness": harness,
+        "displayName": adapter.displayName,
+        "state": "skipped",
+        "reason": reason,
+        "outputRoot": str(Path(project_root) / adapter.outputRoot),
+        "nextSteps": [],
+    }
+
+
+def _build_selected_entry(
+    bundle: CompiledHarnessBundle, result: _Phase1InstallResult
+) -> HarnessInstallReportEntry:
+    adapter = HARNESS_ADAPTERS[bundle.harness]
+    return {
+        "harness": bundle.harness,
+        "displayName": adapter.displayName,
+        "state": result["state"],
+        "reason": result["reason"],
+        "outputRoot": bundle.outputRoot,
+        "nextSteps": result["nextSteps"],
+    }
+
+
+def _build_compile_failure_entry(
+    project_root: str, harness: HarnessName, error: BaseException
+) -> HarnessInstallReportEntry:
+    adapter = HARNESS_ADAPTERS[harness]
+    return {
+        "harness": harness,
+        "displayName": adapter.displayName,
+        "state": "failed",
+        "reason": f"Failed to compile {adapter.outputRoot}: {_error_message(error)}",
+        "outputRoot": str(Path(project_root) / adapter.outputRoot),
+        "nextSteps": [],
+    }
+
+
+async def _install_selected_harness(
+    project_root: str,
+    harness: HarnessName,
+    *,
+    find_command: Callable[[str], Awaitable[str | None]],
+    execute_command: CommandExecutor,
+) -> HarnessInstallReportEntry:
+    try:
+        bundle = await compile_harness_bundle(project_root=project_root, harness=harness)
+    except Exception as error:  # noqa: BLE001
+        return _build_compile_failure_entry(project_root, harness, error)
+
+    context = _SelectedInstallContext(
+        bundle=bundle,
+        findCommand=find_command,
+        executeCommand=execute_command,
+    )
+    result = await _run_phase1_install(context)
+    return _build_selected_entry(bundle, result)
+
+
+async def _install_selected_harnesses(
+    plan: HarnessInstallPlan,
+    *,
+    project_root: str,
+    environment: InstallEnvironment | None,
+) -> dict[HarnessName, HarnessInstallReportEntry]:
+    selected_entries: dict[HarnessName, HarnessInstallReportEntry] = {}
+    find_command = (
+        environment.findCommand
+        if environment is not None and environment.findCommand is not None
+        else find_command_on_path
+    )
+    execute_command = (
+        environment.executeCommand
+        if environment is not None and environment.executeCommand is not None
+        else default_command_executor
+    )
+
+    for harness in plan["selectedHarnesses"]:
+        selected_entries[harness] = await _install_selected_harness(
+            project_root,
+            harness,
+            find_command=find_command,
+            execute_command=execute_command,
+        )
+
+    return selected_entries
+
+
+def _order_results(
+    plan: HarnessInstallPlan,
+    project_root: str,
+    selected_entries: dict[HarnessName, HarnessInstallReportEntry],
+) -> list[HarnessInstallReportEntry]:
+    skipped_entries = [
+        _build_skipped_entry(project_root, entry["harness"], entry["reason"])
+        for entry in plan["entries"]
+        if entry["selection"] == "skipped"
+    ]
+    selected_results = [
+        selected_entries[harness]
+        for harness in plan["selectedHarnesses"]
+        if harness in selected_entries
+    ]
+    return [*selected_results, *skipped_entries]
+
+
+def _is_successful(entry: HarnessInstallReportEntry) -> bool:
+    return entry["state"] == "installed" or entry["state"] == "skipped"
+
+
+async def install_harnesses(
+    *,
+    project_root: str,
+    requested_harnesses: list[HarnessName] | None = None,
+    environment: InstallEnvironment | None = None,
+) -> InstallReport:
+    requested = dedupe_harness_names(list(requested_harnesses or []))
+    detection_env = (
+        HarnessDetectionEnvironment(
+            findCommand=environment.findCommand,
+            hasDirectory=environment.hasDirectory,
+        )
+        if environment is not None
+        else None
+    )
+    plan = await create_harness_install_plan(
+        project_root=project_root,
+        requested_harnesses=requested,
+        environment=detection_env,
+    )
+
+    if not plan["ok"]:
+        report: InstallReport = {
+            "selectionMode": plan["selectionMode"],
+            "results": [
+                _build_skipped_entry(project_root, entry["harness"], entry["reason"])
+                for entry in plan["entries"]
+            ],
+            "ok": False,
+        }
+        if "guidance" in plan:
+            report["guidance"] = plan["guidance"]
+        return report
+
+    selected_entries = await _install_selected_harnesses(
+        plan, project_root=project_root, environment=environment
+    )
+    results = _order_results(plan, project_root, selected_entries)
+    return {
+        "selectionMode": plan["selectionMode"],
+        "results": results,
+        "ok": all(_is_successful(entry) for entry in results),
+    }
+
+
+def has_blocking_install_result(report: InstallReport) -> bool:
+    return not report["ok"]
+
+
+def _format_entry(entry: HarnessInstallReportEntry) -> list[str]:
+    lines = [f"[{entry['state']}] {entry['displayName']}"]
+    if "outputRoot" in entry:
+        lines.append(f"  Bundle: {entry['outputRoot']}")
+    lines.append(f"  {entry['reason']}")
+    if entry["nextSteps"]:
+        lines.append("  Next steps:")
+        lines.extend(f"  - {step}" for step in entry["nextSteps"])
+    return lines
+
+
+def format_install_report(report: InstallReport) -> str:
+    lines: list[str] = []
+    for entry in report["results"]:
+        lines.extend(_format_entry(entry))
+        lines.append("")
+    if "guidance" in report:
+        lines.append(f"Guidance: {report['guidance']}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+async def _run_phase1_install(
+    context: _SelectedInstallContext,
+) -> _Phase1InstallResult:
+    harness = context.bundle.harness
+    if harness == "cursor":
+        return await _install_cursor_bundle()
+    if harness == "copilot-cli":
+        return await _install_copilot_cli_bundle(context)
+    if harness == "claude-code":
+        return await _install_claude_code_bundle(context)
+    if harness == "codex":
+        return await _install_codex_bundle(context)
+    raise ValueError(f"Unsupported harness: {harness}")  # pragma: no cover
+
+
+async def _install_cursor_bundle() -> _Phase1InstallResult:
+    return {
+        "state": "installed",
+        "reason": "Compiled .cursor/ tree is the installed surface for Cursor.",
+        "nextSteps": [],
+    }
+
+
+async def _install_copilot_cli_bundle(
+    context: _SelectedInstallContext,
+) -> _Phase1InstallResult:
+    copilot_path = await context.findCommand("copilot")
+    install_command = f"copilot plugin install {_shell_quote(context.bundle.outputRoot)}"
+
+    if copilot_path is None:
+        return {
+            "state": "failed",
+            "reason": (
+                'GitHub Copilot CLI requires the "copilot" command on PATH to '
+                "finish installation."
+            ),
+            "nextSteps": [f"Install GitHub Copilot CLI, then run {install_command}."],
+        }
+
+    try:
+        await context.executeCommand(
+            copilot_path,
+            ["plugin", "install", context.bundle.outputRoot],
+            os.path.dirname(context.bundle.outputRoot),
+        )
+    except Exception as error:  # noqa: BLE001
+        return {
+            "state": "failed",
+            "reason": f"copilot plugin install failed: {_command_failure_message(error)}",
+            "nextSteps": [],
+        }
+
+    return {
+        "state": "installed",
+        "reason": f"Installed the compiled bundle with {install_command}.",
+        "nextSteps": [],
+    }
+
+
+async def _install_claude_code_bundle(
+    context: _SelectedInstallContext,
+) -> _Phase1InstallResult:
+    details = await write_claude_marketplace(
+        context.bundle.outputRoot,
+        context.bundle.pluginMetadata,
+    )
+    claude_path = await context.findCommand("claude")
+    add_command = (
+        f"claude plugin marketplace add {_shell_quote(context.bundle.outputRoot)}"
+    )
+    reason = (
+        'Claude Code still requires manual installation, and the "claude" CLI is not '
+        "on PATH for the marketplace-add step."
+        if claude_path is None
+        else "Claude Code still requires manual installation after adding the local marketplace."
+    )
+    return {
+        "state": "manual",
+        "reason": reason,
+        "nextSteps": [
+            add_command,
+            (
+                f'Open Claude Code, run /plugin, then install "{details.pluginName}" '
+                f'from "{details.marketplaceName}".'
+            ),
+        ],
+    }
+
+
+async def _install_codex_bundle(
+    context: _SelectedInstallContext,
+) -> _Phase1InstallResult:
+    details = await write_codex_marketplace(
+        context.bundle.outputRoot,
+        context.bundle.pluginMetadata,
+    )
+    codex_path = await context.findCommand("codex")
+    add_command = (
+        f"codex plugin marketplace add {_shell_quote(context.bundle.outputRoot)}"
+    )
+    reason = (
+        'Codex still requires manual installation, and the "codex" CLI is not on '
+        "PATH for the marketplace-add step."
+        if codex_path is None
+        else "Codex still requires manual installation after adding the local marketplace."
+    )
+    return {
+        "state": "manual",
+        "reason": reason,
+        "nextSteps": [
+            add_command,
+            "Restart Codex.",
+            (
+                f'Open /plugins, choose "{details.marketplaceName}", and install '
+                f'"{details.pluginName}".'
+            ),
+        ],
+    }
+
+
+__all__ = [
+    "CommandExecutionResult",
+    "CommandExecutor",
+    "HarnessInstallReportEntry",
+    "HarnessInstallState",
+    "InstallEnvironment",
+    "InstallReport",
+    "default_command_executor",
+    "format_install_report",
+    "has_blocking_install_result",
+    "install_harnesses",
+]

--- a/python/cheese_flow/lib/local_marketplaces.py
+++ b/python/cheese_flow/lib/local_marketplaces.py
@@ -1,0 +1,125 @@
+"""Port of `src/lib/local-marketplaces.ts` — local marketplace JSON writers.
+
+Mirrors the TS surface: ``write_claude_marketplace`` and
+``write_codex_marketplace`` emit harness-specific ``marketplace.json`` files
+under the compiled bundle root. Both return a small dataclass describing the
+marketplace and plugin names so installer guidance can reference them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from cheese_flow.lib.harness import PluginMetadata
+
+
+@dataclass(frozen=True)
+class MarketplaceInstallDetails:
+    marketplaceName: str
+    pluginName: str
+
+
+def _marketplace_name(plugin_name: str) -> str:
+    return f"{plugin_name}-local"
+
+
+async def _write_json_file(file_path: Path, payload: dict[str, Any]) -> None:
+    def _write() -> None:
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+    await asyncio.to_thread(_write)
+
+
+def _author_payload(metadata: PluginMetadata) -> dict[str, Any]:
+    author = metadata["author"]
+    payload: dict[str, Any] = {"name": author["name"]}
+    if "email" in author:
+        payload["email"] = author["email"]
+    return payload
+
+
+def _claude_plugin_entry(metadata: PluginMetadata) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "name": metadata["name"],
+        "source": "./",
+        "description": metadata["description"],
+        "version": metadata["version"],
+        "author": metadata["author"],
+        "repository": metadata["repository"],
+    }
+    if "homepage" in metadata:
+        entry["homepage"] = metadata["homepage"]
+    if "keywords" in metadata:
+        entry["keywords"] = metadata["keywords"]
+    entry["strict"] = True
+    return entry
+
+
+async def write_claude_marketplace(
+    bundle_root: str,
+    metadata: PluginMetadata,
+) -> MarketplaceInstallDetails:
+    details = MarketplaceInstallDetails(
+        marketplaceName=_marketplace_name(metadata["name"]),
+        pluginName=metadata["name"],
+    )
+    payload: dict[str, Any] = {
+        "name": details.marketplaceName,
+        "owner": _author_payload(metadata),
+        "plugins": [_claude_plugin_entry(metadata)],
+    }
+    await _write_json_file(
+        Path(bundle_root) / ".claude-plugin" / "marketplace.json",
+        payload,
+    )
+    return details
+
+
+async def write_codex_marketplace(
+    bundle_root: str,
+    metadata: PluginMetadata,
+) -> MarketplaceInstallDetails:
+    details = MarketplaceInstallDetails(
+        marketplaceName=_marketplace_name(metadata["name"]),
+        pluginName=metadata["name"],
+    )
+    payload: dict[str, Any] = {
+        "name": details.marketplaceName,
+        "interface": {
+            "displayName": f"{metadata['name']} Local",
+        },
+        "plugins": [
+            {
+                "name": metadata["name"],
+                "source": {
+                    "source": "local",
+                    "path": "./",
+                },
+                "policy": {
+                    "installation": "AVAILABLE",
+                    "authentication": "ON_INSTALL",
+                },
+                "category": "Development",
+            }
+        ],
+    }
+    await _write_json_file(
+        Path(bundle_root) / ".agents" / "plugins" / "marketplace.json",
+        payload,
+    )
+    return details
+
+
+__all__ = [
+    "MarketplaceInstallDetails",
+    "write_claude_marketplace",
+    "write_codex_marketplace",
+]

--- a/ralphs/python-migration/TODO.md
+++ b/ralphs/python-migration/TODO.md
@@ -13,7 +13,7 @@ US-005 (install-plan), US-006 (harness-detection), and US-007 (harness-compat).
 - [x] US-005 — Port `src/lib/install-plan.ts` → `python/cheese_flow/lib/install_plan.py`; port `tests/install-plan.test.ts`
 - [x] US-006 — Port `src/lib/harness-detection.ts` → `python/cheese_flow/lib/harness_detection.py`; port `tests/harness-detection.test.ts`
 - [x] US-007 — Port `src/lib/harness-compat.ts` → `python/cheese_flow/lib/harness_compat.py`; port `tests/harness-compat.test.ts`
-- [ ] US-008 — Port `src/lib/installer.ts` → `python/cheese_flow/lib/installer.py`; depends on US-005/006/007; port `tests/installer.test.ts`
+- [x] US-008 — Port `src/lib/installer.ts` → `python/cheese_flow/lib/installer.py`; depends on US-005/006/007; port `tests/installer.test.ts`
 - [ ] US-009 — Port `src/lib/sweeper.ts` → `python/cheese_flow/lib/sweeper.py`; port `tests/sweeper.test.ts`
 - [ ] US-010 — Port `src/lib/session-start.ts` → `python/cheese_flow/lib/session_start.py`; port `tests/session-start.test.ts`
 - [ ] US-011 — Port `src/lib/doctor.ts` → `python/cheese_flow/lib/doctor.py`; port matching vitest cases

--- a/tests/python/test_installer.py
+++ b/tests/python/test_installer.py
@@ -77,9 +77,7 @@ def _make_environment(
     async def has_directory(directory_path: str) -> bool:
         return directory_path in surface_set
 
-    async def execute_command(
-        command: str, args: list[str], cwd: str
-    ) -> CommandExecutionResult:
+    async def execute_command(command: str, args: list[str], cwd: str) -> CommandExecutionResult:
         if on_execute is not None:
             on_execute(command, args, cwd)
         return {"stdout": "", "stderr": ""}
@@ -174,21 +172,15 @@ def test_auto_detects_claude_code_and_codex_from_path_and_reports_manual_next_st
     assert "[manual] Codex" in output
     assert "[skipped] Cursor" in output
     assert "[skipped] GitHub Copilot CLI" in output
-    assert (
-        f"claude plugin marketplace add {json.dumps(str(project_root / '.claude'))}"
-    ) in output
-    assert (
-        f"codex plugin marketplace add {json.dumps(str(project_root / '.codex'))}"
-    ) in output
+    assert (f"claude plugin marketplace add {json.dumps(str(project_root / '.claude'))}") in output
+    assert (f"codex plugin marketplace add {json.dumps(str(project_root / '.codex'))}") in output
     assert (
         'Open Claude Code, run /plugin, then install "cheese-flow" from "cheese-flow-local".'
     ) in output
     assert "Restart Codex." in output
     assert "Guidance:" not in output
     assert (project_root / ".claude" / ".claude-plugin" / "marketplace.json").exists()
-    assert (
-        project_root / ".codex" / ".agents" / "plugins" / "marketplace.json"
-    ).exists()
+    assert (project_root / ".codex" / ".agents" / "plugins" / "marketplace.json").exists()
 
 
 def test_marks_claude_code_and_codex_as_manual_and_emits_local_marketplace_helpers(
@@ -210,13 +202,9 @@ def test_marks_claude_code_and_codex_as_manual_and_emits_local_marketplace_helpe
 
     assert report["ok"] is False
     assert "[manual] Claude Code" in output
-    assert (
-        f"claude plugin marketplace add {json.dumps(str(project_root / '.claude'))}"
-    ) in output
+    assert (f"claude plugin marketplace add {json.dumps(str(project_root / '.claude'))}") in output
     assert "[manual] Codex" in output
-    assert (
-        f"codex plugin marketplace add {json.dumps(str(project_root / '.codex'))}"
-    ) in output
+    assert (f"codex plugin marketplace add {json.dumps(str(project_root / '.codex'))}") in output
     assert "Restart Codex." in output
     assert 'Open /plugins, choose "cheese-flow-local"' in output
 
@@ -228,9 +216,9 @@ def test_marks_claude_code_and_codex_as_manual_and_emits_local_marketplace_helpe
     assert claude_marketplace["plugins"][0]["source"] == "./"
 
     codex_marketplace = json.loads(
-        (
-            project_root / ".codex" / ".agents" / "plugins" / "marketplace.json"
-        ).read_text(encoding="utf-8")
+        (project_root / ".codex" / ".agents" / "plugins" / "marketplace.json").read_text(
+            encoding="utf-8"
+        )
     )
     assert codex_marketplace["plugins"][0]["source"] == {
         "source": "local",
@@ -260,17 +248,13 @@ def test_parses_repeated_harness_overrides_and_bypasses_auto_detect_for_other_ha
     report = asyncio.run(
         install_harnesses(
             project_root=str(project_root),
-            requested_harnesses=parse_harness_overrides(
-                ["cursor,copilot-cli", "cursor"]
-            ),
+            requested_harnesses=parse_harness_overrides(["cursor,copilot-cli", "cursor"]),
             environment=environment,
         )
     )
     output = format_install_report(report)
 
-    assert (
-        len([line for line in output.split("\n") if "[installed] Cursor" in line]) == 1
-    )
+    assert len([line for line in output.split("\n") if "[installed] Cursor" in line]) == 1
     assert "[installed] GitHub Copilot CLI" in output
     assert "[skipped] Claude Code" in output
     assert "[skipped] Codex" in output

--- a/tests/python/test_installer.py
+++ b/tests/python/test_installer.py
@@ -1,0 +1,320 @@
+"""Port of `tests/installer.test.ts`.
+
+The TS suite spawns ``cheese install`` as a subprocess via ``tsx`` and asserts
+on the formatted stdout/stderr. The Python ``cheese`` CLI does not exist yet
+(arrives in US-015), so this port translates the test surface to library-level
+calls against ``install_harnesses`` + ``format_install_report`` while still
+asserting on the same formatted output strings the TS test verifies.
+
+Each TS case maps 1:1 to a Python case:
+
+* ``runCheeseInstall(["--project-root", projectRoot])`` →
+  ``install_harnesses(project_root=..., environment=...)`` with a mocked
+  ``find_command`` / ``has_directory`` / ``execute_command``.
+* ``--harness foo,bar`` → ``requested_harnesses=[foo, bar]`` (the CLI parses
+  the comma-list into the same shape).
+* PATH overrides → ``find_command`` only resolves the names enumerated in the
+  per-test environment.
+* ``-H cursor,copilot-cli -H cursor`` → the dedupe happens in
+  ``parse_harness_overrides``; the test uses that helper directly to mirror
+  what the CLI will do in US-015.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cheese_flow.lib.install_plan import parse_harness_overrides
+from cheese_flow.lib.installer import (
+    CommandExecutionResult,
+    InstallEnvironment,
+    InstallReport,
+    format_install_report,
+    install_harnesses,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def project_factory(tmp_path: Path) -> Any:
+    """Returns a callable that copies agents/skills/commands into a fresh tmp dir."""
+
+    created: list[Path] = []
+
+    def make_project_root(prefix: str) -> Path:
+        directory = tmp_path / f"{prefix}-{uuid.uuid4()}"
+        directory.mkdir(parents=True)
+        for source_name in ("agents", "skills", "commands"):
+            shutil.copytree(REPO_ROOT / source_name, directory / source_name)
+        created.append(directory)
+        return directory
+
+    yield make_project_root
+
+    for directory in created:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+def _make_environment(
+    *,
+    commands: dict[str, str] | None = None,
+    surfaces: list[str] | None = None,
+    on_execute: Any = None,
+) -> InstallEnvironment:
+    command_map = dict(commands or {})
+    surface_set = set(surfaces or [])
+
+    async def find_command(command: str) -> str | None:
+        return command_map.get(command)
+
+    async def has_directory(directory_path: str) -> bool:
+        return directory_path in surface_set
+
+    async def execute_command(
+        command: str, args: list[str], cwd: str
+    ) -> CommandExecutionResult:
+        if on_execute is not None:
+            on_execute(command, args, cwd)
+        return {"stdout": "", "stderr": ""}
+
+    return InstallEnvironment(
+        findCommand=find_command,
+        hasDirectory=has_directory,
+        executeCommand=execute_command,
+    )
+
+
+def test_fails_with_guidance_and_emits_no_bundles_when_auto_detect_finds_nothing(
+    project_factory: Any,
+) -> None:
+    project_root = project_factory("install-no-detect")
+
+    report = asyncio.run(
+        install_harnesses(
+            project_root=str(project_root),
+            environment=_make_environment(),
+        )
+    )
+
+    assert report["ok"] is False
+    output = format_install_report(report)
+    assert "No installed harnesses detected" in output
+    assert "cheese compile" in output
+    assert not (project_root / ".claude").exists()
+    assert not (project_root / ".codex").exists()
+    assert not (project_root / ".copilot").exists()
+    assert not (project_root / ".cursor").exists()
+
+
+def test_auto_detects_cursor_and_copilot_compiles_only_those_bundles_and_installs_copilot(
+    project_factory: Any,
+) -> None:
+    project_root = project_factory("install-auto")
+    (project_root / ".cursor").mkdir()
+
+    captured: list[tuple[str, list[str], str]] = []
+
+    def record(command: str, args: list[str], cwd: str) -> None:
+        captured.append((command, args, cwd))
+
+    environment = _make_environment(
+        commands={"copilot": "/mock/bin/copilot"},
+        surfaces=[str(project_root / ".cursor")],
+        on_execute=record,
+    )
+
+    report = asyncio.run(
+        install_harnesses(
+            project_root=str(project_root),
+            environment=environment,
+        )
+    )
+    output = format_install_report(report)
+
+    assert "[installed] Cursor" in output
+    assert "[installed] GitHub Copilot CLI" in output
+    assert "[skipped] Claude Code" in output
+    assert "[skipped] Codex" in output
+    assert (project_root / ".cursor").exists()
+    assert (project_root / ".copilot").exists()
+    assert not (project_root / ".claude").exists()
+    assert not (project_root / ".codex").exists()
+    assert any(
+        command == "/mock/bin/copilot"
+        and args == ["plugin", "install", str(project_root / ".copilot")]
+        for command, args, _ in captured
+    )
+
+
+def test_auto_detects_claude_code_and_codex_from_path_and_reports_manual_next_steps(
+    project_factory: Any,
+) -> None:
+    project_root = project_factory("install-manual-auto")
+
+    environment = _make_environment(
+        commands={"claude": "/mock/bin/claude", "codex": "/mock/bin/codex"},
+    )
+    report = asyncio.run(
+        install_harnesses(
+            project_root=str(project_root),
+            environment=environment,
+        )
+    )
+    output = format_install_report(report)
+
+    assert report["ok"] is False
+    assert "[manual] Claude Code" in output
+    assert "[manual] Codex" in output
+    assert "[skipped] Cursor" in output
+    assert "[skipped] GitHub Copilot CLI" in output
+    assert (
+        f"claude plugin marketplace add {json.dumps(str(project_root / '.claude'))}"
+    ) in output
+    assert (
+        f"codex plugin marketplace add {json.dumps(str(project_root / '.codex'))}"
+    ) in output
+    assert (
+        'Open Claude Code, run /plugin, then install "cheese-flow" from "cheese-flow-local".'
+    ) in output
+    assert "Restart Codex." in output
+    assert "Guidance:" not in output
+    assert (project_root / ".claude" / ".claude-plugin" / "marketplace.json").exists()
+    assert (
+        project_root / ".codex" / ".agents" / "plugins" / "marketplace.json"
+    ).exists()
+
+
+def test_marks_claude_code_and_codex_as_manual_and_emits_local_marketplace_helpers(
+    project_factory: Any,
+) -> None:
+    project_root = project_factory("install-manual")
+
+    environment = _make_environment(
+        commands={"claude": "/mock/bin/claude", "codex": "/mock/bin/codex"},
+    )
+    report = asyncio.run(
+        install_harnesses(
+            project_root=str(project_root),
+            requested_harnesses=parse_harness_overrides(["claude-code,codex"]),
+            environment=environment,
+        )
+    )
+    output = format_install_report(report)
+
+    assert report["ok"] is False
+    assert "[manual] Claude Code" in output
+    assert (
+        f"claude plugin marketplace add {json.dumps(str(project_root / '.claude'))}"
+    ) in output
+    assert "[manual] Codex" in output
+    assert (
+        f"codex plugin marketplace add {json.dumps(str(project_root / '.codex'))}"
+    ) in output
+    assert "Restart Codex." in output
+    assert 'Open /plugins, choose "cheese-flow-local"' in output
+
+    claude_marketplace = json.loads(
+        (project_root / ".claude" / ".claude-plugin" / "marketplace.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert claude_marketplace["plugins"][0]["source"] == "./"
+
+    codex_marketplace = json.loads(
+        (
+            project_root / ".codex" / ".agents" / "plugins" / "marketplace.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert codex_marketplace["plugins"][0]["source"] == {
+        "source": "local",
+        "path": "./",
+    }
+
+
+def test_parses_repeated_harness_overrides_and_bypasses_auto_detect_for_other_harnesses(
+    project_factory: Any,
+) -> None:
+    project_root = project_factory("install-explicit")
+    (project_root / ".cursor").mkdir()
+
+    captured: list[tuple[str, list[str], str]] = []
+
+    def record(command: str, args: list[str], cwd: str) -> None:
+        captured.append((command, args, cwd))
+
+    environment = _make_environment(
+        commands={
+            "claude": "/mock/bin/claude",
+            "codex": "/mock/bin/codex",
+            "copilot": "/mock/bin/copilot",
+        },
+        on_execute=record,
+    )
+    report = asyncio.run(
+        install_harnesses(
+            project_root=str(project_root),
+            requested_harnesses=parse_harness_overrides(
+                ["cursor,copilot-cli", "cursor"]
+            ),
+            environment=environment,
+        )
+    )
+    output = format_install_report(report)
+
+    assert (
+        len([line for line in output.split("\n") if "[installed] Cursor" in line]) == 1
+    )
+    assert "[installed] GitHub Copilot CLI" in output
+    assert "[skipped] Claude Code" in output
+    assert "[skipped] Codex" in output
+    assert (project_root / ".cursor").exists()
+    assert (project_root / ".copilot").exists()
+    assert not (project_root / ".claude").exists()
+    assert not (project_root / ".codex").exists()
+    assert any(
+        command == "/mock/bin/copilot"
+        and args == ["plugin", "install", str(project_root / ".copilot")]
+        for command, args, _ in captured
+    )
+
+
+def test_fails_a_selected_copilot_install_when_the_copilot_cli_is_unavailable(
+    project_factory: Any,
+) -> None:
+    project_root = project_factory("install-copilot-missing")
+
+    environment = _make_environment()
+    report = asyncio.run(
+        install_harnesses(
+            project_root=str(project_root),
+            requested_harnesses=parse_harness_overrides(["copilot-cli"]),
+            environment=environment,
+        )
+    )
+    output = format_install_report(report)
+
+    assert report["ok"] is False
+    assert "[failed] GitHub Copilot CLI" in output
+    assert 'requires the "copilot" command on PATH' in output
+    assert (project_root / ".copilot").exists()
+
+
+def test_install_report_typed_dict_fields_match_ts_shape() -> None:
+    """Sanity: TS ``InstallReport`` carries ``selectionMode``, ``results``,
+    ``ok``, optional ``guidance``. The Python TypedDict mirror should accept the
+    same payload shapes — verify by constructing a minimal report."""
+    report: InstallReport = {
+        "selectionMode": "auto-detect",
+        "results": [],
+        "ok": True,
+    }
+    assert report["selectionMode"] == "auto-detect"
+    assert report["results"] == []
+    assert report["ok"] is True


### PR DESCRIPTION
Ports `src/lib/installer.ts` to `python/cheese_flow/lib/installer.py`,
with the local marketplace JSON writers (`writeClaudeMarketplace`,
`writeCodexMarketplace`) ported alongside as `local_marketplaces.py`
since the installer is their only consumer.

`install_harnesses` consumes the install_plan, harness_detection, and
local_marketplaces modules to produce the same `InstallReport` shape
the TS surface emits, with `format_install_report` matching the
TS `formatInstallReport` output line-for-line.

Tests: `tests/installer.test.ts` ported as library-level pytest cases
under `tests/python/test_installer.py`. The TS suite spawns
`cheese install` via tsx; since the Python CLI is a US-015
deliverable, this port calls `install_harnesses` directly with mocked
`find_command`/`has_directory`/`execute_command` while still asserting
on the same formatted strings (`[installed] Cursor`, `cheese compile`
guidance, marketplace.json contents, etc.).

Co-authored-by: Ralphify <noreply@ralphify.co>