### PR TITLE
feat(migration): US-014 lint pipeline (TS → Python)

### DIFF
--- a/python/cheese_flow/lib/lint_skill_rules.py
+++ b/python/cheese_flow/lib/lint_skill_rules.py
@@ -1,0 +1,237 @@
+"""Port of `src/lib/lint-skill-rules.ts` — skill linter rule library.
+
+Mirrors the TS surface: ``lint_skill_source``, ``make_issue_factory``, and the
+``LintIssue`` / ``LintSeverity`` / ``IssueFactory`` / ``LintSourceContext``
+types. Behavior parity with the TS module is the bar.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from typing import Literal, TypedDict
+
+from pydantic import ValidationError
+
+from cheese_flow.lib.frontmatter import parse_frontmatter
+from cheese_flow.lib.harness_compat import (
+    check_allowed_tools_portability,
+    check_body_harness_idioms,
+    check_frontmatter_portability,
+)
+from cheese_flow.lib.schemas import parse_skill_frontmatter
+
+LintSeverity = Literal["error", "warning"]
+
+
+class _LintIssueRequired(TypedDict):
+    skill: str
+    file: str
+    severity: LintSeverity
+    rule: str
+    message: str
+
+
+class LintIssue(_LintIssueRequired, total=False):
+    line: int
+
+
+IssueFactory = Callable[..., LintIssue]
+
+
+class LintSourceContext(TypedDict):
+    directoryName: str
+    relativeFile: str
+    source: str
+
+
+_RECOMMENDED_BODY_LINE_LIMIT = 500
+_MIN_DESCRIPTION_LENGTH = 20
+
+_BODY_OFFSET_PATTERN = re.compile(r"\r?\n---\r?\n")
+_LINE_SPLIT_PATTERN = re.compile(r"\r?\n")
+
+
+def make_issue_factory(directory_name: str, relative_file: str) -> IssueFactory:
+    def factory(
+        severity: LintSeverity,
+        rule: str,
+        message: str,
+        line: int | None = None,
+    ) -> LintIssue:
+        issue: LintIssue = {
+            "skill": directory_name,
+            "file": relative_file,
+            "severity": severity,
+            "rule": rule,
+            "message": message,
+        }
+        if line is not None:
+            issue["line"] = line
+        return issue
+
+    return factory
+
+
+def lint_skill_source(context: LintSourceContext) -> list[LintIssue]:
+    issue = make_issue_factory(context["directoryName"], context["relativeFile"])
+
+    try:
+        data, body = parse_frontmatter(context["source"])
+    except Exception as error:  # noqa: BLE001 - mirror TS catch
+        return [issue("error", "frontmatter-parse", str(error))]
+
+    issues: list[LintIssue] = []
+    issues.extend(_validate_frontmatter(data, context, issue))
+    issues.extend(_validate_body(body, _body_line_offset(context["source"]), issue))
+    return issues
+
+
+def _body_line_offset(source: str) -> int:
+    match = _BODY_OFFSET_PATTERN.search(source)
+    if match is None:
+        return 0
+    lead = source[: match.start()]
+    header_lines = len(_LINE_SPLIT_PATTERN.split(lead))
+    return header_lines + 1
+
+
+def _validate_frontmatter(
+    data: object,
+    context: LintSourceContext,
+    issue: IssueFactory,
+) -> list[LintIssue]:
+    issues: list[LintIssue] = []
+    frontmatter = _try_parse_frontmatter(data, issue, issues)
+
+    if frontmatter is not None:
+        issues.extend(_name_and_description_checks(frontmatter, context, issue))
+
+    if isinstance(data, dict):
+        raw = dict(data)
+        issues.extend(_portability_checks(raw.get("allowed-tools"), raw, issue))
+
+    return issues
+
+
+def _try_parse_frontmatter(
+    data: object,
+    issue: IssueFactory,
+    issues: list[LintIssue],
+):
+    try:
+        return parse_skill_frontmatter(data)
+    except ValidationError as error:
+        _push_pydantic_issues(error, issue, issues)
+        return None
+    except Exception as error:  # noqa: BLE001 - mirror TS catch
+        issues.append(issue("error", "frontmatter-parse", str(error)))
+        return None
+
+
+def _push_pydantic_issues(
+    error: ValidationError,
+    issue: IssueFactory,
+    issues: list[LintIssue],
+) -> None:
+    for entry in error.errors():
+        location = entry.get("loc", ())
+        field_path = ".".join(str(part) for part in location) or "<frontmatter>"
+        message = entry.get("msg", "")
+        issues.append(
+            issue(
+                "error",
+                f"frontmatter:{field_path}",
+                f"{field_path}: {message}",
+            )
+        )
+
+
+def _name_and_description_checks(
+    frontmatter,
+    context: LintSourceContext,
+    issue: IssueFactory,
+) -> list[LintIssue]:
+    issues: list[LintIssue] = []
+    if frontmatter.name != context["directoryName"]:
+        issues.append(
+            issue(
+                "error",
+                "name-matches-directory",
+                f'frontmatter name "{frontmatter.name}" must match parent '
+                f'directory "{context["directoryName"]}".',
+            )
+        )
+
+    description = frontmatter.description.strip()
+    if len(description) < _MIN_DESCRIPTION_LENGTH:
+        issues.append(
+            issue(
+                "warning",
+                "description-too-short",
+                f"description is {len(description)} chars; aim for at least "
+                f"{_MIN_DESCRIPTION_LENGTH} so agents can match it during "
+                "discovery.",
+            )
+        )
+    return issues
+
+
+def _portability_checks(
+    allowed_tools: object,
+    raw_frontmatter: dict[str, object],
+    issue: IssueFactory,
+) -> list[LintIssue]:
+    issues: list[LintIssue] = []
+    allowed: str | list[str] | None = (
+        allowed_tools if isinstance(allowed_tools, (str, list)) else None
+    )
+
+    for finding in check_allowed_tools_portability(allowed):
+        issues.append(issue(finding["severity"], finding["rule"], finding["message"]))
+    for finding in check_frontmatter_portability(raw_frontmatter, "skill"):
+        issues.append(issue(finding["severity"], finding["rule"], finding["message"]))
+    return issues
+
+
+def _validate_body(
+    body: str,
+    line_offset: int,
+    issue: IssueFactory,
+) -> list[LintIssue]:
+    issues: list[LintIssue] = []
+    body_line_count = len(_LINE_SPLIT_PATTERN.split(body))
+    if body_line_count > _RECOMMENDED_BODY_LINE_LIMIT:
+        issues.append(
+            issue(
+                "warning",
+                "body-too-long",
+                f"SKILL.md body is {body_line_count} lines; the spec "
+                f"recommends staying under {_RECOMMENDED_BODY_LINE_LIMIT}. "
+                "Move detail into references/.",
+            )
+        )
+    for finding in check_body_harness_idioms(body):
+        finding_line = finding.get("line")
+        absolute_line = (
+            finding_line + line_offset if finding_line is not None else None
+        )
+        issues.append(
+            issue(
+                finding["severity"],
+                finding["rule"],
+                finding["message"],
+                absolute_line,
+            )
+        )
+    return issues
+
+
+__all__ = [
+    "IssueFactory",
+    "LintIssue",
+    "LintSeverity",
+    "LintSourceContext",
+    "lint_skill_source",
+    "make_issue_factory",
+]

--- a/python/cheese_flow/lib/lint_skill_rules.py
+++ b/python/cheese_flow/lib/lint_skill_rules.py
@@ -213,9 +213,7 @@ def _validate_body(
         )
     for finding in check_body_harness_idioms(body):
         finding_line = finding.get("line")
-        absolute_line = (
-            finding_line + line_offset if finding_line is not None else None
-        )
+        absolute_line = finding_line + line_offset if finding_line is not None else None
         issues.append(
             issue(
                 finding["severity"],

--- a/python/cheese_flow/lib/lint_skills.py
+++ b/python/cheese_flow/lib/lint_skills.py
@@ -47,9 +47,7 @@ async def lint_skills_directory(
 
     issues: list[LintIssue] = []
     for directory_name in directories:
-        issues.extend(
-            await _lint_skill_directory(skills_root, directory_name, compile_fn)
-        )
+        issues.extend(await _lint_skill_directory(skills_root, directory_name, compile_fn))
     return {"scanned": len(directories), "issues": issues}
 
 
@@ -86,8 +84,7 @@ async def _lint_skill_directory(
 
     compile_findings = await compile_fn(directory_name, source_or_issue["source"])
     compile_issues = [
-        _finding_to_issue(finding, directory_name, relative_file)
-        for finding in compile_findings
+        _finding_to_issue(finding, directory_name, relative_file) for finding in compile_findings
     ]
 
     return [*source_issues, *compile_issues]
@@ -101,9 +98,7 @@ class _SourceFailed(TypedDict):
     issues: list[LintIssue]
 
 
-async def _read_skill_source(
-    skill_file: Path, issue: IssueFactory
-) -> _SourceOk | _SourceFailed:
+async def _read_skill_source(skill_file: Path, issue: IssueFactory) -> _SourceOk | _SourceFailed:
     try:
         await asyncio.to_thread(skill_file.stat)
     except FileNotFoundError:
@@ -165,9 +160,7 @@ def format_lint_report(report: LintReport) -> str:
     for item in report["issues"]:
         tag = "ERROR" if item["severity"] == "error" else "WARN"
         item_line = item.get("line")
-        anchor = (
-            f"{item['file']}:{item_line}" if item_line is not None else item["file"]
-        )
+        anchor = f"{item['file']}:{item_line}" if item_line is not None else item["file"]
         lines.append(f"[{tag}] {anchor} ({item['rule']}): {item['message']}")
 
     error_count = sum(1 for entry in report["issues"] if entry["severity"] == "error")

--- a/python/cheese_flow/lib/lint_skills.py
+++ b/python/cheese_flow/lib/lint_skills.py
@@ -1,0 +1,195 @@
+"""Port of `src/lib/lint-skills.ts` — directory-level skill linter.
+
+Mirrors the TS surface: ``lint_skills_directory``, ``format_lint_report``,
+``has_errors``, plus ``LintReport`` / ``CompileSkillFn`` /
+``LintSkillsDirectoryOptions`` types. Re-exports ``LintIssue``,
+``LintSeverity``, and ``lint_skill_source`` from ``lint_skill_rules``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import TypedDict
+
+from cheese_flow.lib.harness_compat import HarnessCompatFinding, compile_test_skill
+from cheese_flow.lib.lint_skill_rules import (
+    IssueFactory,
+    LintIssue,
+    LintSeverity,
+    lint_skill_source,
+    make_issue_factory,
+)
+
+CompileSkillFn = Callable[[str, str], Awaitable[list[HarnessCompatFinding]]]
+
+
+class LintReport(TypedDict):
+    scanned: int
+    issues: list[LintIssue]
+
+
+class LintSkillsDirectoryOptions(TypedDict, total=False):
+    compile: CompileSkillFn
+
+
+async def lint_skills_directory(
+    skills_root: str,
+    options: LintSkillsDirectoryOptions | None = None,
+) -> LintReport:
+    options = options or {}
+    compile_fn: CompileSkillFn = options.get("compile") or compile_test_skill
+
+    root = Path(skills_root)
+    entries = await asyncio.to_thread(_list_entries, root)
+    directories = sorted(entry.name for entry in entries if entry.is_dir())
+
+    issues: list[LintIssue] = []
+    for directory_name in directories:
+        issues.extend(
+            await _lint_skill_directory(skills_root, directory_name, compile_fn)
+        )
+    return {"scanned": len(directories), "issues": issues}
+
+
+def _list_entries(root: Path) -> list[Path]:
+    return list(root.iterdir())
+
+
+async def _lint_skill_directory(
+    skills_root: str,
+    directory_name: str,
+    compile_fn: CompileSkillFn,
+) -> list[LintIssue]:
+    skill_file = Path(skills_root) / directory_name / "SKILL.md"
+    relative_file = str(skill_file.relative_to(Path(skills_root)))
+    issue = make_issue_factory(directory_name, relative_file)
+
+    source_or_issue = await _read_skill_source(skill_file, issue)
+    if "issues" in source_or_issue:
+        return source_or_issue["issues"]
+
+    source_issues = lint_skill_source(
+        {
+            "directoryName": directory_name,
+            "relativeFile": relative_file,
+            "source": source_or_issue["source"],
+        }
+    )
+
+    # Skip the cross-harness compile-trip when the source itself has errors.
+    # The compile step would re-surface the same parse/name failures four times,
+    # one per adapter, drowning out the real source issue.
+    if any(entry["severity"] == "error" for entry in source_issues):
+        return source_issues
+
+    compile_findings = await compile_fn(directory_name, source_or_issue["source"])
+    compile_issues = [
+        _finding_to_issue(finding, directory_name, relative_file)
+        for finding in compile_findings
+    ]
+
+    return [*source_issues, *compile_issues]
+
+
+class _SourceOk(TypedDict):
+    source: str
+
+
+class _SourceFailed(TypedDict):
+    issues: list[LintIssue]
+
+
+async def _read_skill_source(
+    skill_file: Path, issue: IssueFactory
+) -> _SourceOk | _SourceFailed:
+    try:
+        await asyncio.to_thread(skill_file.stat)
+    except FileNotFoundError:
+        return {
+            "issues": [
+                issue(
+                    "error",
+                    "skill-md-required",
+                    "SKILL.md is required at the skill directory root.",
+                )
+            ]
+        }
+
+    try:
+        source = await asyncio.to_thread(skill_file.read_text, encoding="utf8")
+    except Exception as error:  # noqa: BLE001 - mirror TS catch
+        return {
+            "issues": [
+                issue(
+                    "error",
+                    "skill-md-unreadable",
+                    f"SKILL.md could not be read: {error}",
+                )
+            ]
+        }
+
+    return {"source": source}
+
+
+def _finding_to_issue(
+    finding: HarnessCompatFinding,
+    directory_name: str,
+    relative_file: str,
+) -> LintIssue:
+    issue: LintIssue = {
+        "skill": directory_name,
+        "file": relative_file,
+        "severity": finding["severity"],
+        "rule": finding["rule"],
+        "message": finding["message"],
+    }
+    finding_line = finding.get("line")
+    if finding_line is not None:
+        issue["line"] = finding_line
+    return issue
+
+
+def format_lint_report(report: LintReport) -> str:
+    plural = "" if report["scanned"] == 1 else "s"
+    lines: list[str] = [
+        f"cheese lint — {report['scanned']} skill{plural} scanned",
+        "",
+    ]
+
+    if not report["issues"]:
+        lines.append("No issues found.")
+        return "\n".join(lines) + "\n"
+
+    for item in report["issues"]:
+        tag = "ERROR" if item["severity"] == "error" else "WARN"
+        item_line = item.get("line")
+        anchor = (
+            f"{item['file']}:{item_line}" if item_line is not None else item["file"]
+        )
+        lines.append(f"[{tag}] {anchor} ({item['rule']}): {item['message']}")
+
+    error_count = sum(1 for entry in report["issues"] if entry["severity"] == "error")
+    warning_count = len(report["issues"]) - error_count
+    lines.append("")
+    lines.append(f"{error_count} error(s), {warning_count} warning(s).")
+
+    return "\n".join(lines) + "\n"
+
+
+def has_errors(report: LintReport) -> bool:
+    return any(item["severity"] == "error" for item in report["issues"])
+
+
+__all__ = [
+    "CompileSkillFn",
+    "LintIssue",
+    "LintReport",
+    "LintSeverity",
+    "LintSkillsDirectoryOptions",
+    "format_lint_report",
+    "has_errors",
+    "lint_skill_source",
+    "lint_skills_directory",
+]

--- a/ralphs/python-migration/TODO.md
+++ b/ralphs/python-migration/TODO.md
@@ -19,7 +19,7 @@ US-005 (install-plan), US-006 (harness-detection), and US-007 (harness-compat).
 - [x] US-011 — Port `src/lib/doctor.ts` → `python/cheese_flow/lib/doctor.py`; port matching vitest cases
 - [x] US-012 — Port `src/lib/cheese-home.ts` → `python/cheese_flow/lib/cheese_home.py`; port `tests/cheese-home.test.ts`
 - [x] US-013 — Port `src/lib/local-marketplaces.ts` → `python/cheese_flow/lib/local_marketplaces.py`; port matching vitest cases
-- [ ] US-014 — Port lint pipeline: `src/lib/lint-skills.ts` + `lint-skill-rules.ts` → `python/cheese_flow/lib/`; port `tests/lint-skills-directory.test.ts` + `tests/lint-skill-source.test.ts`
+- [x] US-014 — Port lint pipeline: `src/lib/lint-skills.ts` + `lint-skill-rules.ts` → `python/cheese_flow/lib/`; port `tests/lint-skills-directory.test.ts` + `tests/lint-skill-source.test.ts`
 - [ ] US-015 — FastMCP umbrella + Typer CLI: `python/cheese_flow/cli.py` (typer app, 7 subcommands, milknado top-level aliases) + `python/cheese_flow/mcp_server.py` (single FastMCP, `cheese_*` and `milknado_*` prefixed tools, stdio); deletes `src/lib/mcp-proxy.ts`; smoke-test that `cheese mcp tools/list` returns both prefix sets
 - [ ] US-016 — Port any remaining `tests/*.test.ts` files not absorbed by earlier stories to `tests/python/test_*.py`
 - [ ] US-017 — Cutover: delete `src/`, `tests/*.test.ts`, `package.json`, `package-lock.json`, `tsconfig*.json`, `biome.json`, `vitest.config.ts`; rewrite `justfile` (drop all `npm` recipes, uv-only `build`); update `.mcp.json` (`npx tsx ...` → `uv run cheese mcp`); update `hooks/cheese-bootstrap.sh`, `AGENTS.md`, `README.md`, `CLAUDE.md`, CI workflows; verify the MCP smoke test from `cheese mcp` and the byte-parity snapshot from US-004 still pass

--- a/tests/python/test_lint_skill_rules.py
+++ b/tests/python/test_lint_skill_rules.py
@@ -41,9 +41,7 @@ def test_flags_name_directory_mismatch_as_an_error() -> None:
     )
     rules = [entry["rule"] for entry in issues]
     assert "name-matches-directory" in rules
-    finding = next(
-        entry for entry in issues if entry["rule"] == "name-matches-directory"
-    )
+    finding = next(entry for entry in issues if entry["rule"] == "name-matches-directory")
     assert finding["severity"] == "error"
 
 
@@ -76,11 +74,7 @@ def test_flags_missing_description() -> None:
         }
     )
     desc_finding = next(
-        (
-            entry
-            for entry in issues
-            if entry["rule"].startswith("frontmatter:description")
-        ),
+        (entry for entry in issues if entry["rule"].startswith("frontmatter:description")),
         None,
     )
     assert desc_finding is not None
@@ -93,9 +87,7 @@ def test_warns_when_the_description_is_too_short() -> None:
         {
             "directoryName": "short-desc",
             "relativeFile": "short-desc/SKILL.md",
-            "source": (
-                "---\nname: short-desc\ndescription: Too short.\n---\n" + VALID_BODY
-            ),
+            "source": ("---\nname: short-desc\ndescription: Too short.\n---\n" + VALID_BODY),
         }
     )
     warning = next(
@@ -161,11 +153,7 @@ def test_flags_compatibility_strings_exceeding_500_characters() -> None:
         }
     )
     compat_finding = next(
-        (
-            entry
-            for entry in issues
-            if entry["rule"].startswith("frontmatter:compatibility")
-        ),
+        (entry for entry in issues if entry["rule"].startswith("frontmatter:compatibility")),
         None,
     )
     assert compat_finding is not None
@@ -186,11 +174,7 @@ def test_warns_when_allowed_tools_uses_claude_code_permission_glob_syntax() -> N
         }
     )
     finding = next(
-        (
-            entry
-            for entry in issues
-            if entry["rule"] == "allowed-tools-claude-permission-syntax"
-        ),
+        (entry for entry in issues if entry["rule"] == "allowed-tools-claude-permission-syntax"),
         None,
     )
     assert finding is not None
@@ -211,11 +195,7 @@ def test_warns_when_allowed_tools_is_an_array_using_claude_permission_glob() -> 
         }
     )
     finding = next(
-        (
-            entry
-            for entry in issues
-            if entry["rule"] == "allowed-tools-claude-permission-syntax"
-        ),
+        (entry for entry in issues if entry["rule"] == "allowed-tools-claude-permission-syntax"),
         None,
     )
     assert finding is not None
@@ -236,8 +216,7 @@ def test_does_not_warn_on_bare_tool_names_in_allowed_tools() -> None:
         }
     )
     assert not any(
-        entry["rule"].startswith("allowed-tools-claude-permission-syntax")
-        for entry in issues
+        entry["rule"].startswith("allowed-tools-claude-permission-syntax") for entry in issues
     )
 
 
@@ -329,8 +308,7 @@ def test_stringifies_non_error_throws_from_parse_skill_frontmatter() -> None:
                 "relativeFile": "stringy/SKILL.md",
                 "source": (
                     "---\nname: stringy\ndescription: A perfectly fine "
-                    "description that is long enough for discovery.\n---\n"
-                    + VALID_BODY
+                    "description that is long enough for discovery.\n---\n" + VALID_BODY
                 ),
             }
         )
@@ -354,9 +332,7 @@ def test_ignores_allowed_tools_when_it_is_neither_string_nor_array() -> None:
             ),
         }
     )
-    assert not any(
-        entry["rule"] == "allowed-tools-claude-permission-syntax" for entry in issues
-    )
+    assert not any(entry["rule"] == "allowed-tools-claude-permission-syntax" for entry in issues)
 
 
 def test_converts_a_non_zod_error_throw_from_parse_skill_frontmatter() -> None:
@@ -373,8 +349,7 @@ def test_converts_a_non_zod_error_throw_from_parse_skill_frontmatter() -> None:
                 "relativeFile": "weird-throw/SKILL.md",
                 "source": (
                     "---\nname: weird-throw\ndescription: A perfectly fine "
-                    "description that is long enough for discovery.\n---\n"
-                    + VALID_BODY
+                    "description that is long enough for discovery.\n---\n" + VALID_BODY
                 ),
             }
         )
@@ -398,9 +373,7 @@ def test_flags_claude_only_frontmatter_fields_via_adapter_capabilities() -> None
             ),
         }
     )
-    portability = [
-        entry for entry in issues if entry["rule"] == "frontmatter-portability"
-    ]
+    portability = [entry for entry in issues if entry["rule"] == "frontmatter-portability"]
     assert len(portability) == 2
     assert all(entry["severity"] == "warning" for entry in portability)
 
@@ -432,9 +405,7 @@ def test_context_fork_produces_exactly_one_portability_warning() -> None:
             ),
         }
     )
-    portability = [
-        entry for entry in issues if entry["rule"] == "frontmatter-portability"
-    ]
+    portability = [entry for entry in issues if entry["rule"] == "frontmatter-portability"]
     assert len(portability) == 1
 
 
@@ -451,11 +422,7 @@ def test_stop_in_body_emits_body_harness_only_hook_event_not_pascal() -> None:
         }
     )
     stop_finding = next(
-        (
-            entry
-            for entry in issues
-            if entry["rule"] == "body-harness-only-hook-event"
-        ),
+        (entry for entry in issues if entry["rule"] == "body-harness-only-hook-event"),
         None,
     )
     assert stop_finding is not None
@@ -477,8 +444,7 @@ def test_stop_camel_case_in_body_does_not_emit_any_hook_warning() -> None:
         }
     )
     assert not any(
-        entry["rule"]
-        in ("body-harness-only-hook-event", "body-pascal-hook-event")
+        entry["rule"] in ("body-harness-only-hook-event", "body-pascal-hook-event")
         for entry in issues
     )
 
@@ -495,9 +461,7 @@ def test_runs_portability_checks_even_when_frontmatter_validation_fails() -> Non
             ),
         }
     )
-    name_finding = next(
-        (entry for entry in issues if entry["rule"] == "frontmatter:name"), None
-    )
+    name_finding = next((entry for entry in issues if entry["rule"] == "frontmatter:name"), None)
     assert name_finding is not None
     assert name_finding["severity"] == "error"
 

--- a/tests/python/test_lint_skill_rules.py
+++ b/tests/python/test_lint_skill_rules.py
@@ -1,0 +1,539 @@
+"""Verbatim port of `tests/lint-skill-source.test.ts`.
+
+Mirrors the vitest cases for ``lint_skill_source`` (re-exported from
+``cheese_flow.lib.lint_skills``). Tests that depend on monkeypatching the
+schemas module use ``monkeypatch`` / ``unittest.mock`` instead of vitest spies.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from cheese_flow.lib.lint_skills import lint_skill_source
+
+VALID_BODY = "# Skill body\n\nUse this skill to do a thing.\n"
+
+
+def test_accepts_a_valid_skill() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "valid-skill",
+            "relativeFile": "valid-skill/SKILL.md",
+            "source": (
+                "---\nname: valid-skill\ndescription: Performs a clearly "
+                "described action when the user asks for it.\n---\n" + VALID_BODY
+            ),
+        }
+    )
+    assert issues == []
+
+
+def test_flags_name_directory_mismatch_as_an_error() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "real-name",
+            "relativeFile": "real-name/SKILL.md",
+            "source": (
+                "---\nname: other-name\ndescription: Performs a clearly "
+                "described action when the user asks for it.\n---\n" + VALID_BODY
+            ),
+        }
+    )
+    rules = [entry["rule"] for entry in issues]
+    assert "name-matches-directory" in rules
+    finding = next(
+        entry for entry in issues if entry["rule"] == "name-matches-directory"
+    )
+    assert finding["severity"] == "error"
+
+
+def test_flags_invalid_kebab_case_names() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "BadName",
+            "relativeFile": "BadName/SKILL.md",
+            "source": (
+                "---\nname: BadName\ndescription: Performs a clearly described "
+                "action when the user asks for it.\n---\n" + VALID_BODY
+            ),
+        }
+    )
+    name_finding = next(
+        (entry for entry in issues if entry["rule"] == "frontmatter:name"),
+        None,
+    )
+    assert name_finding is not None
+    assert name_finding["severity"] == "error"
+    assert "name" in name_finding["message"]
+
+
+def test_flags_missing_description() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "no-desc",
+            "relativeFile": "no-desc/SKILL.md",
+            "source": "---\nname: no-desc\n---\n" + VALID_BODY,
+        }
+    )
+    desc_finding = next(
+        (
+            entry
+            for entry in issues
+            if entry["rule"].startswith("frontmatter:description")
+        ),
+        None,
+    )
+    assert desc_finding is not None
+    assert desc_finding["severity"] == "error"
+    assert desc_finding["rule"] == "frontmatter:description"
+
+
+def test_warns_when_the_description_is_too_short() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "short-desc",
+            "relativeFile": "short-desc/SKILL.md",
+            "source": (
+                "---\nname: short-desc\ndescription: Too short.\n---\n" + VALID_BODY
+            ),
+        }
+    )
+    warning = next(
+        (entry for entry in issues if entry["rule"] == "description-too-short"),
+        None,
+    )
+    assert warning is not None
+    assert warning["severity"] == "warning"
+
+
+def test_warns_when_the_body_exceeds_the_recommended_line_limit() -> None:
+    long_body = "line\n" * 600
+    issues = lint_skill_source(
+        {
+            "directoryName": "long-body",
+            "relativeFile": "long-body/SKILL.md",
+            "source": (
+                "---\nname: long-body\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n---\n" + long_body
+            ),
+        }
+    )
+    warning = next((entry for entry in issues if entry["rule"] == "body-too-long"), None)
+    assert warning is not None
+    assert warning["severity"] == "warning"
+
+
+def test_flags_scalar_frontmatter_with_the_frontmatter_path_label() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "scalar",
+            "relativeFile": "scalar/SKILL.md",
+            "source": "---\n42\n---\n" + VALID_BODY,
+        }
+    )
+    assert any(entry["rule"] == "frontmatter:<frontmatter>" for entry in issues)
+
+
+def test_returns_a_parse_error_when_frontmatter_markers_are_missing() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "broken",
+            "relativeFile": "broken/SKILL.md",
+            "source": "no frontmatter here\n",
+        }
+    )
+    assert len(issues) == 1
+    assert issues[0]["rule"] == "frontmatter-parse"
+    assert issues[0]["severity"] == "error"
+
+
+def test_flags_compatibility_strings_exceeding_500_characters() -> None:
+    long_compat = "x" * 600
+    issues = lint_skill_source(
+        {
+            "directoryName": "wide-compat",
+            "relativeFile": "wide-compat/SKILL.md",
+            "source": (
+                "---\nname: wide-compat\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n"
+                f"compatibility: {long_compat}\n---\n" + VALID_BODY
+            ),
+        }
+    )
+    compat_finding = next(
+        (
+            entry
+            for entry in issues
+            if entry["rule"].startswith("frontmatter:compatibility")
+        ),
+        None,
+    )
+    assert compat_finding is not None
+    assert compat_finding["severity"] == "error"
+    assert compat_finding["rule"] == "frontmatter:compatibility"
+
+
+def test_warns_when_allowed_tools_uses_claude_code_permission_glob_syntax() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "claude-perms",
+            "relativeFile": "claude-perms/SKILL.md",
+            "source": (
+                "---\nname: claude-perms\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n"
+                "allowed-tools: Bash(git diff:*), Read\n---\n" + VALID_BODY
+            ),
+        }
+    )
+    finding = next(
+        (
+            entry
+            for entry in issues
+            if entry["rule"] == "allowed-tools-claude-permission-syntax"
+        ),
+        None,
+    )
+    assert finding is not None
+    assert finding["severity"] == "warning"
+    assert "Bash(git diff:*)" in finding["message"]
+
+
+def test_warns_when_allowed_tools_is_an_array_using_claude_permission_glob() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "claude-perms-array",
+            "relativeFile": "claude-perms-array/SKILL.md",
+            "source": (
+                "---\nname: claude-perms-array\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n"
+                "allowed-tools:\n  - Bash(gh:*)\n  - Read\n---\n" + VALID_BODY
+            ),
+        }
+    )
+    finding = next(
+        (
+            entry
+            for entry in issues
+            if entry["rule"] == "allowed-tools-claude-permission-syntax"
+        ),
+        None,
+    )
+    assert finding is not None
+    assert finding["severity"] == "warning"
+    assert "Bash(gh:*)" in finding["message"]
+
+
+def test_does_not_warn_on_bare_tool_names_in_allowed_tools() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "bare-tools",
+            "relativeFile": "bare-tools/SKILL.md",
+            "source": (
+                "---\nname: bare-tools\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n"
+                "allowed-tools:\n  - read\n  - write\n  - bash\n---\n" + VALID_BODY
+            ),
+        }
+    )
+    assert not any(
+        entry["rule"].startswith("allowed-tools-claude-permission-syntax")
+        for entry in issues
+    )
+
+
+def test_warns_when_body_references_claude_only_agent_tool() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "agent-call",
+            "relativeFile": "agent-call/SKILL.md",
+            "source": (
+                "---\nname: agent-call\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n---\n# Body\n"
+                'Use Agent(subagent_type="foo") to spawn a sub-agent.\n'
+            ),
+        }
+    )
+    finding = next(
+        (entry for entry in issues if entry["rule"] == "body-claude-only-tool"),
+        None,
+    )
+    assert finding is not None
+    assert finding["severity"] == "warning"
+    assert "Agent" in finding["message"]
+
+
+def test_warns_when_body_references_claude_only_task_tool() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "task-call",
+            "relativeFile": "task-call/SKILL.md",
+            "source": (
+                "---\nname: task-call\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n---\n# Body\n"
+                "Dispatch via Task(...)\n"
+            ),
+        }
+    )
+    finding = next(
+        (entry for entry in issues if entry["rule"] == "body-claude-only-tool"),
+        None,
+    )
+    assert finding is not None
+    assert finding["severity"] == "warning"
+    assert "Task" in finding["message"]
+
+
+def test_warns_when_body_references_pascal_case_hook_event_names() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "pascal-hook",
+            "relativeFile": "pascal-hook/SKILL.md",
+            "source": (
+                "---\nname: pascal-hook\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n---\n# Body\n"
+                "Fires on SessionStart and PreToolUse events.\n"
+            ),
+        }
+    )
+    findings = [entry for entry in issues if entry["rule"] == "body-pascal-hook-event"]
+    assert len(findings) == 2
+    assert all(f["severity"] == "warning" for f in findings)
+
+
+def test_does_not_flag_camel_case_hook_event_names_in_body() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "camel-hook",
+            "relativeFile": "camel-hook/SKILL.md",
+            "source": (
+                "---\nname: camel-hook\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n---\n# Body\n"
+                "Fires on sessionStart and preToolUse events.\n"
+            ),
+        }
+    )
+    assert not any(entry["rule"] == "body-pascal-hook-event" for entry in issues)
+
+
+def test_stringifies_non_error_throws_from_parse_skill_frontmatter() -> None:
+    def _raise(_: object):
+        raise RuntimeError("stringy doom")
+
+    with patch(
+        "cheese_flow.lib.lint_skill_rules.parse_skill_frontmatter",
+        side_effect=_raise,
+    ):
+        issues = lint_skill_source(
+            {
+                "directoryName": "stringy",
+                "relativeFile": "stringy/SKILL.md",
+                "source": (
+                    "---\nname: stringy\ndescription: A perfectly fine "
+                    "description that is long enough for discovery.\n---\n"
+                    + VALID_BODY
+                ),
+            }
+        )
+    finding = next(
+        (entry for entry in issues if entry["rule"] == "frontmatter-parse"),
+        None,
+    )
+    assert finding is not None
+    assert finding["message"] == "stringy doom"
+
+
+def test_ignores_allowed_tools_when_it_is_neither_string_nor_array() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "weird-tools",
+            "relativeFile": "weird-tools/SKILL.md",
+            "source": (
+                "---\nname: weird-tools\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n"
+                "allowed-tools: 42\n---\n" + VALID_BODY
+            ),
+        }
+    )
+    assert not any(
+        entry["rule"] == "allowed-tools-claude-permission-syntax" for entry in issues
+    )
+
+
+def test_converts_a_non_zod_error_throw_from_parse_skill_frontmatter() -> None:
+    def _raise(_: object):
+        raise Exception("synthetic non-zod failure")
+
+    with patch(
+        "cheese_flow.lib.lint_skill_rules.parse_skill_frontmatter",
+        side_effect=_raise,
+    ):
+        issues = lint_skill_source(
+            {
+                "directoryName": "weird-throw",
+                "relativeFile": "weird-throw/SKILL.md",
+                "source": (
+                    "---\nname: weird-throw\ndescription: A perfectly fine "
+                    "description that is long enough for discovery.\n---\n"
+                    + VALID_BODY
+                ),
+            }
+        )
+    finding = next(
+        (entry for entry in issues if entry["rule"] == "frontmatter-parse"),
+        None,
+    )
+    assert finding is not None
+    assert "synthetic non-zod failure" in finding["message"]
+
+
+def test_flags_claude_only_frontmatter_fields_via_adapter_capabilities() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "claude-only-fields",
+            "relativeFile": "claude-only-fields/SKILL.md",
+            "source": (
+                "---\nname: claude-only-fields\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n"
+                "model: opus\ncontext: fork\n---\n" + VALID_BODY
+            ),
+        }
+    )
+    portability = [
+        entry for entry in issues if entry["rule"] == "frontmatter-portability"
+    ]
+    assert len(portability) == 2
+    assert all(entry["severity"] == "warning" for entry in portability)
+
+
+def test_does_not_flag_context_inline_because_it_is_the_portable_default() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "inline-context",
+            "relativeFile": "inline-context/SKILL.md",
+            "source": (
+                "---\nname: inline-context\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n"
+                "context: inline\n---\n" + VALID_BODY
+            ),
+        }
+    )
+    assert not any(entry["rule"] == "frontmatter-portability" for entry in issues)
+
+
+def test_context_fork_produces_exactly_one_portability_warning() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "fork-context",
+            "relativeFile": "fork-context/SKILL.md",
+            "source": (
+                "---\nname: fork-context\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n"
+                "context: fork\n---\n" + VALID_BODY
+            ),
+        }
+    )
+    portability = [
+        entry for entry in issues if entry["rule"] == "frontmatter-portability"
+    ]
+    assert len(portability) == 1
+
+
+def test_stop_in_body_emits_body_harness_only_hook_event_not_pascal() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "stop-hook",
+            "relativeFile": "stop-hook/SKILL.md",
+            "source": (
+                "---\nname: stop-hook\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n---\n# Body\n"
+                "Fires on Stop events.\n"
+            ),
+        }
+    )
+    stop_finding = next(
+        (
+            entry
+            for entry in issues
+            if entry["rule"] == "body-harness-only-hook-event"
+        ),
+        None,
+    )
+    assert stop_finding is not None
+    assert stop_finding["severity"] == "warning"
+    assert "Stop" in stop_finding["message"]
+    assert not any(entry["rule"] == "body-pascal-hook-event" for entry in issues)
+
+
+def test_stop_camel_case_in_body_does_not_emit_any_hook_warning() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "stop-camel",
+            "relativeFile": "stop-camel/SKILL.md",
+            "source": (
+                "---\nname: stop-camel\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n---\n# Body\n"
+                "Fires on stop events.\n"
+            ),
+        }
+    )
+    assert not any(
+        entry["rule"]
+        in ("body-harness-only-hook-event", "body-pascal-hook-event")
+        for entry in issues
+    )
+
+
+def test_runs_portability_checks_even_when_frontmatter_validation_fails() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "BadName",
+            "relativeFile": "BadName/SKILL.md",
+            "source": (
+                "---\nname: BadName\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n"
+                "context: fork\n---\n# Body\nUse Agent(...) for sub-agent dispatch.\n"
+            ),
+        }
+    )
+    name_finding = next(
+        (entry for entry in issues if entry["rule"] == "frontmatter:name"), None
+    )
+    assert name_finding is not None
+    assert name_finding["severity"] == "error"
+
+    portability_finding = next(
+        (entry for entry in issues if entry["rule"] == "frontmatter-portability"),
+        None,
+    )
+    assert portability_finding is not None
+    assert portability_finding["severity"] == "warning"
+
+    body_finding = next(
+        (entry for entry in issues if entry["rule"] == "body-claude-only-tool"),
+        None,
+    )
+    assert body_finding is not None
+    assert body_finding["severity"] == "warning"
+    assert "Agent" in body_finding["message"]
+
+
+def test_attaches_an_absolute_skill_md_line_number_to_body_findings() -> None:
+    issues = lint_skill_source(
+        {
+            "directoryName": "agent-line",
+            "relativeFile": "agent-line/SKILL.md",
+            "source": (
+                "---\nname: agent-line\ndescription: A perfectly fine "
+                "description that is long enough for discovery.\n---\n"
+                "first body line\nsecond line uses Agent(...)\n"
+            ),
+        }
+    )
+    finding = next(
+        (entry for entry in issues if entry["rule"] == "body-claude-only-tool"),
+        None,
+    )
+    assert finding is not None
+    # Frontmatter spans SKILL.md lines 1-4 (`---`, name, description, `---`).
+    # Body line 2 is the Agent(...) line, so absolute = 4 + 2 = 6.
+    assert finding.get("line") == 6

--- a/tests/python/test_lint_skills.py
+++ b/tests/python/test_lint_skills.py
@@ -1,0 +1,253 @@
+"""Verbatim port of `tests/lint-skills-directory.test.ts`.
+
+Mirrors the vitest cases for ``lint_skills_directory``, ``format_lint_report``,
+and ``has_errors``. The directory-as-SKILL.md trick from the TS suite (forces
+``readFile`` to fail with EISDIR) maps cleanly to the Python read_text branch
+which raises ``IsADirectoryError`` (a subclass of ``OSError``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+from pathlib import Path
+
+from cheese_flow.lib.harness_compat import HarnessCompatFinding
+from cheese_flow.lib.lint_skills import (
+    format_lint_report,
+    has_errors,
+    lint_skills_directory,
+)
+
+VALID_BODY = "# Skill body\n\nUse this skill to do a thing.\n"
+
+
+def _write_skill(skills_root: Path, directory_name: str, contents: str) -> None:
+    target = skills_root / directory_name
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "SKILL.md").write_text(contents, encoding="utf8")
+
+
+def _run(coro: Awaitable[object]):
+    return asyncio.run(coro)  # type: ignore[arg-type]
+
+
+def test_reports_skill_md_is_required_when_missing(tmp_path: Path) -> None:
+    (tmp_path / "empty-skill").mkdir()
+
+    report = _run(lint_skills_directory(str(tmp_path)))
+
+    assert report["scanned"] == 1
+    assert len(report["issues"]) == 1
+    assert report["issues"][0]["rule"] == "skill-md-required"
+    assert has_errors(report) is True
+
+
+def test_reports_skill_md_unreadable_when_skill_md_exists_but_cannot_be_read(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "unreadable-skill" / "SKILL.md").mkdir(parents=True)
+
+    report = _run(lint_skills_directory(str(tmp_path)))
+
+    assert report["scanned"] == 1
+    assert len(report["issues"]) == 1
+    assert report["issues"][0]["rule"] == "skill-md-unreadable"
+    assert "SKILL.md could not be read" in report["issues"][0]["message"]
+    assert has_errors(report) is True
+
+
+def test_returns_a_clean_report_when_all_skills_validate(tmp_path: Path) -> None:
+    _write_skill(
+        tmp_path,
+        "good-skill",
+        (
+            "---\nname: good-skill\ndescription: A perfectly fine description "
+            "that is long enough for discovery.\n---\n" + VALID_BODY
+        ),
+    )
+
+    report = _run(lint_skills_directory(str(tmp_path)))
+
+    assert report["scanned"] == 1
+    assert report["issues"] == []
+    assert has_errors(report) is False
+
+
+def test_runs_compile_test_against_harness_adapters_with_emit_surface(
+    tmp_path: Path,
+) -> None:
+    _write_skill(
+        tmp_path,
+        "good-skill",
+        (
+            "---\nname: good-skill\ndescription: A perfectly fine description "
+            "that is long enough for discovery.\n---\n" + VALID_BODY
+        ),
+    )
+
+    report = _run(lint_skills_directory(str(tmp_path)))
+
+    assert not any(entry["rule"].startswith("compile-") for entry in report["issues"])
+
+
+def test_skips_compile_test_when_source_has_errors(tmp_path: Path) -> None:
+    # Malformed YAML causes a frontmatter-parse source error. The early
+    # return in lint_skill_directory should prevent compile-test from running,
+    # so only the source error is reported (not duplicate adapter failures).
+    _write_skill(
+        tmp_path,
+        "bad-yaml",
+        (
+            "---\nname: bad-yaml\ndescription: A perfectly fine description "
+            "that is long enough for discovery.\n"
+            "allowed-tools: { unclosed: brace\n---\n" + VALID_BODY
+        ),
+    )
+
+    report = _run(lint_skills_directory(str(tmp_path)))
+
+    error_finding = next(
+        (entry for entry in report["issues"] if entry["severity"] == "error"),
+        None,
+    )
+    assert error_finding is not None
+    assert error_finding["severity"] == "error"
+    assert not any(entry["rule"].startswith("compile-") for entry in report["issues"])
+
+
+def test_returns_no_issues_when_source_is_clean_and_every_adapter_compiles(
+    tmp_path: Path,
+) -> None:
+    _write_skill(
+        tmp_path,
+        "good-skill",
+        (
+            "---\nname: good-skill\ndescription: A perfectly fine description "
+            "that is long enough for discovery.\n---\n" + VALID_BODY
+        ),
+    )
+    report = _run(lint_skills_directory(str(tmp_path)))
+    assert report["issues"] == []
+
+
+def test_format_lint_report_reports_a_clean_run_when_issues_are_empty() -> None:
+    text = format_lint_report({"scanned": 1, "issues": []})
+    assert "1 skill scanned" in text
+    assert "No issues found." in text
+
+
+def test_format_lint_report_anchors_body_findings_with_file_line() -> None:
+    text = format_lint_report(
+        {
+            "scanned": 1,
+            "issues": [
+                {
+                    "skill": "x",
+                    "file": "x/SKILL.md",
+                    "severity": "warning",
+                    "rule": "body-claude-only-tool",
+                    "message": "agent-only",
+                    "line": 42,
+                }
+            ],
+        }
+    )
+    assert "x/SKILL.md:42" in text
+
+
+def test_converts_compile_trip_findings_into_lint_issues_when_source_is_clean(
+    tmp_path: Path,
+) -> None:
+    _write_skill(
+        tmp_path,
+        "clean-skill",
+        (
+            "---\nname: clean-skill\ndescription: A perfectly fine description "
+            "that is long enough for discovery.\n---\n" + VALID_BODY
+        ),
+    )
+
+    async def fake_compile(
+        _name: str, _source: str
+    ) -> list[HarnessCompatFinding]:
+        return [
+            {
+                "rule": "compile-cursor-failed",
+                "severity": "error",
+                "message": "synthetic adapter failure",
+            },
+            {
+                "rule": "compile-codex-warned",
+                "severity": "warning",
+                "message": "synthetic adapter warning at body line 3",
+                "line": 3,
+            },
+        ]
+
+    report = _run(lint_skills_directory(str(tmp_path), {"compile": fake_compile}))
+
+    compile_issue = next(
+        (entry for entry in report["issues"] if entry["rule"] == "compile-cursor-failed"),
+        None,
+    )
+    assert compile_issue is not None
+    assert compile_issue["severity"] == "error"
+    assert "synthetic adapter failure" in compile_issue["message"]
+    assert compile_issue["skill"] == "clean-skill"
+    assert compile_issue.get("line") is None
+
+    lined_issue = next(
+        (entry for entry in report["issues"] if entry["rule"] == "compile-codex-warned"),
+        None,
+    )
+    assert lined_issue is not None
+    assert lined_issue.get("line") == 3
+
+
+def test_emits_skill_md_unreadable_when_skill_md_is_a_directory(tmp_path: Path) -> None:
+    # Sibling skill with a regular SKILL.md — should produce no issues.
+    blocked_dir = tmp_path / "blocked-skill"
+    blocked_dir.mkdir()
+    (blocked_dir / "SKILL.md").write_text("ok\n", encoding="utf8")
+    # Force read_text(EISDIR) by making SKILL.md a directory. stat() succeeds
+    # (it's a real entry), but read_text raises IsADirectoryError —
+    # exercising the non-FileNotFoundError branch in the SKILL.md loader.
+    (tmp_path / "dir-as-file" / "SKILL.md").mkdir(parents=True)
+
+    report = _run(lint_skills_directory(str(tmp_path)))
+    unreadable_finding = next(
+        (entry for entry in report["issues"] if entry["rule"] == "skill-md-unreadable"),
+        None,
+    )
+    assert unreadable_finding is not None
+    assert unreadable_finding["severity"] == "error"
+    assert unreadable_finding["skill"] == "dir-as-file"
+
+
+def test_format_lint_report_summarizes_counts() -> None:
+    text = format_lint_report(
+        {
+            "scanned": 2,
+            "issues": [
+                {
+                    "skill": "a",
+                    "file": "a/SKILL.md",
+                    "severity": "error",
+                    "rule": "frontmatter:name",
+                    "message": "bad",
+                },
+                {
+                    "skill": "b",
+                    "file": "b/SKILL.md",
+                    "severity": "warning",
+                    "rule": "body-too-long",
+                    "message": "long",
+                },
+            ],
+        }
+    )
+    assert "2 skills scanned" in text
+    assert "[ERROR]" in text
+    assert "[WARN]" in text
+    assert "1 error(s), 1 warning(s)" in text

--- a/tests/python/test_lint_skills.py
+++ b/tests/python/test_lint_skills.py
@@ -168,9 +168,7 @@ def test_converts_compile_trip_findings_into_lint_issues_when_source_is_clean(
         ),
     )
 
-    async def fake_compile(
-        _name: str, _source: str
-    ) -> list[HarnessCompatFinding]:
+    async def fake_compile(_name: str, _source: str) -> list[HarnessCompatFinding]:
         return [
             {
                 "rule": "compile-cursor-failed",


### PR DESCRIPTION
Port lint-skills.ts + lint-skill-rules.ts to python/cheese_flow/lib/, plus
the matching vitest cases (lint-skills-directory and lint-skill-source).

Co-authored-by: Ralphify <noreply@ralphify.co>