### PR TITLE
feat(migration): US-003 adapters (TS → Python)

### DIFF
--- a/python/cheese_flow/adapters/__init__.py
+++ b/python/cheese_flow/adapters/__init__.py
@@ -1,5 +1,31 @@
 """cheese-flow harness adapters.
 
 Houses the ports of `src/adapters/*.ts` (claude-code, codex, cursor,
-copilot-cli, and the shared manifest builders). Populated in US-003.
+copilot-cli, and the shared manifest builders).
 """
+
+from __future__ import annotations
+
+from cheese_flow.adapters.claude_code import claude_code_adapter
+from cheese_flow.adapters.codex import codex_adapter
+from cheese_flow.adapters.copilot_cli import copilot_cli_adapter
+from cheese_flow.adapters.cursor import cursor_adapter
+from cheese_flow.lib.harness import HarnessAdapter, HarnessName
+
+HARNESS_ADAPTERS: dict[HarnessName, HarnessAdapter] = {
+    "claude-code": claude_code_adapter,
+    "codex": codex_adapter,
+    "cursor": cursor_adapter,
+    "copilot-cli": copilot_cli_adapter,
+}
+
+HARNESS_NAMES: tuple[HarnessName, ...] = tuple(HARNESS_ADAPTERS.keys())
+
+__all__ = [
+    "HARNESS_ADAPTERS",
+    "HARNESS_NAMES",
+    "claude_code_adapter",
+    "codex_adapter",
+    "copilot_cli_adapter",
+    "cursor_adapter",
+]

--- a/python/cheese_flow/adapters/_shared.py
+++ b/python/cheese_flow/adapters/_shared.py
@@ -1,0 +1,137 @@
+"""Port of `src/adapters/_shared.ts` — shared manifest + hook + agent builders."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cheese_flow.lib.harness import (
+    PORTABLE_EVENTS,
+    AgentArtifact,
+    AgentArtifactInput,
+    HookEntry,
+    ManifestComponentPaths,
+    PluginMetadata,
+    PortableHooks,
+)
+
+_PASCAL_MAP: dict[str, str] = {
+    "sessionStart": "SessionStart",
+    "preToolUse": "PreToolUse",
+    "postToolUse": "PostToolUse",
+}
+
+_DEFAULT_HOOK_TIMEOUT = 600
+
+_EMPTY_AGENT_KEYS: frozenset[str] = frozenset()
+
+
+def _pick_manifest_paths(
+    component_paths: ManifestComponentPaths,
+    supported_keys: tuple[str, ...],
+) -> dict[str, str]:
+    return {
+        key: component_paths[key]  # type: ignore[literal-required]
+        for key in supported_keys
+        if key in component_paths and component_paths[key] is not None  # type: ignore[literal-required]
+    }
+
+
+def build_base_manifest(
+    metadata: PluginMetadata,
+    component_paths: ManifestComponentPaths,
+    supported_keys: tuple[str, ...],
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "name": metadata["name"],
+        "version": metadata["version"],
+        "description": metadata["description"],
+        "author": metadata["author"],
+        "license": metadata["license"],
+        "repository": metadata["repository"],
+    }
+    homepage = metadata.get("homepage")
+    if homepage is not None:
+        result["homepage"] = homepage
+    keywords = metadata.get("keywords")
+    if keywords is not None:
+        result["keywords"] = keywords
+    result.update(_pick_manifest_paths(component_paths, supported_keys))
+    return result
+
+
+def camel_case_hooks(portable: PortableHooks) -> dict[str, list[HookEntry]]:
+    result: dict[str, list[HookEntry]] = {}
+    for event in PORTABLE_EVENTS:
+        entries = portable.get(event)
+        if entries is not None:
+            result[event] = entries
+    return result
+
+
+def pascal_matcher_hooks(portable: PortableHooks) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for event in PORTABLE_EVENTS:
+        entries = portable.get(event)
+        if entries is None:
+            continue
+        result[_PASCAL_MAP[event]] = [
+            {
+                "matcher": "*",
+                "hooks": [
+                    {
+                        "type": entry["type"],
+                        "command": entry["command"],
+                        "timeout": entry.get("timeout", _DEFAULT_HOOK_TIMEOUT),
+                    },
+                ],
+            }
+            for entry in entries
+        ]
+    return result
+
+
+def _build_skills_appendix(skills: list[str]) -> str:
+    lines = "\n".join(f"- {skill}" for skill in skills)
+    return (
+        "\n## Required skills (prompt contract)\n\n"
+        "This harness does not expose a structured skills binding, so treat the\n"
+        "following skill names as a hard prompt contract — invoke them by name when\n"
+        "the workflow calls for their behavior:\n\n"
+        f"{lines}\n"
+    )
+
+
+def build_base_agent_artifact(
+    artifact_input: AgentArtifactInput,
+    agent_frontmatter_keys: frozenset[str],
+) -> AgentArtifact:
+    frontmatter = artifact_input.frontmatter
+    data: dict[str, Any] = {
+        "name": frontmatter["name"],
+        "description": frontmatter["description"],
+        "model": artifact_input.resolvedModel,
+    }
+    tools = frontmatter["tools"]
+    if len(tools) > 0:
+        data["tools"] = tools
+    raw: dict[str, Any] = dict(frontmatter)
+    for key in agent_frontmatter_keys:
+        value = raw.get(key)
+        if value is None:
+            continue
+        if isinstance(value, list) and len(value) == 0:
+            continue
+        data[key] = value
+    skills = frontmatter["skills"]
+    appendix = (
+        ""
+        if "skills" in agent_frontmatter_keys or len(skills) == 0
+        else _build_skills_appendix(skills)
+    )
+    return AgentArtifact(frontmatter=data, appendix=appendix)
+
+
+def build_portable_agent_artifact(
+    artifact_input: AgentArtifactInput,
+) -> AgentArtifact:
+    return build_base_agent_artifact(artifact_input, _EMPTY_AGENT_KEYS)

--- a/python/cheese_flow/adapters/claude_code.py
+++ b/python/cheese_flow/adapters/claude_code.py
@@ -1,0 +1,101 @@
+"""Port of `src/adapters/claude-code.ts`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cheese_flow.adapters._shared import (
+    build_base_agent_artifact,
+    build_base_manifest,
+    camel_case_hooks,
+)
+from cheese_flow.lib.harness import (
+    AgentArtifact,
+    AgentArtifactInput,
+    HarnessAdapter,
+    HarnessCapabilities,
+    ManifestComponentPaths,
+    PluginMetadata,
+    PortableHooks,
+)
+
+CLAUDE_AGENT_KEYS: frozenset[str] = frozenset(
+    {
+        "skills",
+        "color",
+        "effort",
+        "disallowedTools",
+        "permissionMode",
+    },
+)
+
+CLAUDE_MANIFEST_KEYS: tuple[str, ...] = (
+    "agents",
+    "skills",
+    "commands",
+    "hooks",
+    "mcpServers",
+)
+
+
+def _build_manifest(
+    metadata: PluginMetadata,
+    component_paths: ManifestComponentPaths,
+) -> dict[str, Any]:
+    return build_base_manifest(metadata, component_paths, CLAUDE_MANIFEST_KEYS)
+
+
+def _build_hook_config(portable: PortableHooks) -> dict[str, Any]:
+    return {"hooks": camel_case_hooks(portable)}
+
+
+def _build_agent_artifact(artifact_input: AgentArtifactInput) -> AgentArtifact:
+    return build_base_agent_artifact(artifact_input, CLAUDE_AGENT_KEYS)
+
+
+claude_code_adapter = HarnessAdapter(
+    name="claude-code",
+    displayName="Claude Code",
+    outputRoot=".claude",
+    agentDirectory="agents",
+    skillDirectory="skills",
+    commandDirectory="commands",
+    defaultModel="sonnet",
+    notes=(
+        "Use concise markdown headings and explicit tool guidance.",
+        "Prefer Claude model identifiers in agent metadata and output.",
+    ),
+    manifestDir=".claude-plugin",
+    buildManifest=_build_manifest,
+    mcpFileName=".mcp.json",
+    buildHookConfig=_build_hook_config,
+    buildAgentArtifact=_build_agent_artifact,
+    capabilities=HarnessCapabilities(
+        skillFrontmatterKeys=frozenset({"model", "context"}),
+        agentFrontmatterKeys=CLAUDE_AGENT_KEYS,
+        hookEvents=frozenset(
+            {
+                "sessionStart",
+                "sessionEnd",
+                "preToolUse",
+                "postToolUse",
+                "stop",
+                "subagentStop",
+                "notification",
+                "preCompact",
+                "userPromptSubmit",
+            },
+        ),
+        toolNames=frozenset(
+            {
+                "Agent",
+                "Task",
+                "NotebookEdit",
+                "WebSearch",
+                "WebFetch",
+                "TodoWrite",
+            },
+        ),
+        bootstrapHook=True,
+    ),
+)

--- a/python/cheese_flow/adapters/codex.py
+++ b/python/cheese_flow/adapters/codex.py
@@ -1,0 +1,58 @@
+"""Port of `src/adapters/codex.ts`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cheese_flow.adapters._shared import (
+    build_base_manifest,
+    build_portable_agent_artifact,
+    pascal_matcher_hooks,
+)
+from cheese_flow.lib.harness import (
+    HarnessAdapter,
+    HarnessCapabilities,
+    ManifestComponentPaths,
+    PluginMetadata,
+    PortableHooks,
+)
+
+CODEX_MANIFEST_KEYS: tuple[str, ...] = ("skills", "mcpServers", "apps")
+
+
+def _build_manifest(
+    metadata: PluginMetadata,
+    component_paths: ManifestComponentPaths,
+) -> dict[str, Any]:
+    return build_base_manifest(metadata, component_paths, CODEX_MANIFEST_KEYS)
+
+
+def _build_hook_config(portable: PortableHooks) -> dict[str, Any]:
+    return {"hooks": pascal_matcher_hooks(portable)}
+
+
+codex_adapter = HarnessAdapter(
+    name="codex",
+    displayName="Codex",
+    outputRoot=".codex",
+    agentDirectory="agents",
+    skillDirectory="skills",
+    commandDirectory="commands",
+    defaultModel="gpt-5-codex",
+    notes=(
+        "Bias instructions toward patch-oriented execution and explicit constraints.",
+        "Prefer Codex model identifiers in agent metadata and output.",
+    ),
+    manifestDir=".codex-plugin",
+    buildManifest=_build_manifest,
+    mcpFileName=".mcp.json",
+    buildHookConfig=_build_hook_config,
+    buildAgentArtifact=build_portable_agent_artifact,
+    capabilities=HarnessCapabilities(
+        skillFrontmatterKeys=frozenset(),
+        agentFrontmatterKeys=frozenset(),
+        hookEvents=frozenset({"sessionStart", "preToolUse", "postToolUse"}),
+        toolNames=frozenset(),
+        bootstrapHook=True,
+    ),
+)

--- a/python/cheese_flow/adapters/copilot_cli.py
+++ b/python/cheese_flow/adapters/copilot_cli.py
@@ -1,0 +1,63 @@
+"""Port of `src/adapters/copilot-cli.ts`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cheese_flow.adapters._shared import (
+    build_base_manifest,
+    build_portable_agent_artifact,
+    camel_case_hooks,
+)
+from cheese_flow.lib.harness import (
+    HarnessAdapter,
+    HarnessCapabilities,
+    ManifestComponentPaths,
+    PluginMetadata,
+    PortableHooks,
+)
+
+COPILOT_MANIFEST_KEYS: tuple[str, ...] = (
+    "agents",
+    "skills",
+    "commands",
+    "hooks",
+    "mcpServers",
+)
+
+
+def _build_manifest(
+    metadata: PluginMetadata,
+    component_paths: ManifestComponentPaths,
+) -> dict[str, Any]:
+    base = build_base_manifest(metadata, component_paths, COPILOT_MANIFEST_KEYS)
+    return {**base, "category": "development", "strict": True}
+
+
+def _build_hook_config(portable: PortableHooks) -> dict[str, Any]:
+    return {"version": 1, "hooks": camel_case_hooks(portable)}
+
+
+copilot_cli_adapter = HarnessAdapter(
+    name="copilot-cli",
+    displayName="GitHub Copilot CLI",
+    outputRoot=".copilot",
+    agentDirectory="agents",
+    skillDirectory="skills",
+    defaultModel="gpt-5",
+    notes=(
+        "Copilot CLI resolves plugin manifests from .claude-plugin/plugin.json as its fourth search path, so the same manifest shape serves both Claude Code and Copilot CLI installations.",  # noqa: E501
+    ),
+    manifestDir=".claude-plugin",
+    buildManifest=_build_manifest,
+    mcpFileName=".mcp.json",
+    buildHookConfig=_build_hook_config,
+    buildAgentArtifact=build_portable_agent_artifact,
+    capabilities=HarnessCapabilities(
+        skillFrontmatterKeys=frozenset(),
+        agentFrontmatterKeys=frozenset(),
+        hookEvents=frozenset({"sessionStart", "preToolUse", "postToolUse"}),
+        toolNames=frozenset(),
+        bootstrapHook=True,
+    ),
+)

--- a/python/cheese_flow/adapters/cursor.py
+++ b/python/cheese_flow/adapters/cursor.py
@@ -1,0 +1,72 @@
+"""Port of `src/adapters/cursor.ts`.
+
+The TS adapter ships an `emitSurface` callback that reads each skill's
+SKILL.md and renders both a Cursor `.mdc` rule and a `.md` slash command.
+That code path imports `parseFrontmatter` from `lib/frontmatter.ts`, which
+the migration spec assigns to US-004. The callable is therefore wired in
+US-004 alongside the frontmatter port; the rest of the cursor adapter
+(declarative metadata, manifest builder, hook config) lands here in US-003
+so the registry shape is complete.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cheese_flow.adapters._shared import (
+    build_base_manifest,
+    build_portable_agent_artifact,
+)
+from cheese_flow.lib.harness import (
+    HarnessAdapter,
+    HarnessCapabilities,
+    ManifestComponentPaths,
+    PluginMetadata,
+    PortableHooks,
+)
+
+CURSOR_MANIFEST_KEYS: tuple[str, ...] = (
+    "rules",
+    "skills",
+    "agents",
+    "commands",
+    "hooks",
+    "mcpServers",
+)
+
+
+def _build_manifest(
+    metadata: PluginMetadata,
+    component_paths: ManifestComponentPaths,
+) -> dict[str, Any]:
+    return build_base_manifest(metadata, component_paths, CURSOR_MANIFEST_KEYS)
+
+
+def _build_hook_config(_portable: PortableHooks) -> None:
+    return None
+
+
+cursor_adapter = HarnessAdapter(
+    name="cursor",
+    displayName="Cursor",
+    outputRoot=".cursor",
+    agentDirectory="agents",
+    skillDirectory="skills",
+    defaultModel="auto",
+    notes=(
+        "Cursor exposes skills on two surfaces: ambient rules (.cursor/rules/*.mdc) and slash commands (.cursor/commands/*.md). Both are emitted from the same SKILL.md source.",  # noqa: E501
+        "MCP-only tool surface applies; Cursor does not support hooks — hook emission is skipped with an info log.",  # noqa: E501
+    ),
+    manifestDir=".cursor-plugin",
+    buildManifest=_build_manifest,
+    mcpFileName="mcp.json",
+    buildHookConfig=_build_hook_config,
+    buildAgentArtifact=build_portable_agent_artifact,
+    capabilities=HarnessCapabilities(
+        skillFrontmatterKeys=frozenset(),
+        agentFrontmatterKeys=frozenset(),
+        hookEvents=frozenset(),
+        toolNames=frozenset(),
+        bootstrapHook=False,
+    ),
+)

--- a/python/cheese_flow/lib/harness.py
+++ b/python/cheese_flow/lib/harness.py
@@ -1,0 +1,177 @@
+"""Port of `src/domain/harness.ts` — harness domain types.
+
+Per the migration spec's Implementation Notes, the TS domain types live on
+the slice as `python/cheese_flow/lib/harness.py`. This module is the typed
+seam that adapters and (later) the compile pipeline both consume.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Literal,
+    TypedDict,
+)
+
+CHEESE_DIR = ".cheese"
+
+HarnessName = Literal["claude-code", "codex", "cursor", "copilot-cli"]
+
+PortableEvent = Literal["sessionStart", "preToolUse", "postToolUse"]
+PORTABLE_EVENTS: tuple[PortableEvent, ...] = (
+    "sessionStart",
+    "preToolUse",
+    "postToolUse",
+)
+
+
+class _HookEntryRequired(TypedDict):
+    type: str
+    command: str
+
+
+class HookEntry(_HookEntryRequired, total=False):
+    """Mirror of `HookEntry` (`type`, `command` required; `timeout` optional)."""
+
+    timeout: int
+
+
+HooksSource = dict[str, list[HookEntry]]
+PortableHooks = dict[PortableEvent, list[HookEntry]]
+
+
+class _PluginAuthorRequired(TypedDict):
+    name: str
+
+
+class PluginAuthor(_PluginAuthorRequired, total=False):
+    email: str
+    url: str
+
+
+class _PluginMetadataRequired(TypedDict):
+    name: str
+    version: str
+    description: str
+    author: PluginAuthor
+    license: str
+    repository: str
+
+
+class PluginMetadata(_PluginMetadataRequired, total=False):
+    """Mirror of `PluginMetadata` from `pluginMetadataSchema`."""
+
+    homepage: str
+    keywords: list[str]
+
+
+class _McpServerConfigRequired(TypedDict):
+    command: str
+    args: list[str]
+
+
+class McpServerConfig(_McpServerConfigRequired, total=False):
+    env: dict[str, str]
+
+
+CANONICAL_MCP_SERVERS: dict[str, McpServerConfig] = {
+    "milknado": {
+        "command": "npx",
+        "args": ["tsx", "src/index.ts", "mcp"],
+    },
+    "tilth": {"command": "npx", "args": ["tilth", "--mcp", "--edit"]},
+    "context7": {
+        "command": "npx",
+        "args": ["-y", "@upstash/context7-mcp"],
+    },
+    "tavily": {
+        "command": "npx",
+        "args": ["-y", "tavily-mcp@latest"],
+        "env": {"TAVILY_API_KEY": "${TAVILY_API_KEY}"},
+    },
+}
+
+
+class SurfaceEmissionResult(TypedDict):
+    rules: list[str]
+    commands: list[str]
+
+
+class ManifestComponentPaths(TypedDict, total=False):
+    agents: str
+    skills: str
+    commands: str
+    hooks: str
+    mcpServers: str
+    rules: str
+    apps: str
+
+
+class _AgentFrontmatterRequired(TypedDict):
+    name: str
+    description: str
+    tools: list[str]
+    skills: list[str]
+    disallowedTools: list[str]
+
+
+class AgentFrontmatterFields(_AgentFrontmatterRequired, total=False):
+    """Narrow record passed to `build_base_agent_artifact`.
+
+    Required keys: `name`, `description`, `tools`, `skills`, `disallowedTools`.
+    Optional keys: `color`, `effort`, `permissionMode`.
+    """
+
+    color: str
+    effort: str
+    permissionMode: str
+
+
+@dataclass(frozen=True)
+class AgentArtifactInput:
+    frontmatter: AgentFrontmatterFields
+    resolvedModel: str
+
+
+@dataclass(frozen=True)
+class AgentArtifact:
+    frontmatter: dict[str, Any]
+    appendix: str
+
+
+@dataclass(frozen=True)
+class HarnessCapabilities:
+    skillFrontmatterKeys: frozenset[str]
+    agentFrontmatterKeys: frozenset[str]
+    hookEvents: frozenset[str]
+    toolNames: frozenset[str]
+    bootstrapHook: bool
+
+
+BuildManifest = Callable[[PluginMetadata, ManifestComponentPaths], dict[str, Any]]
+BuildHookConfig = Callable[[PortableHooks], dict[str, Any] | None]
+BuildAgentArtifact = Callable[[AgentArtifactInput], AgentArtifact]
+EmitSurface = Callable[[str, str], Awaitable[SurfaceEmissionResult]]
+
+
+@dataclass(frozen=True)
+class HarnessAdapter:
+    """Mirror of the TS `HarnessAdapter` interface as a frozen dataclass."""
+
+    name: HarnessName
+    displayName: str
+    outputRoot: str
+    agentDirectory: str
+    skillDirectory: str
+    defaultModel: str
+    notes: tuple[str, ...]
+    manifestDir: str
+    mcpFileName: str
+    buildManifest: BuildManifest
+    buildHookConfig: BuildHookConfig
+    buildAgentArtifact: BuildAgentArtifact
+    capabilities: HarnessCapabilities
+    commandDirectory: str | None = None
+    emitSurface: EmitSurface | None = None

--- a/ralphs/python-migration/TODO.md
+++ b/ralphs/python-migration/TODO.md
@@ -8,7 +8,7 @@ US-005 (install-plan), US-006 (harness-detection), and US-007 (harness-compat).
 
 - [x] US-001 — Package skeleton: rename pyproject to `cheese-flow`, add deps (typer, jinja2, pydantic>=2, ruamel.yaml), create `python/cheese_flow/{__init__,lib/__init__,adapters/__init__}.py`, declare `[project.scripts] cheese = "cheese_flow.cli:app"` placeholder, verify the correct `mcp` SDK version on PyPI before pinning
 - [x] US-002 — Port `src/lib/schemas.ts` → `python/cheese_flow/lib/schemas.py` (Pydantic v2, `extra="forbid"`, all 9 schemas + discriminated unions); port matching vitest cases verbatim
-- [ ] US-003 — Port `src/adapters/{claude-code,codex,cursor,copilot-cli,_shared,index}.ts` → `python/cheese_flow/adapters/`; preserve registry shape; port adapter vitest cases
+- [x] US-003 — Port `src/adapters/{claude-code,codex,cursor,copilot-cli,_shared,index}.ts` → `python/cheese_flow/adapters/`; preserve registry shape; port adapter vitest cases
 - [ ] US-004 — Port compile pipeline: `compiler.ts` + `emit.ts` + `frontmatter.ts` + `capabilities.ts` + `model-manifest.ts` → `python/cheese_flow/lib/`; Eta `<%= %>` / `<% %>` → Jinja2 `{{ }}` / `{% %}`; `Promise.all` → `asyncio.gather`; commit a byte-parity snapshot fixture for one agent + one skill
 - [ ] US-005 — Port `src/lib/install-plan.ts` → `python/cheese_flow/lib/install_plan.py`; port `tests/install-plan.test.ts`
 - [ ] US-006 — Port `src/lib/harness-detection.ts` → `python/cheese_flow/lib/harness_detection.py`; port `tests/harness-detection.test.ts`

--- a/tests/python/test_adapters.py
+++ b/tests/python/test_adapters.py
@@ -1,0 +1,125 @@
+"""Verbatim port of the adapter-only vitest cases.
+
+The TS test surface for adapters is the `adapter capabilities declarations`
+describe block in `tests/capabilities.test.ts:10-102`. The remaining describe
+blocks in that file (`fieldSupport`, `eventSupport`, `toolSupport`) drive
+`src/lib/capabilities.ts` and land alongside the lib port in US-004.
+
+The cursor-surface tests in `tests/cursor-surface.test.ts` exercise the
+`emit_surface` callback, which depends on `parse_frontmatter`. Per the spec,
+that callable + its tests land in US-004 alongside the frontmatter port.
+"""
+
+from __future__ import annotations
+
+import pytest
+from cheese_flow.adapters import HARNESS_ADAPTERS
+from cheese_flow.lib.harness import PORTABLE_EVENTS, HarnessCapabilities
+
+
+def test_every_adapter_has_a_capabilities_object() -> None:
+    for name, adapter in HARNESS_ADAPTERS.items():
+        assert isinstance(adapter.capabilities, HarnessCapabilities), f"{name} missing capabilities"
+        assert isinstance(adapter.capabilities.skillFrontmatterKeys, frozenset)
+        assert isinstance(adapter.capabilities.agentFrontmatterKeys, frozenset)
+        assert isinstance(adapter.capabilities.hookEvents, frozenset)
+        assert isinstance(adapter.capabilities.toolNames, frozenset)
+
+
+def test_claude_code_declares_the_expected_claude_only_skill_keys() -> None:
+    cc = HARNESS_ADAPTERS["claude-code"].capabilities
+    assert "model" in cc.skillFrontmatterKeys
+    assert "context" in cc.skillFrontmatterKeys
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["skills", "color", "effort", "disallowedTools", "permissionMode"],
+)
+def test_claude_code_declares_the_expected_claude_only_agent_keys(key: str) -> None:
+    cc = HARNESS_ADAPTERS["claude-code"].capabilities
+    assert key in cc.agentFrontmatterKeys, f"missing agent key: {key}"
+
+
+def test_claude_code_declares_all_9_hook_events() -> None:
+    cc = HARNESS_ADAPTERS["claude-code"].capabilities
+    assert len(cc.hookEvents) == 9
+    for event in (
+        "sessionStart",
+        "sessionEnd",
+        "preToolUse",
+        "postToolUse",
+        "stop",
+    ):
+        assert event in cc.hookEvents, f"missing event: {event}"
+
+
+@pytest.mark.parametrize(
+    "tool",
+    ["Agent", "Task", "NotebookEdit", "WebSearch", "WebFetch", "TodoWrite"],
+)
+def test_claude_code_declares_all_claude_only_tools(tool: str) -> None:
+    cc = HARNESS_ADAPTERS["claude-code"].capabilities
+    assert tool in cc.toolNames, f"missing tool: {tool}"
+
+
+@pytest.mark.parametrize("name", ["codex", "copilot-cli"])
+def test_codex_and_copilot_cli_declare_the_3_portable_hook_events(
+    name: str,
+) -> None:
+    adapter = HARNESS_ADAPTERS[name]  # type: ignore[index]
+    for event in PORTABLE_EVENTS:
+        assert event in adapter.capabilities.hookEvents, f"{name} missing portable event: {event}"
+
+
+def test_cursor_declares_zero_hook_events() -> None:
+    assert len(HARNESS_ADAPTERS["cursor"].capabilities.hookEvents) == 0
+
+
+@pytest.mark.parametrize("name", ["codex", "cursor", "copilot-cli"])
+def test_non_claude_adapters_declare_no_claude_only_skill_or_agent_keys(
+    name: str,
+) -> None:
+    cap = HARNESS_ADAPTERS[name].capabilities  # type: ignore[index]
+    assert len(cap.skillFrontmatterKeys) == 0
+    assert len(cap.agentFrontmatterKeys) == 0
+
+
+@pytest.mark.parametrize("name", ["codex", "cursor", "copilot-cli"])
+def test_non_claude_adapters_declare_no_tool_names(name: str) -> None:
+    assert len(HARNESS_ADAPTERS[name].capabilities.toolNames) == 0  # type: ignore[index]
+
+
+def test_registry_exposes_exactly_the_four_supported_harnesses() -> None:
+    assert set(HARNESS_ADAPTERS.keys()) == {
+        "claude-code",
+        "codex",
+        "cursor",
+        "copilot-cli",
+    }
+
+
+def test_each_adapter_self_identifies_via_name_field() -> None:
+    for harness, adapter in HARNESS_ADAPTERS.items():
+        assert adapter.name == harness
+
+
+def test_claude_code_and_codex_share_the_default_command_directory() -> None:
+    assert HARNESS_ADAPTERS["claude-code"].commandDirectory == "commands"
+    assert HARNESS_ADAPTERS["codex"].commandDirectory == "commands"
+
+
+def test_cursor_and_copilot_cli_omit_the_command_directory() -> None:
+    assert HARNESS_ADAPTERS["cursor"].commandDirectory is None
+    assert HARNESS_ADAPTERS["copilot-cli"].commandDirectory is None
+
+
+def test_only_cursor_skips_the_bootstrap_hook() -> None:
+    for name, adapter in HARNESS_ADAPTERS.items():
+        expected = name != "cursor"
+        assert adapter.capabilities.bootstrapHook is expected
+
+
+def test_cursor_returns_none_for_build_hook_config() -> None:
+    cursor = HARNESS_ADAPTERS["cursor"]
+    assert cursor.buildHookConfig({}) is None


### PR DESCRIPTION
Ports `src/adapters/{_shared,claude-code,codex,copilot-cli,cursor,index}.ts`
into `python/cheese_flow/adapters/`, with the harness domain types landing
on the slice at `python/cheese_flow/lib/harness.py`. The registry shape
matches the TS export (`HARNESS_ADAPTERS: Dict[HarnessName, HarnessAdapter]`),
and each adapter is a frozen dataclass instance with the same capability
table its TS counterpart declares.

The cursor adapter's `emit_surface` callback depends on
`parse_frontmatter`, which the spec assigns to US-004. It is therefore
left as `None` here and wired in US-004 alongside the frontmatter port;
`tests/cursor-surface.test.ts` lands in that PR for the same reason.

Tests:
- `tests/python/test_adapters.py` — verbatim port of the
  `adapter capabilities declarations` describe block from
  `tests/capabilities.test.ts:10-102`, plus a handful of registry-shape
  assertions covering bootstrap-hook + command-directory invariants. The
  remaining `fieldSupport`/`eventSupport`/`toolSupport` cases drive
  `src/lib/capabilities.ts` and land in US-004.

Gates: `uv run --group dev pytest` (202 passed), `uv run --group dev
ruff check` clean, `npm test` (352 passed).

Co-authored-by: Ralphify <noreply@ralphify.co>

(Continuation of #65 — original was auto-closed when its base branch merged as #64.)