### PR TITLE
feat(migration): US-012 cheese-home (TS → Python)

### DIFF
--- a/python/cheese_flow/lib/cheese_home.py
+++ b/python/cheese_flow/lib/cheese_home.py
@@ -62,8 +62,7 @@ def parse_worktree_main(out: str, cwd: str) -> str:
     first_line = out.split("\n", 1)[0] if out else ""
     if not first_line.startswith("worktree "):
         raise RuntimeError(
-            f"discoverCanonicalRepo: {cwd} is not inside a git worktree "
-            "(no 'worktree' line)"
+            f"discoverCanonicalRepo: {cwd} is not inside a git worktree (no 'worktree' line)"
         )
     return first_line[len("worktree ") :]
 
@@ -90,15 +89,11 @@ def discover_canonical_repo(cwd: str) -> str:
     return str(Path(parse_worktree_main(out, cwd)).resolve())
 
 
-def resolve_cheese_home(
-    cwd: str, options: CheeseHomeOptions | None = None
-) -> CheeseHomePaths:
+def resolve_cheese_home(cwd: str, options: CheeseHomeOptions | None = None) -> CheeseHomePaths:
     opts = options or CheeseHomeOptions()
     root = opts.home if opts.home is not None else str(Path.home() / ".cheese")
     canonical_repo = (
-        opts.canonicalRepo
-        if opts.canonicalRepo is not None
-        else discover_canonical_repo(cwd)
+        opts.canonicalRepo if opts.canonicalRepo is not None else discover_canonical_repo(cwd)
     )
     repo_slug = path_slug(canonical_repo)
     worktree_path = str(Path(cwd).resolve())
@@ -116,9 +111,7 @@ def resolve_cheese_home(
     )
 
 
-def ensure_cheese_home(
-    cwd: str, options: CheeseHomeOptions | None = None
-) -> CheeseHomePaths:
+def ensure_cheese_home(cwd: str, options: CheeseHomeOptions | None = None) -> CheeseHomePaths:
     paths = resolve_cheese_home(cwd, options)
     os.makedirs(os.path.dirname(paths.milknadoDb), exist_ok=True)
     os.makedirs(paths.manifestsDir, exist_ok=True)
@@ -129,9 +122,7 @@ def ensure_cheese_home(
 
 
 def _write_sidecar(worktree_dir: str, original_path: str) -> None:
-    Path(worktree_dir, ".path").write_text(
-        f"{original_path}\n", encoding="utf-8"
-    )
+    Path(worktree_dir, ".path").write_text(f"{original_path}\n", encoding="utf-8")
 
 
 def read_retention_config(project_dir: str) -> RetentionConfig:

--- a/python/cheese_flow/lib/cheese_home.py
+++ b/python/cheese_flow/lib/cheese_home.py
@@ -1,0 +1,175 @@
+"""Port of `src/lib/cheese-home.ts` — ``~/.cheese`` home directory resolution.
+
+Mirrors the TS surface: ``CheeseHomePaths``, ``CheeseHomeOptions``,
+``RetentionConfig``, ``path_slug``, ``discover_canonical_repo``,
+``parse_worktree_main``, ``resolve_cheese_home``, ``ensure_cheese_home``,
+and ``read_retention_config``.
+
+Field names on the dataclasses keep TS camelCase (``projectDir``,
+``milknadoDb``, etc.) so callers ported from TS read the same.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_RETENTION_DAYS = 30
+_RETENTION_NUMERIC_KEYS: frozenset[str] = frozenset(
+    {
+        "defaultDays",
+        "milknadoDays",
+        "manifestsDays",
+        "runsDays",
+        "worktreeDays",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CheeseHomePaths:
+    root: str
+    projectDir: str
+    milknadoDb: str
+    worktreeDir: str
+    manifestsDir: str
+    runsDir: str
+    sharedDir: str
+
+
+@dataclass(frozen=True)
+class CheeseHomeOptions:
+    home: str | None = None
+    canonicalRepo: str | None = None
+
+
+@dataclass
+class RetentionConfig:
+    defaultDays: int = DEFAULT_RETENTION_DAYS
+    milknadoDays: int | None = None
+    manifestsDays: int | None = None
+    runsDays: int | None = None
+    worktreeDays: int | None = None
+
+
+def path_slug(abs_path: str) -> str:
+    return abs_path.replace("/", "-")
+
+
+def parse_worktree_main(out: str, cwd: str) -> str:
+    first_line = out.split("\n", 1)[0] if out else ""
+    if not first_line.startswith("worktree "):
+        raise RuntimeError(
+            f"discoverCanonicalRepo: {cwd} is not inside a git worktree "
+            "(no 'worktree' line)"
+        )
+    return first_line[len("worktree ") :]
+
+
+def _run_git_worktree_list(cwd: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as error:
+        message = str(error)
+        raise RuntimeError(
+            f"discoverCanonicalRepo: {cwd} is not inside a git repo: {message}"
+        ) from error
+    return result.stdout
+
+
+def discover_canonical_repo(cwd: str) -> str:
+    out = _run_git_worktree_list(cwd)
+    return str(Path(parse_worktree_main(out, cwd)).resolve())
+
+
+def resolve_cheese_home(
+    cwd: str, options: CheeseHomeOptions | None = None
+) -> CheeseHomePaths:
+    opts = options or CheeseHomeOptions()
+    root = opts.home if opts.home is not None else str(Path.home() / ".cheese")
+    canonical_repo = (
+        opts.canonicalRepo
+        if opts.canonicalRepo is not None
+        else discover_canonical_repo(cwd)
+    )
+    repo_slug = path_slug(canonical_repo)
+    worktree_path = str(Path(cwd).resolve())
+    wt_slug = path_slug(worktree_path)
+    project_dir = os.path.join(root, "projects", repo_slug)
+    worktree_dir = os.path.join(project_dir, "worktrees", wt_slug)
+    return CheeseHomePaths(
+        root=root,
+        projectDir=project_dir,
+        milknadoDb=os.path.join(project_dir, "milknado", "milknado.db"),
+        worktreeDir=worktree_dir,
+        manifestsDir=os.path.join(worktree_dir, "manifests"),
+        runsDir=os.path.join(worktree_dir, "runs"),
+        sharedDir=os.path.join(project_dir, "shared"),
+    )
+
+
+def ensure_cheese_home(
+    cwd: str, options: CheeseHomeOptions | None = None
+) -> CheeseHomePaths:
+    paths = resolve_cheese_home(cwd, options)
+    os.makedirs(os.path.dirname(paths.milknadoDb), exist_ok=True)
+    os.makedirs(paths.manifestsDir, exist_ok=True)
+    os.makedirs(paths.runsDir, exist_ok=True)
+    os.makedirs(paths.sharedDir, exist_ok=True)
+    _write_sidecar(paths.worktreeDir, str(Path(cwd).resolve()))
+    return paths
+
+
+def _write_sidecar(worktree_dir: str, original_path: str) -> None:
+    Path(worktree_dir, ".path").write_text(
+        f"{original_path}\n", encoding="utf-8"
+    )
+
+
+def read_retention_config(project_dir: str) -> RetentionConfig:
+    toml_path = Path(project_dir) / "shared" / "retention.toml"
+    try:
+        body = toml_path.read_text(encoding="utf-8")
+    except OSError:
+        return RetentionConfig()
+    return _parse_retention_toml(body)
+
+
+def _strip_comment(line: str) -> str:
+    hash_idx = line.find("#")
+    return line if hash_idx < 0 else line[:hash_idx]
+
+
+def _parse_retention_toml(body: str) -> RetentionConfig:
+    config: dict[str, int] = {"defaultDays": DEFAULT_RETENTION_DAYS}
+    for raw_line in body.splitlines():
+        line = _strip_comment(raw_line).strip()
+        if line == "" or line.startswith("["):
+            continue
+        eq = line.find("=")
+        if eq < 0:
+            continue
+        key = line[:eq].strip()
+        value = line[eq + 1 :].strip()
+        if key not in _RETENTION_NUMERIC_KEYS:
+            continue
+        try:
+            parsed = int(value, 10)
+        except ValueError:
+            continue
+        config[key] = parsed
+    return RetentionConfig(
+        defaultDays=config.get("defaultDays", DEFAULT_RETENTION_DAYS),
+        milknadoDays=config.get("milknadoDays"),
+        manifestsDays=config.get("manifestsDays"),
+        runsDays=config.get("runsDays"),
+        worktreeDays=config.get("worktreeDays"),
+    )

--- a/python/cheese_flow/lib/session_start.py
+++ b/python/cheese_flow/lib/session_start.py
@@ -115,9 +115,7 @@ def _read_update_check(home: str) -> dict[str, Any] | None:
     return {
         "checked_at": checked_at if isinstance(checked_at, str) else "",
         "latest_version": latest_version if isinstance(latest_version, str) else None,
-        "nudged_for_version": (
-            nudged_for_version if isinstance(nudged_for_version, str) else None
-        ),
+        "nudged_for_version": (nudged_for_version if isinstance(nudged_for_version, str) else None),
     }
 
 
@@ -252,11 +250,7 @@ async def run_session_start(opts: RunSessionStartOptions) -> SessionStartResult:
         update = await check_for_update(update_opts)
         if update is not None:
             prior = _prior_nudged_version(paths.root)
-            if (
-                update.behind
-                and update.latestVersion is not None
-                and update.latestVersion != prior
-            ):
+            if update.behind and update.latestVersion is not None and update.latestVersion != prior:
                 nudge = UpdateNudge(
                     version=update.latestVersion,
                     current=opts.currentVersion,

--- a/python/cheese_flow/lib/session_start.py
+++ b/python/cheese_flow/lib/session_start.py
@@ -1,10 +1,8 @@
 """Port of `src/lib/session-start.ts` — update checks + housekeeping.
 
 Mirrors the TS surface: ``check_for_update``, ``should_check_update``,
-``record_nudged_version``, ``run_session_start``. The TS module imports
-``ensureCheeseHome`` from ``./cheese-home.ts``; US-012 hasn't ported
-``cheese-home.ts`` yet, so this file inlines the minimal surface
-(``_ensure_cheese_home``). When US-012 lands, the inlined helper moves there.
+``record_nudged_version``, ``run_session_start``. Delegates to
+``cheese_home.ensure_cheese_home`` for the ``~/.cheese`` tree.
 
 The TS abort/timeout protocol on ``fetch`` translates to ``asyncio.wait_for``:
 the abort behaviour under test ("returns null when fetch times out") is
@@ -15,8 +13,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
-import subprocess
 import sys
 import time
 import urllib.request
@@ -26,6 +22,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from cheese_flow.lib.cheese_home import CheeseHomeOptions, ensure_cheese_home
 from cheese_flow.lib.sweeper import SweepOptions, SweepReport, sweep
 
 DEFAULT_REGISTRY_URL = "https://registry.npmjs.org/cheese-flow/latest"
@@ -118,7 +115,9 @@ def _read_update_check(home: str) -> dict[str, Any] | None:
     return {
         "checked_at": checked_at if isinstance(checked_at, str) else "",
         "latest_version": latest_version if isinstance(latest_version, str) else None,
-        "nudged_for_version": (nudged_for_version if isinstance(nudged_for_version, str) else None),
+        "nudged_for_version": (
+            nudged_for_version if isinstance(nudged_for_version, str) else None
+        ),
     }
 
 
@@ -227,7 +226,7 @@ async def run_session_start(opts: RunSessionStartOptions) -> SessionStartResult:
     def remaining_ms() -> int:
         return int((deadline - time.monotonic()) * 1000)
 
-    paths = _ensure_cheese_home(opts.cwd, home=opts.home)
+    paths = ensure_cheese_home(opts.cwd, CheeseHomeOptions(home=opts.home))
 
     result = SessionStartResult(ok=True)
 
@@ -253,7 +252,11 @@ async def run_session_start(opts: RunSessionStartOptions) -> SessionStartResult:
         update = await check_for_update(update_opts)
         if update is not None:
             prior = _prior_nudged_version(paths.root)
-            if update.behind and update.latestVersion is not None and update.latestVersion != prior:
+            if (
+                update.behind
+                and update.latestVersion is not None
+                and update.latestVersion != prior
+            ):
                 nudge = UpdateNudge(
                     version=update.latestVersion,
                     current=opts.currentVersion,
@@ -270,68 +273,3 @@ async def run_session_start(opts: RunSessionStartOptions) -> SessionStartResult:
                 _record_check(paths.root, update.latestVersion, prior, now)
 
     return result
-
-
-# ---------- inlined cheese-home helper (US-012 will absorb this) ----------
-
-
-@dataclass
-class _CheeseHomePaths:
-    root: str
-    projectDir: str
-    milknadoDb: str
-    worktreeDir: str
-    manifestsDir: str
-    runsDir: str
-    sharedDir: str
-
-
-def _path_slug(abs_path: str) -> str:
-    return abs_path.replace("/", "-")
-
-
-def _discover_canonical_repo(cwd: str) -> str:
-    try:
-        result = subprocess.run(
-            ["git", "worktree", "list", "--porcelain"],
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError) as error:
-        raise RuntimeError(
-            f"discoverCanonicalRepo: {cwd} is not inside a git repo: {error}"
-        ) from error
-    out = result.stdout
-    first_line = out.split("\n", 1)[0] if out else ""
-    if not first_line.startswith("worktree "):
-        raise RuntimeError(
-            f"discoverCanonicalRepo: {cwd} is not inside a git worktree (no 'worktree' line)"
-        )
-    return str(Path(first_line[len("worktree ") :]).resolve())
-
-
-def _ensure_cheese_home(cwd: str, *, home: str | None = None) -> _CheeseHomePaths:
-    root = home if home is not None else str(Path.home() / ".cheese")
-    canonical_repo = _discover_canonical_repo(cwd)
-    repo_slug = _path_slug(canonical_repo)
-    worktree_path = str(Path(cwd).resolve())
-    wt_slug = _path_slug(worktree_path)
-    project_dir = os.path.join(root, "projects", repo_slug)
-    worktree_dir = os.path.join(project_dir, "worktrees", wt_slug)
-    paths = _CheeseHomePaths(
-        root=root,
-        projectDir=project_dir,
-        milknadoDb=os.path.join(project_dir, "milknado", "milknado.db"),
-        worktreeDir=worktree_dir,
-        manifestsDir=os.path.join(worktree_dir, "manifests"),
-        runsDir=os.path.join(worktree_dir, "runs"),
-        sharedDir=os.path.join(project_dir, "shared"),
-    )
-    os.makedirs(os.path.dirname(paths.milknadoDb), exist_ok=True)
-    os.makedirs(paths.manifestsDir, exist_ok=True)
-    os.makedirs(paths.runsDir, exist_ok=True)
-    os.makedirs(paths.sharedDir, exist_ok=True)
-    Path(worktree_dir, ".path").write_text(f"{worktree_path}\n", encoding="utf-8")
-    return paths

--- a/python/cheese_flow/lib/sweeper.py
+++ b/python/cheese_flow/lib/sweeper.py
@@ -5,10 +5,9 @@ entries and any non-fatal errors. Atomic deletion via rename-into-orphan-then-rm
 24h debounce via ``.last-sweep`` mtime, per-repo retention overrides via
 ``shared/retention.toml``.
 
-The TS module imports ``readRetentionConfig`` and ``RetentionConfig`` from
-``./cheese-home.ts``. US-012 hasn't ported ``cheese-home.ts`` yet, so this file
-inlines the minimal retention-config surface. When US-012 lands, the inlined
-helpers can move there.
+Retention-config surface lives in ``cheese_home`` (port of
+``src/lib/cheese-home.ts``); this module re-exports ``RetentionConfig`` for
+existing import sites.
 """
 
 from __future__ import annotations
@@ -21,27 +20,21 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, TypedDict
 
+from cheese_flow.lib.cheese_home import RetentionConfig, read_retention_config
+
 DEBOUNCE_MS = 24 * 60 * 60 * 1000
 ORPHAN_PREFIX = ".reap-"
-DEFAULT_RETENTION_DAYS = 30
-_RETENTION_NUMERIC_KEYS: frozenset[str] = frozenset(
-    {
-        "defaultDays",
-        "milknadoDays",
-        "manifestsDays",
-        "runsDays",
-        "worktreeDays",
-    }
-)
 
-
-@dataclass
-class RetentionConfig:
-    defaultDays: int = DEFAULT_RETENTION_DAYS
-    milknadoDays: int | None = None
-    manifestsDays: int | None = None
-    runsDays: int | None = None
-    worktreeDays: int | None = None
+__all__ = [
+    "DEBOUNCE_MS",
+    "ORPHAN_PREFIX",
+    "ReapEntry",
+    "RetentionConfig",
+    "SweepError",
+    "SweepOptions",
+    "SweepReport",
+    "sweep",
+]
 
 
 class ReapEntry(TypedDict):
@@ -82,47 +75,6 @@ def _to_now_ms(now: float | None) -> int:
     return int(now)
 
 
-def _read_retention_config(project_dir: str) -> RetentionConfig:
-    toml_path = Path(project_dir) / "shared" / "retention.toml"
-    try:
-        body = toml_path.read_text(encoding="utf-8")
-    except OSError:
-        return RetentionConfig()
-    return _parse_retention_toml(body)
-
-
-def _strip_comment(line: str) -> str:
-    hash_idx = line.find("#")
-    return line if hash_idx < 0 else line[:hash_idx]
-
-
-def _parse_retention_toml(body: str) -> RetentionConfig:
-    config: dict[str, int] = {"defaultDays": DEFAULT_RETENTION_DAYS}
-    for raw_line in body.splitlines():
-        line = _strip_comment(raw_line).strip()
-        if line == "" or line.startswith("["):
-            continue
-        eq = line.find("=")
-        if eq < 0:
-            continue
-        key = line[:eq].strip()
-        value = line[eq + 1 :].strip()
-        if key not in _RETENTION_NUMERIC_KEYS:
-            continue
-        try:
-            parsed = int(value, 10)
-        except ValueError:
-            continue
-        config[key] = parsed
-    return RetentionConfig(
-        defaultDays=config.get("defaultDays", DEFAULT_RETENTION_DAYS),
-        milknadoDays=config.get("milknadoDays"),
-        manifestsDays=config.get("manifestsDays"),
-        runsDays=config.get("runsDays"),
-        worktreeDays=config.get("worktreeDays"),
-    )
-
-
 def sweep(opts: SweepOptions) -> SweepReport:
     start = _now_ms()
     now_ms = _to_now_ms(opts.now)
@@ -140,7 +92,7 @@ def sweep(opts: SweepOptions) -> SweepReport:
     reaped: list[ReapEntry] = []
     errors: list[SweepError] = []
     for project_dir in project_dirs:
-        config = _read_retention_config(project_dir)
+        config = read_retention_config(project_dir)
         _sweep_project(project_dir, config, now_ms, opts.dryRun, reaped, errors)
     if not opts.dryRun:
         _touch_file(last_sweep, now_ms)

--- a/ralphs/python-migration/TODO.md
+++ b/ralphs/python-migration/TODO.md
@@ -17,7 +17,7 @@ US-005 (install-plan), US-006 (harness-detection), and US-007 (harness-compat).
 - [x] US-009 — Port `src/lib/sweeper.ts` → `python/cheese_flow/lib/sweeper.py`; port `tests/sweeper.test.ts`
 - [x] US-010 — Port `src/lib/session-start.ts` → `python/cheese_flow/lib/session_start.py`; port `tests/session-start.test.ts`
 - [x] US-011 — Port `src/lib/doctor.ts` → `python/cheese_flow/lib/doctor.py`; port matching vitest cases
-- [ ] US-012 — Port `src/lib/cheese-home.ts` → `python/cheese_flow/lib/cheese_home.py`; port `tests/cheese-home.test.ts`
+- [x] US-012 — Port `src/lib/cheese-home.ts` → `python/cheese_flow/lib/cheese_home.py`; port `tests/cheese-home.test.ts`
 - [ ] US-013 — Port `src/lib/local-marketplaces.ts` → `python/cheese_flow/lib/local_marketplaces.py`; port matching vitest cases
 - [ ] US-014 — Port lint pipeline: `src/lib/lint-skills.ts` + `lint-skill-rules.ts` → `python/cheese_flow/lib/`; port `tests/lint-skills-directory.test.ts` + `tests/lint-skill-source.test.ts`
 - [ ] US-015 — FastMCP umbrella + Typer CLI: `python/cheese_flow/cli.py` (typer app, 7 subcommands, milknado top-level aliases) + `python/cheese_flow/mcp_server.py` (single FastMCP, `cheese_*` and `milknado_*` prefixed tools, stdio); deletes `src/lib/mcp-proxy.ts`; smoke-test that `cheese mcp tools/list` returns both prefix sets

--- a/tests/python/test_cheese_home.py
+++ b/tests/python/test_cheese_home.py
@@ -154,9 +154,7 @@ def test_resolve_cheese_home_skips_git_lookup_when_canonical_repo_provided(
         CheeseHomeOptions(home=str(home), canonicalRepo=canonical_repo),
     )
 
-    assert paths.projectDir == os.path.join(
-        str(home), "projects", path_slug(canonical_repo)
-    )
+    assert paths.projectDir == os.path.join(str(home), "projects", path_slug(canonical_repo))
 
 
 # ---------- resolveCheeseHome ----------
@@ -181,22 +179,16 @@ def test_resolve_cheese_home_derives_all_paths_from_cwd_without_writing(
     assert paths.milknadoDb == os.path.join(
         str(home), "projects", repo_slug, "milknado", "milknado.db"
     )
-    assert paths.worktreeDir == os.path.join(
-        str(home), "projects", repo_slug, "worktrees", wt_slug
-    )
+    assert paths.worktreeDir == os.path.join(str(home), "projects", repo_slug, "worktrees", wt_slug)
     assert paths.manifestsDir == os.path.join(
         str(home), "projects", repo_slug, "worktrees", wt_slug, "manifests"
     )
     assert paths.runsDir == os.path.join(
         str(home), "projects", repo_slug, "worktrees", wt_slug, "runs"
     )
-    assert paths.sharedDir == os.path.join(
-        str(home), "projects", repo_slug, "shared"
-    )
+    assert paths.sharedDir == os.path.join(str(home), "projects", repo_slug, "shared")
 
-    assert not Path(
-        str(home), "projects", repo_slug, "milknado", "milknado.db"
-    ).exists()
+    assert not Path(str(home), "projects", repo_slug, "milknado", "milknado.db").exists()
 
 
 def test_resolve_cheese_home_uses_homedir_when_no_override(tmp_path: Path) -> None:

--- a/tests/python/test_cheese_home.py
+++ b/tests/python/test_cheese_home.py
@@ -1,0 +1,340 @@
+"""Tests for `python/cheese_flow/lib/cheese_home.py`.
+
+Line-by-line port of `tests/cheese-home.test.ts`. Each describe block
+maps to a sibling pytest test cluster; each `it(...)` maps to one
+`def test_...` function.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from cheese_flow.lib.cheese_home import (
+    CheeseHomeOptions,
+    discover_canonical_repo,
+    ensure_cheese_home,
+    parse_worktree_main,
+    path_slug,
+    read_retention_config,
+    resolve_cheese_home,
+)
+
+GIT_ENV = {
+    "GIT_AUTHOR_NAME": "Test",
+    "GIT_AUTHOR_EMAIL": "test@example.com",
+    "GIT_COMMITTER_NAME": "Test",
+    "GIT_COMMITTER_EMAIL": "test@example.com",
+}
+
+
+def _init_real_repo(directory: Path) -> None:
+    subprocess.run(
+        ["git", "init", "--quiet", "-b", "main", str(directory)],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(directory),
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+            "--quiet",
+        ],
+        check=True,
+        env={**os.environ, **GIT_ENV},
+    )
+
+
+# ---------- pathSlug ----------
+
+
+def test_path_slug_replaces_every_slash_with_dash() -> None:
+    assert path_slug("/Users/paul/Dev/cheese-flow") == "-Users-paul-Dev-cheese-flow"
+
+
+def test_path_slug_returns_dash_for_filesystem_root() -> None:
+    assert path_slug("/") == "-"
+
+
+def test_path_slug_preserves_trailing_slash_as_trailing_dash() -> None:
+    assert path_slug("/Users/paul/Dev/cheese-flow/") == "-Users-paul-Dev-cheese-flow-"
+
+
+def test_path_slug_does_not_escape_legitimate_dash_in_segments() -> None:
+    assert path_slug("/Users/john-doe/Dev/cheese-flow") == "-Users-john-doe-Dev-cheese-flow"
+
+
+def test_path_slug_returns_input_unchanged_when_no_slash() -> None:
+    assert path_slug("plain-name") == "plain-name"
+
+
+# ---------- discoverCanonicalRepo ----------
+
+
+def test_discover_canonical_repo_returns_canonical_absolute_path_for_plain_checkout(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "plain"
+    repo.mkdir()
+    _init_real_repo(repo)
+    assert discover_canonical_repo(str(repo)) == str(repo.resolve())
+
+
+def test_discover_canonical_repo_returns_main_worktree_path_from_linked_worktree(
+    tmp_path: Path,
+) -> None:
+    main = tmp_path / "main"
+    main.mkdir()
+    _init_real_repo(main)
+    linked = tmp_path / "main-linked"
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(main),
+            "worktree",
+            "add",
+            "-b",
+            "feature",
+            str(linked),
+        ],
+        check=True,
+        env={**os.environ, **GIT_ENV},
+    )
+    assert discover_canonical_repo(str(linked)) == str(main.resolve())
+
+
+def test_discover_canonical_repo_throws_when_cwd_not_inside_git_repo(
+    tmp_path: Path,
+) -> None:
+    nogit = tmp_path / "nogit"
+    nogit.mkdir()
+    with pytest.raises(RuntimeError, match=r"not inside a git"):
+        discover_canonical_repo(str(nogit))
+
+
+# ---------- parseWorktreeMain ----------
+
+
+def test_parse_worktree_main_returns_path_from_first_worktree_line() -> None:
+    out = "worktree /repos/main\nbranch refs/heads/main\nHEAD abc\n"
+    assert parse_worktree_main(out, "/cwd") == "/repos/main"
+
+
+def test_parse_worktree_main_throws_when_porcelain_output_empty() -> None:
+    with pytest.raises(RuntimeError, match=r"not inside a git"):
+        parse_worktree_main("", "/cwd")
+
+
+def test_parse_worktree_main_throws_when_first_line_not_worktree_marker() -> None:
+    with pytest.raises(RuntimeError, match=r"not inside a git"):
+        parse_worktree_main("HEAD abc\n", "/cwd")
+
+
+# ---------- resolveCheeseHome — explicit canonicalRepo ----------
+
+
+def test_resolve_cheese_home_skips_git_lookup_when_canonical_repo_provided(
+    tmp_path: Path,
+) -> None:
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    canonical_repo = "/Users/paul/Dev/example-repo"
+
+    paths = resolve_cheese_home(
+        str(cwd),
+        CheeseHomeOptions(home=str(home), canonicalRepo=canonical_repo),
+    )
+
+    assert paths.projectDir == os.path.join(
+        str(home), "projects", path_slug(canonical_repo)
+    )
+
+
+# ---------- resolveCheeseHome ----------
+
+
+def test_resolve_cheese_home_derives_all_paths_from_cwd_without_writing(
+    tmp_path: Path,
+) -> None:
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _init_real_repo(cwd)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    paths = resolve_cheese_home(str(cwd), CheeseHomeOptions(home=str(home)))
+
+    real_cwd = str(cwd.resolve())
+    repo_slug = path_slug(real_cwd)
+    wt_slug = path_slug(real_cwd)
+    assert paths.root == str(home)
+    assert paths.projectDir == os.path.join(str(home), "projects", repo_slug)
+    assert paths.milknadoDb == os.path.join(
+        str(home), "projects", repo_slug, "milknado", "milknado.db"
+    )
+    assert paths.worktreeDir == os.path.join(
+        str(home), "projects", repo_slug, "worktrees", wt_slug
+    )
+    assert paths.manifestsDir == os.path.join(
+        str(home), "projects", repo_slug, "worktrees", wt_slug, "manifests"
+    )
+    assert paths.runsDir == os.path.join(
+        str(home), "projects", repo_slug, "worktrees", wt_slug, "runs"
+    )
+    assert paths.sharedDir == os.path.join(
+        str(home), "projects", repo_slug, "shared"
+    )
+
+    assert not Path(
+        str(home), "projects", repo_slug, "milknado", "milknado.db"
+    ).exists()
+
+
+def test_resolve_cheese_home_uses_homedir_when_no_override(tmp_path: Path) -> None:
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _init_real_repo(cwd)
+
+    paths = resolve_cheese_home(str(cwd))
+    assert paths.root == str(Path.home() / ".cheese")
+
+
+# ---------- ensureCheeseHome ----------
+
+
+def test_ensure_cheese_home_creates_tree_and_writes_path_sidecar(
+    tmp_path: Path,
+) -> None:
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _init_real_repo(cwd)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    paths = ensure_cheese_home(str(cwd), CheeseHomeOptions(home=str(home)))
+
+    assert Path(paths.projectDir).is_dir()
+    assert Path(paths.milknadoDb).parent.is_dir()
+    assert Path(paths.manifestsDir).is_dir()
+    assert Path(paths.runsDir).is_dir()
+    assert Path(paths.sharedDir).is_dir()
+
+    sidecar_path = Path(paths.worktreeDir, ".path")
+    sidecar = sidecar_path.read_text(encoding="utf-8")
+    assert sidecar == f"{cwd.resolve()}\n"
+
+
+def test_ensure_cheese_home_is_idempotent(tmp_path: Path) -> None:
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _init_real_repo(cwd)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    first = ensure_cheese_home(str(cwd), CheeseHomeOptions(home=str(home)))
+    second = ensure_cheese_home(str(cwd), CheeseHomeOptions(home=str(home)))
+
+    assert second.worktreeDir == first.worktreeDir
+    sidecar = Path(first.worktreeDir, ".path").read_text(encoding="utf-8")
+    assert sidecar == f"{cwd.resolve()}\n"
+
+
+# ---------- readRetentionConfig ----------
+
+
+def test_read_retention_config_returns_default_when_no_toml(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    config = read_retention_config(str(project_dir))
+
+    assert config.defaultDays == 30
+    assert config.milknadoDays is None
+    assert config.manifestsDays is None
+    assert config.runsDays is None
+    assert config.worktreeDays is None
+
+
+def test_read_retention_config_reads_numeric_overrides(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    (project_dir / "shared").mkdir(parents=True)
+    (project_dir / "shared" / "retention.toml").write_text(
+        "\n".join(
+            [
+                "defaultDays = 14",
+                "milknadoDays = 7",
+                "manifestsDays = 3",
+                "runsDays = 90",
+                "worktreeDays = 60",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = read_retention_config(str(project_dir))
+
+    assert config.defaultDays == 14
+    assert config.milknadoDays == 7
+    assert config.manifestsDays == 3
+    assert config.runsDays == 90
+    assert config.worktreeDays == 60
+
+
+def test_read_retention_config_ignores_section_headers_and_non_numeric_values(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "project"
+    (project_dir / "shared").mkdir(parents=True)
+    (project_dir / "shared" / "retention.toml").write_text(
+        "\n".join(
+            [
+                "[retention]",
+                "no-equals-sign-here",
+                "milknadoDays = not-a-number",
+                "manifestsDays =",
+                "runsDays = 12",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = read_retention_config(str(project_dir))
+
+    assert config.defaultDays == 30
+    assert config.milknadoDays is None
+    assert config.manifestsDays is None
+    assert config.runsDays == 12
+
+
+def test_read_retention_config_ignores_comments_blank_lines_and_unknown_keys(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "project"
+    (project_dir / "shared").mkdir(parents=True)
+    (project_dir / "shared" / "retention.toml").write_text(
+        "\n".join(
+            [
+                "# retention overrides",
+                "",
+                "defaultDays = 21",
+                "unknownKey = 99",
+                "  milknadoDays = 5  # inline ignored",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = read_retention_config(str(project_dir))
+
+    assert config.defaultDays == 21
+    assert config.milknadoDays == 5
+    assert not hasattr(config, "unknownKey")


### PR DESCRIPTION
Port src/lib/cheese-home.ts to python/cheese_flow/lib/cheese_home.py
with full surface (CheeseHomePaths, CheeseHomeOptions, RetentionConfig,
path_slug, parse_worktree_main, discover_canonical_repo,
resolve_cheese_home, ensure_cheese_home, read_retention_config).
Dataclass field names keep TS camelCase so callers ported from TS
read the same.

Refactor session_start.py and sweeper.py to import from cheese_home
instead of carrying their own inlined helpers. The TODO comments
in those modules anticipated this absorption.

Port tests/cheese-home.test.ts to tests/python/test_cheese_home.py
line-by-line; 18 new pytest cases covering pathSlug,
discoverCanonicalRepo (real-repo + linked-worktree + non-git error),
parseWorktreeMain, resolveCheeseHome (explicit + default home),
ensureCheeseHome (creates tree + sidecar + idempotent), and
readRetentionConfig (default, numeric overrides, edge cases,
comments and unknown keys).

Co-authored-by: Ralphify <noreply@ralphify.co>