### PR TITLE
feat(migration): US-011 doctor (TS → Python)

### DIFF
--- a/python/cheese_flow/lib/doctor.py
+++ b/python/cheese_flow/lib/doctor.py
@@ -53,8 +53,7 @@ TOOL_CHECKS: list[ToolCheck] = [
         tier="required",
         purpose="Tree-sitter code intelligence used by exploration skills.",
         installHint=(
-            "Bundled with cheese-flow. If missing, install globally: "
-            "npm install -g cheese-flow"
+            "Bundled with cheese-flow. If missing, install globally: npm install -g cheese-flow"
         ),
     ),
     ToolCheck(
@@ -76,9 +75,7 @@ def _spawn_env() -> dict[str, str]:
     env = dict(os.environ)
     existing_path = env.get("PATH", "")
     env["PATH"] = (
-        f"{BUNDLED_BIN_DIR}{os.pathsep}{existing_path}"
-        if existing_path
-        else BUNDLED_BIN_DIR
+        f"{BUNDLED_BIN_DIR}{os.pathsep}{existing_path}" if existing_path else BUNDLED_BIN_DIR
     )
     return env
 

--- a/python/cheese_flow/lib/doctor.py
+++ b/python/cheese_flow/lib/doctor.py
@@ -1,0 +1,170 @@
+"""Port of `src/lib/doctor.ts` — tool dependency checks for ``cheese doctor``.
+
+Mirrors the TS surface: ``TOOL_CHECKS`` (list of ``ToolCheck``),
+``run_tool_check``, ``run_all_tool_checks``, ``format_report``, and
+``has_blocking_failure``. The TS module spawns each binary with
+``--version`` via ``child_process.spawn``; the port uses
+``asyncio.create_subprocess_exec`` so ``Promise.all`` becomes
+``asyncio.gather`` per decision 6 (no async redesign).
+
+The TS module prepends ``<repo>/node_modules/.bin`` to ``PATH`` so the
+bundled ``tilth`` binary is reachable. The port preserves that behaviour
+by computing the same path relative to ``__file__``: from
+``python/cheese_flow/lib/doctor.py`` the repo root is three parents up.
+The npm-bundled bin directory disappears in US-017 (TS cutover); until
+then it stays so Python and TS doctor invocations agree.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+ToolTier = Literal["required", "recommended", "suggested"]
+
+BUNDLED_BIN_DIR: str = str(Path(__file__).resolve().parents[3] / "node_modules" / ".bin")
+
+
+@dataclass(frozen=True)
+class ToolCheck:
+    name: str
+    tier: ToolTier
+    purpose: str
+    installHint: str
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    name: str
+    tier: ToolTier
+    purpose: str
+    installHint: str
+    ok: bool
+    version: str | None = None
+    error: str | None = None
+
+
+TOOL_CHECKS: list[ToolCheck] = [
+    ToolCheck(
+        name="tilth",
+        tier="required",
+        purpose="Tree-sitter code intelligence used by exploration skills.",
+        installHint=(
+            "Bundled with cheese-flow. If missing, install globally: "
+            "npm install -g cheese-flow"
+        ),
+    ),
+    ToolCheck(
+        name="mergiraf",
+        tier="recommended",
+        purpose="Syntax-aware merge driver for resolving conflicts cleanly.",
+        installHint="brew install mergiraf  (or: cargo install mergiraf)",
+    ),
+    ToolCheck(
+        name="rtk",
+        tier="suggested",
+        purpose="Token-optimized CLI proxy for Claude Code sessions.",
+        installHint="cargo install rtk-cli",
+    ),
+]
+
+
+def _spawn_env() -> dict[str, str]:
+    env = dict(os.environ)
+    existing_path = env.get("PATH", "")
+    env["PATH"] = (
+        f"{BUNDLED_BIN_DIR}{os.pathsep}{existing_path}"
+        if existing_path
+        else BUNDLED_BIN_DIR
+    )
+    return env
+
+
+def _result(
+    check: ToolCheck,
+    *,
+    ok: bool,
+    version: str | None = None,
+    error: str | None = None,
+) -> ToolResult:
+    return ToolResult(
+        name=check.name,
+        tier=check.tier,
+        purpose=check.purpose,
+        installHint=check.installHint,
+        ok=ok,
+        version=version,
+        error=error,
+    )
+
+
+async def run_tool_check(check: ToolCheck) -> ToolResult:
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            check.name,
+            "--version",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=_spawn_env(),
+        )
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        return _result(check, ok=False, error=str(exc))
+
+    stdout_bytes, stderr_bytes = await proc.communicate()
+    code = proc.returncode
+    if code == 0:
+        text = (stdout_bytes.decode() or stderr_bytes.decode()).strip()
+        first_line = text.split("\n")[0] if text else ""
+        if first_line:
+            return _result(check, ok=True, version=first_line)
+        return _result(check, ok=True)
+    code_label = str(code) if code is not None else "unknown"
+    return _result(check, ok=False, error=f"exited with code {code_label}")
+
+
+async def run_all_tool_checks() -> list[ToolResult]:
+    return list(await asyncio.gather(*(run_tool_check(c) for c in TOOL_CHECKS)))
+
+
+_TIER_LABELS: dict[ToolTier, str] = {
+    "required": "REQUIRED",
+    "recommended": "RECOMMENDED",
+    "suggested": "SUGGESTED",
+}
+
+
+def format_report(results: list[ToolResult]) -> str:
+    lines: list[str] = ["cheese doctor — tool dependency check", ""]
+    for result in results:
+        status = "ok" if result.ok else "missing"
+        tag = _TIER_LABELS[result.tier]
+        lines.append(f"[{tag}] {result.name}: {status}")
+        lines.append(f"  {result.purpose}")
+        if result.ok and result.version:
+            lines.append(f"  found: {result.version}")
+        elif result.ok:
+            lines.append("  found")
+        else:
+            lines.append(f"  install: {result.installHint}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def has_blocking_failure(results: list[ToolResult]) -> bool:
+    return any(r.tier == "required" and not r.ok for r in results)
+
+
+__all__ = [
+    "BUNDLED_BIN_DIR",
+    "TOOL_CHECKS",
+    "ToolCheck",
+    "ToolResult",
+    "ToolTier",
+    "format_report",
+    "has_blocking_failure",
+    "run_all_tool_checks",
+    "run_tool_check",
+]

--- a/ralphs/python-migration/TODO.md
+++ b/ralphs/python-migration/TODO.md
@@ -16,7 +16,7 @@ US-005 (install-plan), US-006 (harness-detection), and US-007 (harness-compat).
 - [x] US-008 — Port `src/lib/installer.ts` → `python/cheese_flow/lib/installer.py`; depends on US-005/006/007; port `tests/installer.test.ts`
 - [x] US-009 — Port `src/lib/sweeper.ts` → `python/cheese_flow/lib/sweeper.py`; port `tests/sweeper.test.ts`
 - [x] US-010 — Port `src/lib/session-start.ts` → `python/cheese_flow/lib/session_start.py`; port `tests/session-start.test.ts`
-- [ ] US-011 — Port `src/lib/doctor.ts` → `python/cheese_flow/lib/doctor.py`; port matching vitest cases
+- [x] US-011 — Port `src/lib/doctor.ts` → `python/cheese_flow/lib/doctor.py`; port matching vitest cases
 - [ ] US-012 — Port `src/lib/cheese-home.ts` → `python/cheese_flow/lib/cheese_home.py`; port `tests/cheese-home.test.ts`
 - [ ] US-013 — Port `src/lib/local-marketplaces.ts` → `python/cheese_flow/lib/local_marketplaces.py`; port matching vitest cases
 - [ ] US-014 — Port lint pipeline: `src/lib/lint-skills.ts` + `lint-skill-rules.ts` → `python/cheese_flow/lib/`; port `tests/lint-skills-directory.test.ts` + `tests/lint-skill-source.test.ts`

--- a/tests/python/test_doctor.py
+++ b/tests/python/test_doctor.py
@@ -99,16 +99,8 @@ def test_format_report_renders_missing_results_with_install_hint() -> None:
 def test_has_blocking_failure_is_true_only_for_missing_required_tools() -> None:
     assert has_blocking_failure([_result(tier="required", ok=False)]) is True
     assert has_blocking_failure([_result(tier="required", ok=True)]) is False
-    assert (
-        has_blocking_failure([_result(name="rtk", tier="suggested", ok=False)])
-        is False
-    )
-    assert (
-        has_blocking_failure(
-            [_result(name="mergiraf", tier="recommended", ok=False)]
-        )
-        is False
-    )
+    assert has_blocking_failure([_result(name="rtk", tier="suggested", ok=False)]) is False
+    assert has_blocking_failure([_result(name="mergiraf", tier="recommended", ok=False)]) is False
 
 
 def test_run_tool_check_returns_version_for_real_executable(

--- a/tests/python/test_doctor.py
+++ b/tests/python/test_doctor.py
@@ -1,0 +1,227 @@
+"""Tests for `python/cheese_flow/lib/doctor.py`.
+
+`src/lib/doctor.ts` shipped without a matching `tests/doctor.test.ts`,
+so there were no vitest cases to port verbatim. These tests exercise
+the ported surface (`TOOL_CHECKS`, `run_tool_check`,
+`run_all_tool_checks`, `format_report`, `has_blocking_failure`) the way
+the TS suite would have, using a tmp_path executable for the
+subprocess-success case so we don't depend on whichever real binaries
+happen to be on the developer's PATH.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import stat
+import textwrap
+from pathlib import Path
+
+import pytest
+from cheese_flow.lib.doctor import (
+    TOOL_CHECKS,
+    ToolCheck,
+    ToolResult,
+    format_report,
+    has_blocking_failure,
+    run_all_tool_checks,
+    run_tool_check,
+)
+
+
+def _make_executable(directory: Path, name: str, body: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    script = directory / name
+    script.write_text(body, encoding="utf-8")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return script
+
+
+def test_tool_checks_cover_required_recommended_and_suggested_tiers() -> None:
+    by_name = {check.name: check for check in TOOL_CHECKS}
+    assert by_name["tilth"].tier == "required"
+    assert by_name["mergiraf"].tier == "recommended"
+    assert by_name["rtk"].tier == "suggested"
+    assert {check.tier for check in TOOL_CHECKS} == {
+        "required",
+        "recommended",
+        "suggested",
+    }
+    for check in TOOL_CHECKS:
+        assert check.purpose
+        assert check.installHint
+
+
+def _result(
+    *,
+    name: str = "tilth",
+    tier: str = "required",
+    ok: bool = True,
+    version: str | None = None,
+    error: str | None = None,
+) -> ToolResult:
+    return ToolResult(
+        name=name,
+        tier=tier,  # type: ignore[arg-type]
+        purpose=f"{name} purpose",
+        installHint=f"install {name}",
+        ok=ok,
+        version=version,
+        error=error,
+    )
+
+
+def test_format_report_renders_ok_results_with_version_and_purpose() -> None:
+    results = [_result(ok=True, version="tilth 1.2.3")]
+    report = format_report(results)
+    assert "cheese doctor — tool dependency check" in report
+    assert "[REQUIRED] tilth: ok" in report
+    assert "  tilth purpose" in report
+    assert "  found: tilth 1.2.3" in report
+
+
+def test_format_report_renders_ok_results_without_version_as_found() -> None:
+    results = [_result(ok=True, version=None)]
+    report = format_report(results)
+    assert "[REQUIRED] tilth: ok" in report
+    assert "  found" in report
+    assert "  found:" not in report
+
+
+def test_format_report_renders_missing_results_with_install_hint() -> None:
+    results = [
+        _result(name="mergiraf", tier="recommended", ok=False),
+    ]
+    report = format_report(results)
+    assert "[RECOMMENDED] mergiraf: missing" in report
+    assert "  install: install mergiraf" in report
+
+
+def test_has_blocking_failure_is_true_only_for_missing_required_tools() -> None:
+    assert has_blocking_failure([_result(tier="required", ok=False)]) is True
+    assert has_blocking_failure([_result(tier="required", ok=True)]) is False
+    assert (
+        has_blocking_failure([_result(name="rtk", tier="suggested", ok=False)])
+        is False
+    )
+    assert (
+        has_blocking_failure(
+            [_result(name="mergiraf", tier="recommended", ok=False)]
+        )
+        is False
+    )
+
+
+def test_run_tool_check_returns_version_for_real_executable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    _make_executable(
+        bin_dir,
+        "fakery",
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            echo 'fakery 9.9.9'
+            """
+        ),
+    )
+    monkeypatch.setenv("PATH", str(bin_dir))
+    check = ToolCheck(
+        name="fakery",
+        tier="required",
+        purpose="fake tool",
+        installHint="brew install fakery",
+    )
+    result = asyncio.run(run_tool_check(check))
+    assert result.ok is True
+    assert result.version == "fakery 9.9.9"
+    assert result.error is None
+    assert result.name == "fakery"
+    assert result.tier == "required"
+
+
+def test_run_tool_check_marks_missing_when_executable_not_found(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    monkeypatch.setenv("PATH", str(empty_dir))
+    check = ToolCheck(
+        name="definitely-not-a-real-binary-xyz",
+        tier="required",
+        purpose="...",
+        installHint="...",
+    )
+    result = asyncio.run(run_tool_check(check))
+    assert result.ok is False
+    assert result.version is None
+    assert result.error is not None and result.error != ""
+
+
+def test_run_tool_check_marks_failure_when_executable_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    _make_executable(
+        bin_dir,
+        "grump",
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            exit 7
+            """
+        ),
+    )
+    monkeypatch.setenv("PATH", str(bin_dir))
+    check = ToolCheck(
+        name="grump",
+        tier="required",
+        purpose="grumpy",
+        installHint="install grump",
+    )
+    result = asyncio.run(run_tool_check(check))
+    assert result.ok is False
+    assert result.error == "exited with code 7"
+    assert result.version is None
+
+
+def test_run_tool_check_marks_ok_without_version_when_stdout_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    _make_executable(
+        bin_dir,
+        "silent",
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            exit 0
+            """
+        ),
+    )
+    monkeypatch.setenv("PATH", str(bin_dir))
+    check = ToolCheck(
+        name="silent",
+        tier="required",
+        purpose="silent",
+        installHint="install silent",
+    )
+    result = asyncio.run(run_tool_check(check))
+    assert result.ok is True
+    assert result.version is None
+
+
+def test_run_all_tool_checks_returns_one_result_per_tool_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    monkeypatch.setenv("PATH", str(empty_dir))
+    results = asyncio.run(run_all_tool_checks())
+    assert len(results) == len(TOOL_CHECKS)
+    assert [r.name for r in results] == [c.name for c in TOOL_CHECKS]


### PR DESCRIPTION
Port src/lib/doctor.ts to python/cheese_flow/lib/doctor.py:
- TOOL_CHECKS list with required/recommended/suggested tiers (tilth, mergiraf, rtk).
- run_tool_check / run_all_tool_checks invoke each binary with --version via
  asyncio.create_subprocess_exec; FileNotFoundError mirrors the TS spawn
  'error' event.
- format_report and has_blocking_failure mirror the TS report shape and
  required-tier failure rule.
- BUNDLED_BIN_DIR resolves to <repo>/node_modules/.bin (three parents up
  from the module file) and prepends to PATH so the bundled tilth stays
  reachable until US-017 deletes the npm surface.

src/lib/doctor.ts shipped without a tests/doctor.test.ts; tests/python/
test_doctor.py exercises the ported surface with tmp_path executables so
the run_tool_check success/failure/no-version branches are covered without
relying on whichever binaries happen to be on the developer's PATH.

Co-authored-by: Ralphify <noreply@ralphify.co>