### PR TITLE
feat(migration): US-009 sweeper (TS → Python)

### DIFF
--- a/python/cheese_flow/lib/sweeper.py
+++ b/python/cheese_flow/lib/sweeper.py
@@ -1,0 +1,358 @@
+"""Port of `src/lib/sweeper.ts` — stale-file cleanup logic for ~/.cheese.
+
+Mirrors the TS surface: ``sweep`` returns a ``SweepReport`` describing reaped
+entries and any non-fatal errors. Atomic deletion via rename-into-orphan-then-rm,
+24h debounce via ``.last-sweep`` mtime, per-repo retention overrides via
+``shared/retention.toml``.
+
+The TS module imports ``readRetentionConfig`` and ``RetentionConfig`` from
+``./cheese-home.ts``. US-012 hasn't ported ``cheese-home.ts`` yet, so this file
+inlines the minimal retention-config surface. When US-012 lands, the inlined
+helpers can move there.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TypedDict
+
+DEBOUNCE_MS = 24 * 60 * 60 * 1000
+ORPHAN_PREFIX = ".reap-"
+DEFAULT_RETENTION_DAYS = 30
+_RETENTION_NUMERIC_KEYS: frozenset[str] = frozenset(
+    {
+        "defaultDays",
+        "milknadoDays",
+        "manifestsDays",
+        "runsDays",
+        "worktreeDays",
+    }
+)
+
+
+@dataclass
+class RetentionConfig:
+    defaultDays: int = DEFAULT_RETENTION_DAYS
+    milknadoDays: int | None = None
+    manifestsDays: int | None = None
+    runsDays: int | None = None
+    worktreeDays: int | None = None
+
+
+class ReapEntry(TypedDict):
+    path: str
+    reason: str
+    bytes: int
+
+
+class SweepError(TypedDict):
+    path: str
+    error: str
+
+
+class SweepReport(TypedDict):
+    scannedProjects: int
+    reaped: list[ReapEntry]
+    errors: list[SweepError]
+    durationMs: int
+
+
+@dataclass
+class SweepOptions:
+    scope: Literal["all", "project"]
+    home: str
+    projectDir: str | None = None
+    now: float | None = None  # epoch ms; mirrors TS Date.getTime()
+    dryRun: bool = False
+    force: bool = False
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _to_now_ms(now: float | None) -> int:
+    if now is None:
+        return _now_ms()
+    return int(now)
+
+
+def _read_retention_config(project_dir: str) -> RetentionConfig:
+    toml_path = Path(project_dir) / "shared" / "retention.toml"
+    try:
+        body = toml_path.read_text(encoding="utf-8")
+    except OSError:
+        return RetentionConfig()
+    return _parse_retention_toml(body)
+
+
+def _strip_comment(line: str) -> str:
+    hash_idx = line.find("#")
+    return line if hash_idx < 0 else line[:hash_idx]
+
+
+def _parse_retention_toml(body: str) -> RetentionConfig:
+    config: dict[str, int] = {"defaultDays": DEFAULT_RETENTION_DAYS}
+    for raw_line in body.splitlines():
+        line = _strip_comment(raw_line).strip()
+        if line == "" or line.startswith("["):
+            continue
+        eq = line.find("=")
+        if eq < 0:
+            continue
+        key = line[:eq].strip()
+        value = line[eq + 1 :].strip()
+        if key not in _RETENTION_NUMERIC_KEYS:
+            continue
+        try:
+            parsed = int(value, 10)
+        except ValueError:
+            continue
+        config[key] = parsed
+    return RetentionConfig(
+        defaultDays=config.get("defaultDays", DEFAULT_RETENTION_DAYS),
+        milknadoDays=config.get("milknadoDays"),
+        manifestsDays=config.get("manifestsDays"),
+        runsDays=config.get("runsDays"),
+        worktreeDays=config.get("worktreeDays"),
+    )
+
+
+def sweep(opts: SweepOptions) -> SweepReport:
+    start = _now_ms()
+    now_ms = _to_now_ms(opts.now)
+    last_sweep = os.path.join(opts.home, ".last-sweep")
+
+    if not opts.force and _is_debounced(last_sweep, now_ms):
+        return SweepReport(
+            scannedProjects=0,
+            reaped=[],
+            errors=[],
+            durationMs=_now_ms() - start,
+        )
+
+    project_dirs = _collect_project_dirs(opts)
+    reaped: list[ReapEntry] = []
+    errors: list[SweepError] = []
+    for project_dir in project_dirs:
+        config = _read_retention_config(project_dir)
+        _sweep_project(project_dir, config, now_ms, opts.dryRun, reaped, errors)
+    if not opts.dryRun:
+        _touch_file(last_sweep, now_ms)
+    return SweepReport(
+        scannedProjects=len(project_dirs),
+        reaped=reaped,
+        errors=errors,
+        durationMs=_now_ms() - start,
+    )
+
+
+def _is_debounced(last_sweep: str, now_ms: int) -> bool:
+    try:
+        info = os.stat(last_sweep)
+    except OSError:
+        return False
+    return now_ms - int(info.st_mtime * 1000) < DEBOUNCE_MS
+
+
+def _collect_project_dirs(opts: SweepOptions) -> list[str]:
+    if opts.scope == "project" and opts.projectDir:
+        return [opts.projectDir]
+    projects_root = os.path.join(opts.home, "projects")
+    try:
+        entries = list(os.scandir(projects_root))
+    except OSError:
+        return []
+    return [entry.path for entry in entries if entry.is_dir()]
+
+
+def _sweep_project(
+    project_dir: str,
+    config: RetentionConfig,
+    now_ms: int,
+    dry_run: bool,
+    reaped: list[ReapEntry],
+    errors: list[SweepError],
+) -> None:
+    _reap_milknado(project_dir, config, now_ms, dry_run, reaped, errors)
+    _reap_worktrees(project_dir, config, now_ms, dry_run, reaped, errors)
+
+
+def _reap_milknado(
+    project_dir: str,
+    config: RetentionConfig,
+    now_ms: int,
+    dry_run: bool,
+    reaped: list[ReapEntry],
+    errors: list[SweepError],
+) -> None:
+    db = os.path.join(project_dir, "milknado", "milknado.db")
+    days = (
+        config.milknadoDays if config.milknadoDays is not None else config.defaultDays
+    )
+    if _is_older_than(db, now_ms, days):
+        _reap(db, f"milknado.db older than {days}d", dry_run, reaped, errors)
+
+
+def _reap_worktrees(
+    project_dir: str,
+    config: RetentionConfig,
+    now_ms: int,
+    dry_run: bool,
+    reaped: list[ReapEntry],
+    errors: list[SweepError],
+) -> None:
+    wt_root = os.path.join(project_dir, "worktrees")
+    try:
+        entries = list(os.scandir(wt_root))
+    except OSError:
+        return
+    for entry in entries:
+        child = os.path.join(wt_root, entry.name)
+        if entry.name.startswith(ORPHAN_PREFIX):
+            _reap(child, "orphaned reap-tmp", dry_run, reaped, errors)
+            continue
+        if not entry.is_dir():
+            continue
+        _sweep_worktree(child, config, now_ms, dry_run, reaped, errors)
+
+
+def _sweep_worktree(
+    worktree_dir: str,
+    config: RetentionConfig,
+    now_ms: int,
+    dry_run: bool,
+    reaped: list[ReapEntry],
+    errors: list[SweepError],
+) -> None:
+    wt_days = (
+        config.worktreeDays if config.worktreeDays is not None else config.defaultDays
+    )
+    if _is_older_than(worktree_dir, now_ms, wt_days) and not _sidecar_target_exists(
+        worktree_dir
+    ):
+        _reap(
+            worktree_dir,
+            f"worktree dir older than {wt_days}d AND .path target gone",
+            dry_run,
+            reaped,
+            errors,
+        )
+        return
+    _reap_manifests(worktree_dir, config, now_ms, dry_run, reaped, errors)
+    _reap_runs(worktree_dir, config, now_ms, dry_run, reaped, errors)
+
+
+def _reap_manifests(
+    worktree_dir: str,
+    config: RetentionConfig,
+    now_ms: int,
+    dry_run: bool,
+    reaped: list[ReapEntry],
+    errors: list[SweepError],
+) -> None:
+    manifests = os.path.join(worktree_dir, "manifests")
+    days = (
+        config.manifestsDays
+        if config.manifestsDays is not None
+        else config.defaultDays
+    )
+    if _is_older_than(manifests, now_ms, days):
+        _reap(manifests, f"manifests older than {days}d", dry_run, reaped, errors)
+
+
+def _reap_runs(
+    worktree_dir: str,
+    config: RetentionConfig,
+    now_ms: int,
+    dry_run: bool,
+    reaped: list[ReapEntry],
+    errors: list[SweepError],
+) -> None:
+    runs = os.path.join(worktree_dir, "runs")
+    days = config.runsDays if config.runsDays is not None else config.defaultDays
+    try:
+        entries = list(os.scandir(runs))
+    except OSError:
+        return
+    for entry in entries:
+        if not entry.is_dir():
+            continue
+        run_dir = os.path.join(runs, entry.name)
+        if _is_older_than(run_dir, now_ms, days):
+            _reap(run_dir, f"run dir older than {days}d", dry_run, reaped, errors)
+
+
+def _sidecar_target_exists(worktree_dir: str) -> bool:
+    sidecar = os.path.join(worktree_dir, ".path")
+    try:
+        body = Path(sidecar).read_text(encoding="utf-8")
+    except OSError:
+        return False
+    target = body.strip()
+    if len(target) == 0:
+        return False
+    try:
+        os.stat(target)
+        return True
+    except OSError:
+        return False
+
+
+def _is_older_than(target: str, now_ms: int, days: int) -> bool:
+    try:
+        info = os.stat(target)
+    except OSError:
+        return False
+    age_ms = now_ms - int(info.st_mtime * 1000)
+    return age_ms > days * 24 * 60 * 60 * 1000
+
+
+def _reap(
+    target: str,
+    reason: str,
+    dry_run: bool,
+    reaped: list[ReapEntry],
+    errors: list[SweepError],
+) -> None:
+    try:
+        info = os.stat(target)
+    except OSError:
+        return
+    bytes_ = 0 if os.path.isdir(target) else info.st_size
+    reaped.append(ReapEntry(path=target, reason=reason, bytes=bytes_))
+    if dry_run:
+        return
+    try:
+        tmp = (
+            f"{os.path.dirname(target)}/{ORPHAN_PREFIX}"
+            f"{_now_ms()}-{os.path.basename(target)}"
+        )
+        os.rename(target, tmp)
+        if os.path.isdir(tmp) and not os.path.islink(tmp):
+            shutil.rmtree(tmp, ignore_errors=True)
+        else:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+    except OSError as error:
+        errors.append(
+            SweepError(
+                path=target,
+                error=str(error) if str(error) else type(error).__name__,
+            )
+        )
+
+
+def _touch_file(target: str, now_ms: int) -> None:
+    try:
+        Path(target).touch(exist_ok=True)
+        ts = now_ms / 1000.0
+        os.utime(target, (ts, ts))
+    except OSError:
+        # best effort
+        pass

--- a/python/cheese_flow/lib/sweeper.py
+++ b/python/cheese_flow/lib/sweeper.py
@@ -192,9 +192,7 @@ def _reap_milknado(
     errors: list[SweepError],
 ) -> None:
     db = os.path.join(project_dir, "milknado", "milknado.db")
-    days = (
-        config.milknadoDays if config.milknadoDays is not None else config.defaultDays
-    )
+    days = config.milknadoDays if config.milknadoDays is not None else config.defaultDays
     if _is_older_than(db, now_ms, days):
         _reap(db, f"milknado.db older than {days}d", dry_run, reaped, errors)
 
@@ -230,12 +228,8 @@ def _sweep_worktree(
     reaped: list[ReapEntry],
     errors: list[SweepError],
 ) -> None:
-    wt_days = (
-        config.worktreeDays if config.worktreeDays is not None else config.defaultDays
-    )
-    if _is_older_than(worktree_dir, now_ms, wt_days) and not _sidecar_target_exists(
-        worktree_dir
-    ):
+    wt_days = config.worktreeDays if config.worktreeDays is not None else config.defaultDays
+    if _is_older_than(worktree_dir, now_ms, wt_days) and not _sidecar_target_exists(worktree_dir):
         _reap(
             worktree_dir,
             f"worktree dir older than {wt_days}d AND .path target gone",
@@ -257,11 +251,7 @@ def _reap_manifests(
     errors: list[SweepError],
 ) -> None:
     manifests = os.path.join(worktree_dir, "manifests")
-    days = (
-        config.manifestsDays
-        if config.manifestsDays is not None
-        else config.defaultDays
-    )
+    days = config.manifestsDays if config.manifestsDays is not None else config.defaultDays
     if _is_older_than(manifests, now_ms, days):
         _reap(manifests, f"manifests older than {days}d", dry_run, reaped, errors)
 
@@ -329,10 +319,7 @@ def _reap(
     if dry_run:
         return
     try:
-        tmp = (
-            f"{os.path.dirname(target)}/{ORPHAN_PREFIX}"
-            f"{_now_ms()}-{os.path.basename(target)}"
-        )
+        tmp = f"{os.path.dirname(target)}/{ORPHAN_PREFIX}{_now_ms()}-{os.path.basename(target)}"
         os.rename(target, tmp)
         if os.path.isdir(tmp) and not os.path.islink(tmp):
             shutil.rmtree(tmp, ignore_errors=True)

--- a/ralphs/python-migration/TODO.md
+++ b/ralphs/python-migration/TODO.md
@@ -14,7 +14,7 @@ US-005 (install-plan), US-006 (harness-detection), and US-007 (harness-compat).
 - [x] US-006 — Port `src/lib/harness-detection.ts` → `python/cheese_flow/lib/harness_detection.py`; port `tests/harness-detection.test.ts`
 - [x] US-007 — Port `src/lib/harness-compat.ts` → `python/cheese_flow/lib/harness_compat.py`; port `tests/harness-compat.test.ts`
 - [x] US-008 — Port `src/lib/installer.ts` → `python/cheese_flow/lib/installer.py`; depends on US-005/006/007; port `tests/installer.test.ts`
-- [ ] US-009 — Port `src/lib/sweeper.ts` → `python/cheese_flow/lib/sweeper.py`; port `tests/sweeper.test.ts`
+- [x] US-009 — Port `src/lib/sweeper.ts` → `python/cheese_flow/lib/sweeper.py`; port `tests/sweeper.test.ts`
 - [ ] US-010 — Port `src/lib/session-start.ts` → `python/cheese_flow/lib/session_start.py`; port `tests/session-start.test.ts`
 - [ ] US-011 — Port `src/lib/doctor.ts` → `python/cheese_flow/lib/doctor.py`; port matching vitest cases
 - [ ] US-012 — Port `src/lib/cheese-home.ts` → `python/cheese_flow/lib/cheese_home.py`; port `tests/cheese-home.test.ts`

--- a/tests/python/test_sweeper.py
+++ b/tests/python/test_sweeper.py
@@ -69,9 +69,7 @@ def test_respects_per_repo_milknado_days_override(tmp_path: Path) -> None:
     db = project_dir / "milknado" / "milknado.db"
     db.write_text("x", encoding="utf-8")
     _set_mtime(db, 10)
-    (project_dir / "shared" / "retention.toml").write_text(
-        "milknadoDays = 7\n", encoding="utf-8"
-    )
+    (project_dir / "shared" / "retention.toml").write_text("milknadoDays = 7\n", encoding="utf-8")
 
     report = sweep(SweepOptions(scope="all", home=str(home)))
 
@@ -331,9 +329,7 @@ def test_scope_project_sweeps_only_supplied_project_dir(tmp_path: Path) -> None:
     _set_mtime(db_a, 90)
     _set_mtime(db_b, 90)
 
-    report = sweep(
-        SweepOptions(scope="project", home=str(home), projectDir=str(a))
-    )
+    report = sweep(SweepOptions(scope="project", home=str(home), projectDir=str(a)))
 
     assert report["scannedProjects"] == 1
     reaped = [r["path"] for r in report["reaped"]]

--- a/tests/python/test_sweeper.py
+++ b/tests/python/test_sweeper.py
@@ -1,0 +1,417 @@
+"""Port of `tests/sweeper.test.ts`.
+
+Line-by-line port of the vitest cases. The TS suite uses ``mkdtemp`` +
+``afterEach`` cleanup; pytest's ``tmp_path`` is per-test, so we use it
+directly (and ``tmp_path_factory`` for the live-target sibling dirs).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+from cheese_flow.lib.sweeper import SweepOptions, sweep
+
+
+def _set_mtime(target: Path, days_ago: float) -> None:
+    when = time.time() - days_ago * 24 * 60 * 60
+    os.utime(target, (when, when))
+
+
+def _make_home(tmp_path: Path) -> Path:
+    home = tmp_path / "cheese-home"
+    (home / "projects").mkdir(parents=True)
+    return home
+
+
+def _create_project(home: Path, slug: str) -> Path:
+    project_dir = home / "projects" / slug
+    (project_dir / "milknado").mkdir(parents=True)
+    (project_dir / "worktrees").mkdir(parents=True)
+    (project_dir / "shared").mkdir(parents=True)
+    return project_dir
+
+
+# region: sweep — milknado db retention
+
+
+def test_reaps_milknado_db_older_than_default_days(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-repo")
+    db = project_dir / "milknado" / "milknado.db"
+    db.write_text("stale-bytes", encoding="utf-8")
+    _set_mtime(db, 31)
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    assert str(db) in [r["path"] for r in report["reaped"]]
+    assert not db.exists()
+
+
+def test_keeps_milknado_db_younger_than_default_days(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-fresh")
+    db = project_dir / "milknado" / "milknado.db"
+    db.write_text("fresh", encoding="utf-8")
+    _set_mtime(db, 5)
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    assert str(db) not in [r["path"] for r in report["reaped"]]
+    assert db.is_file()
+
+
+def test_respects_per_repo_milknado_days_override(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-override")
+    db = project_dir / "milknado" / "milknado.db"
+    db.write_text("x", encoding="utf-8")
+    _set_mtime(db, 10)
+    (project_dir / "shared" / "retention.toml").write_text(
+        "milknadoDays = 7\n", encoding="utf-8"
+    )
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    assert str(db) in [r["path"] for r in report["reaped"]]
+
+
+# endregion
+
+# region: sweep — manifests + runs retention
+
+
+def test_reaps_stale_manifests_keeps_fresh_runs(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-mixed")
+    wt_dir = project_dir / "worktrees" / "-Users-paul-mixed"
+    (wt_dir / "manifests").mkdir(parents=True)
+    (wt_dir / "runs" / "abc").mkdir(parents=True)
+    (wt_dir / ".path").write_text(f"{wt_dir}\n", encoding="utf-8")
+    _set_mtime(wt_dir / "manifests", 40)
+    _set_mtime(wt_dir / "runs" / "abc", 5)
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    assert str(wt_dir / "manifests") in [r["path"] for r in report["reaped"]]
+    assert (wt_dir / "runs" / "abc").is_dir()
+
+
+def test_reaps_individual_stale_run_dirs(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-runs")
+    wt_dir = project_dir / "worktrees" / "-Users-paul-runs"
+    stale = wt_dir / "runs" / "stale"
+    fresh = wt_dir / "runs" / "fresh"
+    stale.mkdir(parents=True)
+    fresh.mkdir(parents=True)
+    (wt_dir / ".path").write_text(f"{wt_dir}\n", encoding="utf-8")
+    _set_mtime(stale, 90)
+    _set_mtime(fresh, 1)
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    paths = [r["path"] for r in report["reaped"]]
+    assert str(stale) in paths
+    assert str(fresh) not in paths
+
+
+# endregion
+
+# region: sweep — whole-worktree reaping
+
+
+def test_reaps_whole_worktree_only_when_stale_and_path_target_gone(
+    tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-dead")
+    live_dir = tmp_path_factory.mktemp("cheese-sweep-live-")
+
+    live_slug = "-Users-paul-live"
+    dead_slug = "-Users-paul-dead-wt"
+    live_wt = project_dir / "worktrees" / live_slug
+    dead_wt = project_dir / "worktrees" / dead_slug
+    live_wt.mkdir(parents=True)
+    dead_wt.mkdir(parents=True)
+    (live_wt / ".path").write_text(f"{live_dir}\n", encoding="utf-8")
+    (dead_wt / ".path").write_text(
+        "/tmp/cheese-this-path-should-not-exist-12345\n", encoding="utf-8"
+    )
+    # both old enough
+    _set_mtime(live_wt, 120)
+    _set_mtime(dead_wt, 120)
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    reaped = [r["path"] for r in report["reaped"]]
+    assert str(dead_wt) in reaped
+    assert str(live_wt) not in reaped
+    assert not dead_wt.exists()
+    assert live_wt.is_dir()
+
+
+def test_does_not_reap_stale_worktree_if_path_target_exists(
+    tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-stale-but-live")
+    live_dir = tmp_path_factory.mktemp("cheese-sweep-live2-")
+    wt = project_dir / "worktrees" / "-Users-paul-stale"
+    wt.mkdir(parents=True)
+    (wt / ".path").write_text(f"{live_dir}\n", encoding="utf-8")
+    _set_mtime(wt, 120)
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    assert str(wt) not in [r["path"] for r in report["reaped"]]
+
+
+# endregion
+
+# region: sweep — never reaps in-repo .cheese/
+
+
+def test_only_walks_cheese_projects_never_user_repo(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-isolation")
+    db = project_dir / "milknado" / "milknado.db"
+    db.write_text("x", encoding="utf-8")
+    _set_mtime(db, 90)
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    assert report["scannedProjects"] == 1
+    assert len(report["reaped"]) >= 1
+    for entry in report["reaped"]:
+        assert entry["path"].startswith(str(home))
+
+
+# endregion
+
+# region: sweep — debounce via .last-sweep
+
+
+def test_noop_when_last_sweep_within_24h(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-debounced")
+    db = project_dir / "milknado" / "milknado.db"
+    db.write_text("stale", encoding="utf-8")
+    _set_mtime(db, 90)
+    last_sweep = home / ".last-sweep"
+    last_sweep.write_text("", encoding="utf-8")
+    _set_mtime(last_sweep, 0)  # just now
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    assert report["reaped"] == []
+    assert report["scannedProjects"] == 0
+    assert db.is_file()
+
+
+def test_runs_and_touches_last_sweep_when_older_than_24h(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-due")
+    db = project_dir / "milknado" / "milknado.db"
+    db.write_text("stale", encoding="utf-8")
+    _set_mtime(db, 90)
+    last_sweep = home / ".last-sweep"
+    last_sweep.write_text("", encoding="utf-8")
+    _set_mtime(last_sweep, 2)
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    assert len(report["reaped"]) >= 1
+    after = last_sweep.stat()
+    assert (time.time() * 1000) - (after.st_mtime * 1000) < 60_000
+
+
+def test_force_bypasses_debounce(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-force")
+    db = project_dir / "milknado" / "milknado.db"
+    db.write_text("stale", encoding="utf-8")
+    _set_mtime(db, 90)
+    last_sweep = home / ".last-sweep"
+    last_sweep.write_text("", encoding="utf-8")
+    _set_mtime(last_sweep, 0)
+
+    report = sweep(SweepOptions(scope="all", home=str(home), force=True))
+
+    assert len(report["reaped"]) >= 1
+
+
+# endregion
+
+# region: sweep — dryRun
+
+
+def test_dry_run_reports_without_deleting(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-dry")
+    db = project_dir / "milknado" / "milknado.db"
+    db.write_text("x", encoding="utf-8")
+    _set_mtime(db, 90)
+
+    report = sweep(SweepOptions(scope="all", home=str(home), dryRun=True))
+
+    assert str(db) in [r["path"] for r in report["reaped"]]
+    assert db.is_file()
+
+
+# endregion
+
+# region: sweep — sidecar edge cases
+
+
+def test_treats_empty_path_sidecar_as_dead_target(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-empty-path")
+    wt = project_dir / "worktrees" / "-Users-paul-empty"
+    wt.mkdir(parents=True)
+    (wt / ".path").write_text("   \n", encoding="utf-8")
+    _set_mtime(wt, 120)
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    assert str(wt) in [r["path"] for r in report["reaped"]]
+
+
+def test_treats_missing_path_sidecar_as_dead_target(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-no-sidecar")
+    wt = project_dir / "worktrees" / "-Users-paul-nosidecar"
+    wt.mkdir(parents=True)
+    _set_mtime(wt, 120)
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    assert str(wt) in [r["path"] for r in report["reaped"]]
+
+
+def test_ignores_non_directory_entries_under_worktrees_and_runs(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-files")
+    wt = project_dir / "worktrees" / "-Users-paul-files"
+    (wt / "runs").mkdir(parents=True)
+    (wt / ".path").write_text(f"{wt}\n", encoding="utf-8")
+    # stray file under worktrees/
+    (project_dir / "worktrees" / "stray.txt").write_text("x", encoding="utf-8")
+    # stray file under runs/
+    (wt / "runs" / "stray.txt").write_text("x", encoding="utf-8")
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    reaped = [r["path"] for r in report["reaped"]]
+    assert str(project_dir / "worktrees" / "stray.txt") not in reaped
+    assert str(wt / "runs" / "stray.txt") not in reaped
+
+
+def test_returns_duration_and_empty_errors_on_clean_sweep(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    _create_project(home, "-Users-paul-clean")
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    assert report["errors"] == []
+    assert isinstance(report["durationMs"], int)
+    assert report["durationMs"] >= 0
+
+
+def test_scope_project_sweeps_only_supplied_project_dir(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    a = _create_project(home, "-Users-paul-scoped-a")
+    b = _create_project(home, "-Users-paul-scoped-b")
+    db_a = a / "milknado" / "milknado.db"
+    db_b = b / "milknado" / "milknado.db"
+    db_a.write_text("x", encoding="utf-8")
+    db_b.write_text("x", encoding="utf-8")
+    _set_mtime(db_a, 90)
+    _set_mtime(db_b, 90)
+
+    report = sweep(
+        SweepOptions(scope="project", home=str(home), projectDir=str(a))
+    )
+
+    assert report["scannedProjects"] == 1
+    reaped = [r["path"] for r in report["reaped"]]
+    assert str(db_a) in reaped
+    assert str(db_b) not in reaped
+
+
+def test_returns_zero_scanned_when_projects_dir_missing(tmp_path: Path) -> None:
+    home = tmp_path / "cheese-home-empty"
+    home.mkdir()
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    assert report["scannedProjects"] == 0
+    assert report["reaped"] == []
+
+
+def test_handles_project_dir_with_no_worktrees(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = home / "projects" / "-Users-paul-no-wts"
+    (project_dir / "milknado").mkdir(parents=True)
+    (project_dir / "shared").mkdir(parents=True)
+    # intentionally NO worktrees/ directory
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    assert report["scannedProjects"] == 1
+    assert report["errors"] == []
+
+
+def test_skips_reap_target_with_failing_stat_broken_symlink(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-broken-orphan")
+    broken = project_dir / "worktrees" / ".reap-12345-broken-symlink"
+    os.symlink("/nonexistent/path/that/does/not/exist", broken)
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    # Either reap (succeeded as symlink unlink) or skipped because stat failed.
+    # We assert no errors are surfaced, and the orphan didn't crash the sweep.
+    assert report["errors"] == []
+
+
+def test_records_rename_failure_as_non_fatal_error(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-readonly-parent")
+    wt = project_dir / "worktrees" / ".reap-99999-orphan"
+    wt.mkdir(parents=True)
+    worktrees_parent = wt.parent
+    # make worktrees/ read-only AFTER creating the orphan, so scandir succeeds
+    # but rename inside it fails with EACCES.
+    os.chmod(worktrees_parent, 0o500)
+    try:
+        report = sweep(SweepOptions(scope="all", home=str(home)))
+        assert len(report["errors"]) >= 1
+        assert report["errors"][0]["path"] == str(wt)
+    finally:
+        os.chmod(worktrees_parent, 0o755)
+
+
+# endregion
+
+# region: sweep — atomicity: orphan .reap-* dirs are cleaned
+
+
+def test_removes_leftover_reap_siblings_on_next_run(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    project_dir = _create_project(home, "-Users-paul-orphan")
+    wt_dir = project_dir / "worktrees" / "-Users-paul-orphan"
+    wt_dir.mkdir(parents=True)
+    (wt_dir / ".path").write_text(f"{wt_dir}\n", encoding="utf-8")
+    orphan = project_dir / "worktrees" / ".reap-12345-stale-runs"
+    orphan.mkdir(parents=True)
+
+    report = sweep(SweepOptions(scope="all", home=str(home)))
+
+    assert not orphan.exists()
+    assert str(orphan) in [r["path"] for r in report["reaped"]]
+
+
+# endregion


### PR DESCRIPTION
Port src/lib/sweeper.ts → python/cheese_flow/lib/sweeper.py and tests/sweeper.test.ts → tests/python/test_sweeper.py. Inlines a minimal RetentionConfig + retention.toml parser; cheese_home.py (US-012) will absorb these helpers when it lands.

Co-authored-by: Ralphify <noreply@ralphify.co>