### PR TITLE
feat(migration): US-013 local-marketplaces (TS → Python)

### DIFF
--- a/ralphs/python-migration/TODO.md
+++ b/ralphs/python-migration/TODO.md
@@ -18,7 +18,7 @@ US-005 (install-plan), US-006 (harness-detection), and US-007 (harness-compat).
 - [x] US-010 — Port `src/lib/session-start.ts` → `python/cheese_flow/lib/session_start.py`; port `tests/session-start.test.ts`
 - [x] US-011 — Port `src/lib/doctor.ts` → `python/cheese_flow/lib/doctor.py`; port matching vitest cases
 - [x] US-012 — Port `src/lib/cheese-home.ts` → `python/cheese_flow/lib/cheese_home.py`; port `tests/cheese-home.test.ts`
-- [ ] US-013 — Port `src/lib/local-marketplaces.ts` → `python/cheese_flow/lib/local_marketplaces.py`; port matching vitest cases
+- [x] US-013 — Port `src/lib/local-marketplaces.ts` → `python/cheese_flow/lib/local_marketplaces.py`; port matching vitest cases
 - [ ] US-014 — Port lint pipeline: `src/lib/lint-skills.ts` + `lint-skill-rules.ts` → `python/cheese_flow/lib/`; port `tests/lint-skills-directory.test.ts` + `tests/lint-skill-source.test.ts`
 - [ ] US-015 — FastMCP umbrella + Typer CLI: `python/cheese_flow/cli.py` (typer app, 7 subcommands, milknado top-level aliases) + `python/cheese_flow/mcp_server.py` (single FastMCP, `cheese_*` and `milknado_*` prefixed tools, stdio); deletes `src/lib/mcp-proxy.ts`; smoke-test that `cheese mcp tools/list` returns both prefix sets
 - [ ] US-016 — Port any remaining `tests/*.test.ts` files not absorbed by earlier stories to `tests/python/test_*.py`

--- a/tests/python/test_local_marketplaces.py
+++ b/tests/python/test_local_marketplaces.py
@@ -159,7 +159,8 @@ def test_write_codex_marketplace_emits_trailing_newline(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("plugin_name", ["foo", "bar-baz", "cheese-flow"])
 def test_marketplace_name_is_plugin_name_with_local_suffix(
-    tmp_path: Path, plugin_name: str,
+    tmp_path: Path,
+    plugin_name: str,
 ) -> None:
     metadata: PluginMetadata = {
         "name": plugin_name,

--- a/tests/python/test_local_marketplaces.py
+++ b/tests/python/test_local_marketplaces.py
@@ -1,0 +1,177 @@
+"""Tests for `python/cheese_flow/lib/local_marketplaces.py`.
+
+There is no dedicated `tests/local-marketplaces.test.ts` upstream — the TS
+surface is exercised transitively by ``tests/installer.test.ts`` (already
+ported in US-008). These tests mirror the TS contract directly against the
+Python helpers so any future drift in JSON shape, file location, or
+optional-field handling is caught at the unit boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from cheese_flow.lib.harness import PluginMetadata
+from cheese_flow.lib.local_marketplaces import (
+    MarketplaceInstallDetails,
+    write_claude_marketplace,
+    write_codex_marketplace,
+)
+
+
+def _full_metadata() -> PluginMetadata:
+    return {
+        "name": "cheese-flow",
+        "version": "1.2.3",
+        "description": "Cheese flow plugin",
+        "author": {"name": "Paul", "email": "paul@example.com"},
+        "license": "MIT",
+        "repository": "https://example.com/repo",
+        "homepage": "https://example.com",
+        "keywords": ["cheese", "flow"],
+    }
+
+
+def _minimal_metadata() -> PluginMetadata:
+    return {
+        "name": "cheese-flow",
+        "version": "1.2.3",
+        "description": "Cheese flow plugin",
+        "author": {"name": "Paul"},
+        "license": "MIT",
+        "repository": "https://example.com/repo",
+    }
+
+
+def test_write_claude_marketplace_writes_marketplace_json(tmp_path: Path) -> None:
+    details = asyncio.run(write_claude_marketplace(str(tmp_path), _full_metadata()))
+
+    assert isinstance(details, MarketplaceInstallDetails)
+    assert details.marketplaceName == "cheese-flow-local"
+    assert details.pluginName == "cheese-flow"
+
+    target = tmp_path / ".claude-plugin" / "marketplace.json"
+    assert target.exists()
+
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload == {
+        "name": "cheese-flow-local",
+        "owner": {"name": "Paul", "email": "paul@example.com"},
+        "plugins": [
+            {
+                "name": "cheese-flow",
+                "source": "./",
+                "description": "Cheese flow plugin",
+                "version": "1.2.3",
+                "author": {"name": "Paul", "email": "paul@example.com"},
+                "repository": "https://example.com/repo",
+                "homepage": "https://example.com",
+                "keywords": ["cheese", "flow"],
+                "strict": True,
+            }
+        ],
+    }
+
+
+def test_write_claude_marketplace_omits_optional_fields(tmp_path: Path) -> None:
+    asyncio.run(write_claude_marketplace(str(tmp_path), _minimal_metadata()))
+
+    payload = json.loads(
+        (tmp_path / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"),
+    )
+    plugin = payload["plugins"][0]
+
+    assert "homepage" not in plugin
+    assert "keywords" not in plugin
+    assert plugin["author"] == {"name": "Paul"}
+    assert payload["owner"] == {"name": "Paul"}
+    assert plugin["strict"] is True
+
+
+def test_write_claude_marketplace_creates_parent_directories(tmp_path: Path) -> None:
+    bundle_root = tmp_path / "deep" / "nested" / "bundle"
+
+    asyncio.run(write_claude_marketplace(str(bundle_root), _minimal_metadata()))
+
+    assert (bundle_root / ".claude-plugin" / "marketplace.json").exists()
+
+
+def test_write_claude_marketplace_emits_trailing_newline(tmp_path: Path) -> None:
+    asyncio.run(write_claude_marketplace(str(tmp_path), _minimal_metadata()))
+
+    raw = (tmp_path / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8")
+    assert raw.endswith("\n")
+
+
+def test_write_codex_marketplace_writes_marketplace_json(tmp_path: Path) -> None:
+    details = asyncio.run(write_codex_marketplace(str(tmp_path), _full_metadata()))
+
+    assert details.marketplaceName == "cheese-flow-local"
+    assert details.pluginName == "cheese-flow"
+
+    target = tmp_path / ".agents" / "plugins" / "marketplace.json"
+    assert target.exists()
+
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload == {
+        "name": "cheese-flow-local",
+        "interface": {"displayName": "cheese-flow Local"},
+        "plugins": [
+            {
+                "name": "cheese-flow",
+                "source": {"source": "local", "path": "./"},
+                "policy": {
+                    "installation": "AVAILABLE",
+                    "authentication": "ON_INSTALL",
+                },
+                "category": "Development",
+            }
+        ],
+    }
+
+
+def test_write_codex_marketplace_ignores_metadata_extras(tmp_path: Path) -> None:
+    """Codex schema does not surface author/homepage/keywords; ensure parity."""
+
+    asyncio.run(write_codex_marketplace(str(tmp_path), _full_metadata()))
+
+    payload = json.loads(
+        (tmp_path / ".agents" / "plugins" / "marketplace.json").read_text(
+            encoding="utf-8",
+        ),
+    )
+    plugin = payload["plugins"][0]
+
+    assert set(plugin.keys()) == {"name", "source", "policy", "category"}
+
+
+def test_write_codex_marketplace_emits_trailing_newline(tmp_path: Path) -> None:
+    asyncio.run(write_codex_marketplace(str(tmp_path), _minimal_metadata()))
+
+    raw = (tmp_path / ".agents" / "plugins" / "marketplace.json").read_text(
+        encoding="utf-8",
+    )
+    assert raw.endswith("\n")
+
+
+@pytest.mark.parametrize("plugin_name", ["foo", "bar-baz", "cheese-flow"])
+def test_marketplace_name_is_plugin_name_with_local_suffix(
+    tmp_path: Path, plugin_name: str,
+) -> None:
+    metadata: PluginMetadata = {
+        "name": plugin_name,
+        "version": "0.0.1",
+        "description": "x",
+        "author": {"name": "Paul"},
+        "license": "MIT",
+        "repository": "https://example.com/repo",
+    }
+
+    claude = asyncio.run(write_claude_marketplace(str(tmp_path / plugin_name), metadata))
+    codex = asyncio.run(write_codex_marketplace(str(tmp_path / plugin_name), metadata))
+
+    assert claude.marketplaceName == f"{plugin_name}-local"
+    assert codex.marketplaceName == f"{plugin_name}-local"


### PR DESCRIPTION
Add dedicated unit tests for the previously-ported local_marketplaces module:
the Python helpers landed alongside US-008 (installer) but lacked direct
coverage of JSON shape, optional-field handling, and marketplace name format.

Co-authored-by: Ralphify <noreply@ralphify.co>