### PR TITLE
feat(cli): declare install state with options instead of a manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ just build
 just build-ci
 ```
 
+No checkout needed — `uvx` runs the CLI straight from the repository:
+
+```bash
+# Interactive wizard
+uvx --from git+https://github.com/paulnsorensen/cheese-flow cheese install
+
+# Headless, no manifest file: declare the state on the command line
+uvx --from git+https://github.com/paulnsorensen/cheese-flow cheese install \
+  --harness "claude-code codex" --component hallouminate,easy-cheese --repo . --json
+```
+
+Append `@main` or `@<sha>` to the URL to pin a revision. `--from` is required either way: the package is `cheese-flow`, the command is `cheese`.
+
 Once published to PyPI, install globally with:
 
 ```bash
@@ -63,11 +76,17 @@ Installs the selected components for the selected harnesses and repositories.
 | Option | Effect |
 |---|---|
 | `--config PATH` | Apply this manifest headlessly instead of running the wizard |
+| `--harness NAMES` | Harnesses to manage, comma- or space-separated. Repeatable. Runs headlessly |
+| `--component NAMES` | Components to install, comma- or space-separated. Defaults to all of them |
+| `--repo PATHS` | Repositories to index, comma- or space-separated. Relative paths are resolved |
+| `--write-config` | Persist the resolved manifest. Options are ephemeral without it |
 | `--dry-run` | Emit the plan without changing managed state |
 | `--json` | Write one JSON document to stdout (also runs headlessly) |
 | `--timeout FLOAT` | Seconds a single command may run before it is killed |
 
-With no `--config`/`--json`, `install` runs the interactive wizard and, on acceptance, persists the manifest to the default config path before applying it.
+With no `--config`/`--json` and no state options, `install` runs the interactive wizard and, on acceptance, persists the manifest to the default config path before applying it.
+
+`--harness`/`--component`/`--repo` declare the desired state without a manifest file, which is the CI and cloud path — nothing is persisted unless you pass `--write-config`. Each selected repository's parent becomes its search root. Two combinations are rejected: `--config` with any state option (two sources of state), and `--write-config` with `--dry-run` (a dry run persists nothing).
 
 ### `cheese doctor`
 

--- a/python/cheese_flow/cli.py
+++ b/python/cheese_flow/cli.py
@@ -1,7 +1,8 @@
 """Typer CLI entry point for cheese-flow.
 
-``cheese install`` runs the wizard, or applies a manifest headlessly with
-``--config``. ``cheese doctor`` verifies declared managed state.
+``cheese install`` runs the wizard, or installs headlessly from a manifest
+(``--config``) or from options (``--harness``/``--component``/``--repo``).
+``cheese doctor`` verifies declared managed state.
 
 Output discipline: in headless mode stdout carries exactly one JSON document and
 nothing else. Every prompt, progress line, and diagnostic goes to stderr.
@@ -21,13 +22,16 @@ from rich.console import Console
 from cheese_flow.adapters import default_component_adapters
 from cheese_flow.desired_state import (
     ManifestError,
+    OptionError,
     default_config_path,
     load_desired_state,
     save_desired_state,
+    state_from_options,
 )
 from cheese_flow.doctor import verify_desired_state
 from cheese_flow.install import apply_install_plan, build_install_plan
 from cheese_flow.models import (
+    COMPONENT_NAMES,
     ApplyReport,
     CommandRunner,
     DesiredState,
@@ -58,6 +62,34 @@ def install(
             help="Apply this manifest headlessly instead of running the wizard.",
         ),
     ] = None,
+    harness: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--harness",
+            help="Harnesses to manage, comma- or space-separated. Repeatable. Runs headlessly.",
+        ),
+    ] = None,
+    component: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--component",
+            help="Components to install, comma- or space-separated. Defaults to all of them.",
+        ),
+    ] = None,
+    repo: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--repo",
+            help="Repositories to index, comma- or space-separated. Relative paths are resolved.",
+        ),
+    ] = None,
+    write_config: Annotated[
+        bool,
+        typer.Option(
+            "--write-config",
+            help="Persist the resolved manifest. Options are ephemeral without it.",
+        ),
+    ] = False,
     dry_run: Annotated[
         bool,
         typer.Option("--dry-run", help="Emit the plan without changing managed state."),
@@ -76,12 +108,17 @@ def install(
 ) -> None:
     """Install the selected components for the selected harnesses and repositories."""
     console = _console()
-    headless = config is not None or json_output
-    state = (
-        _headless_state(console, config)
-        if headless
-        else _interactive_state(console, dry_run=dry_run)
+    declared = (_tokens(harness), _tokens(component), _tokens(repo))
+    _reject_conflicting_options(
+        console, config=config, declared=declared, write_config=write_config, dry_run=dry_run
     )
+    headless = config is not None or json_output or any(declared)
+    if any(declared):
+        state = _option_state(console, *declared)
+    elif headless:
+        state = _headless_state(console, config)
+    else:
+        state = _interactive_state(console, dry_run=dry_run)
 
     if dry_run:
         # spec:105 — resolve metadata against a throwaway npm cache, removed on exit.
@@ -97,7 +134,7 @@ def install(
         # planning resolved (acceptance:150).
         adapters = default_component_adapters(runner)
         plan = build_install_plan(state, adapters)
-        if not headless:
+        if write_config or not headless:
             save_desired_state(state, default_config_path())
             console.print(f"Wrote {default_config_path()}")
         _announce(console, plan)
@@ -141,6 +178,51 @@ def _default_runner(
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> CommandRunner:
     return SubprocessRunner(env=env, timeout=timeout)
+
+
+def _tokens(values: list[str] | None) -> tuple[str, ...]:
+    """Split option values on commas or whitespace, so both separators read alike."""
+    return tuple(token for value in values or () for token in value.replace(",", " ").split())
+
+
+def _reject_conflicting_options(
+    console: Console,
+    *,
+    config: Path | None,
+    declared: tuple[tuple[str, ...], ...],
+    write_config: bool,
+    dry_run: bool,
+) -> None:
+    """Refuse option sets that name two sources of state, or a write that cannot happen."""
+    if config is not None and any(declared):
+        console.print(
+            "Invalid options: --config and --harness/--component/--repo "
+            "name two sources of desired state."
+        )
+        raise typer.Exit(_MANIFEST_EXIT_CODE)
+    if write_config and dry_run:
+        console.print(
+            "Invalid options: --dry-run persists nothing, so --write-config cannot apply."
+        )
+        raise typer.Exit(_MANIFEST_EXIT_CODE)
+
+
+def _option_state(
+    console: Console,
+    harnesses: tuple[str, ...],
+    components: tuple[str, ...],
+    repositories: tuple[str, ...],
+) -> DesiredState:
+    """Build the desired state from options, failing before planning or mutation."""
+    try:
+        return state_from_options(
+            harnesses,
+            components or COMPONENT_NAMES,
+            tuple(Path(path) for path in repositories),
+        )
+    except OptionError as error:
+        console.print(f"Invalid options: {error}")
+        raise typer.Exit(_MANIFEST_EXIT_CODE) from error
 
 
 def _headless_state(console: Console, config: Path | None) -> DesiredState:

--- a/python/cheese_flow/desired_state.py
+++ b/python/cheese_flow/desired_state.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 import os
 import tempfile
 import tomllib
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
 from pydantic import ValidationError
 
-from cheese_flow.models import COMPONENT_NAMES, HARNESS_NAMES, DesiredState
+from cheese_flow.models import (
+    COMPONENT_NAMES,
+    HARNESS_NAMES,
+    DesiredState,
+    RepositorySelection,
+    canonicalize,
+)
 
 
 class ManifestError(Exception):
@@ -20,6 +27,10 @@ class ManifestError(Exception):
         super().__init__(f"{path}: {reason}")
         self.path = path
         self.reason = reason
+
+
+class OptionError(Exception):
+    """Command-line options do not describe a valid desired state."""
 
 
 def default_config_path() -> Path:
@@ -37,6 +48,29 @@ def load_desired_state(path: Path) -> DesiredState:
     document = _read_document(path)
     _reject_non_integer_max_depth(path, document)
     return _build_state(path, document)
+
+
+def state_from_options(
+    harnesses: Sequence[str],
+    components: Sequence[str],
+    repositories: Sequence[Path],
+) -> DesiredState:
+    """Build a validated desired state from command-line options, not a manifest.
+
+    Repository paths are resolved against the working directory, so a caller may
+    name one relatively; each selection's parent becomes its search root, which
+    is the narrowest root that satisfies the selection-under-a-root rule.
+    """
+    selected = tuple(dict.fromkeys(canonicalize(path) for path in repositories))
+    search_roots = tuple(dict.fromkeys(path.parent for path in selected))
+    try:
+        return DesiredState(
+            harnesses=tuple(harnesses),
+            components=tuple(components),
+            repositories=RepositorySelection(search_roots=search_roots, selected=selected),
+        )
+    except ValidationError as error:
+        raise OptionError(_describe(error)) from error
 
 
 def save_desired_state(state: DesiredState, path: Path) -> None:

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -15,7 +15,9 @@ from pathlib import Path
 import pytest
 from cheese_flow import cli
 from cheese_flow.cli import app
+from cheese_flow.desired_state import load_desired_state
 from cheese_flow.models import (
+    COMPONENT_NAMES,
     ApplyReport,
     CommandOutcome,
     DesiredState,
@@ -203,13 +205,13 @@ def test_purged_commands_are_rejected() -> None:
         assert result.exit_code != 0, f"purged command still runs: {command!r}"
 
 
-def test_install_help_documents_its_three_options() -> None:
+def test_install_help_documents_its_options() -> None:
     result = runner.invoke(app, ["install", "--help"])
     assert result.exit_code == 0
     output = result.stdout
-    assert "--config" in output
-    assert "--dry-run" in output
-    assert "--json" in output
+    for option in ("--config", "--dry-run", "--json", "--harness", "--component", "--repo"):
+        assert option in output, f"install help omits {option}"
+    assert "--write-config" in output
 
 
 def test_doctor_help_documents_config_option() -> None:
@@ -294,6 +296,202 @@ def test_json_flag_without_config_runs_headless_from_the_default_manifest(
     assert result.exit_code == 0, result.stderr
     assert calls["wizard"] == []
     assert json.loads(result.stdout)["status"] == "succeeded"
+
+
+# ─── Option-driven headless install ──────────────────────────────────────────
+
+
+def test_options_build_the_desired_state_without_a_manifest(
+    tmp_path: Path, config_home: Path, command_runner: RecordingRunner, calls: dict
+) -> None:
+    project = tmp_path / "code" / "project"
+    project.mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "install",
+            "--harness",
+            "claude-code",
+            "--component",
+            "hallouminate,easy-cheese",
+            "--repo",
+            str(project),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert calls["wizard"] == []
+    assert calls["plan"] == [
+        DesiredState(
+            harnesses=("claude-code",),
+            components=("hallouminate", "easy-cheese"),
+            repositories=RepositorySelection(
+                search_roots=(project.parent.resolve(),),
+                selected=(project.resolve(),),
+            ),
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("name", "argv"),
+    [
+        ("comma-separated", ["--harness", "claude-code,codex"]),
+        ("space-separated", ["--harness", "claude-code codex"]),
+        ("repeated", ["--harness", "claude-code", "--harness", "codex"]),
+        ("mixed", ["--harness", "claude-code, codex"]),
+    ],
+)
+def test_list_options_accept_commas_whitespace_and_repetition(
+    name: str, argv: list[str], config_home: Path, command_runner: RecordingRunner, calls: dict
+) -> None:
+    result = runner.invoke(app, ["install", *argv, "--component", "hallouminate easy-cheese"])
+
+    assert result.exit_code == 0, f"{name}: {result.stderr}"
+    state = calls["plan"][0]
+    assert state.harnesses == ("claude-code", "codex"), name
+    assert state.components == ("hallouminate", "easy-cheese"), name
+
+
+def test_omitted_component_option_selects_every_component(
+    config_home: Path, command_runner: RecordingRunner, calls: dict
+) -> None:
+    result = runner.invoke(app, ["install", "--harness", "claude-code"])
+
+    assert result.exit_code == 0, result.stderr
+    assert calls["plan"][0].components == COMPONENT_NAMES
+
+
+def test_a_relative_repo_option_resolves_against_the_working_directory(
+    tmp_path: Path,
+    config_home: Path,
+    command_runner: RecordingRunner,
+    calls: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "code" / "project"
+    project.mkdir(parents=True)
+    monkeypatch.chdir(project.parent)
+
+    result = runner.invoke(app, ["install", "--harness", "claude-code", "--repo", "project"])
+
+    assert result.exit_code == 0, result.stderr
+    assert calls["plan"][0].repositories.selected == (project.resolve(),)
+
+
+def test_options_are_ephemeral_unless_write_config_is_passed(
+    config_home: Path, command_runner: RecordingRunner, calls: dict
+) -> None:
+    result = runner.invoke(app, ["install", "--harness", "claude-code"])
+
+    assert result.exit_code == 0, result.stderr
+    assert not config_home.exists(), "options must not persist a manifest by default"
+
+
+def test_write_config_persists_the_option_built_manifest(
+    tmp_path: Path, config_home: Path, command_runner: RecordingRunner, calls: dict
+) -> None:
+    project = tmp_path / "code" / "project"
+    project.mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        ["install", "--harness", "codex", "--repo", str(project), "--write-config"],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert load_desired_state(config_home) == calls["plan"][0]
+
+
+def test_write_config_is_written_before_the_plan_is_applied(
+    config_home: Path,
+    command_runner: RecordingRunner,
+    calls: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    written: list[bool] = []
+    faked = cli.apply_install_plan
+
+    def record(plan: InstallPlan, runner_: object, *, adapters: object) -> ApplyReport:
+        written.append(config_home.exists())
+        return faked(plan, runner_, adapters=adapters)
+
+    monkeypatch.setattr(cli, "apply_install_plan", record)
+
+    result = runner.invoke(app, ["install", "--harness", "codex", "--write-config"])
+
+    assert result.exit_code == 0, result.stderr
+    assert written == [True]
+
+
+def test_options_combined_with_config_are_rejected_before_planning(
+    tmp_path: Path, config_home: Path, command_runner: RecordingRunner, calls: dict
+) -> None:
+    manifest = write_manifest(tmp_path)
+
+    result = runner.invoke(app, ["install", "--config", str(manifest), "--harness", "claude-code"])
+
+    assert result.exit_code == 2
+    assert calls["plan"] == []
+    assert command_runner.commands == []
+    assert "two sources" in result.stderr
+
+
+def test_write_config_combined_with_dry_run_is_rejected(
+    config_home: Path, command_runner: RecordingRunner, calls: dict
+) -> None:
+    result = runner.invoke(
+        app, ["install", "--harness", "claude-code", "--write-config", "--dry-run"]
+    )
+
+    assert result.exit_code == 2
+    assert calls["plan"] == []
+    assert not config_home.exists()
+
+
+@pytest.mark.parametrize(
+    ("name", "argv", "expected"),
+    [
+        ("unknown harness", ["--harness", "pi"], "unknown harness names: pi"),
+        (
+            "missing required component",
+            ["--harness", "codex", "--component", "tilth"],
+            "components must include required components: hallouminate, easy-cheese",
+        ),
+        (
+            "duplicate harness",
+            ["--harness", "codex,codex"],
+            "harnesses must not contain duplicates: codex",
+        ),
+    ],
+)
+def test_invalid_options_exit_nonzero_before_planning_or_running_anything(
+    name: str,
+    argv: list[str],
+    expected: str,
+    config_home: Path,
+    command_runner: RecordingRunner,
+    calls: dict,
+) -> None:
+    result = runner.invoke(app, ["install", *argv])
+
+    assert result.exit_code == 2, name
+    assert expected in result.stderr, name
+    assert calls["plan"] == [], name
+    assert command_runner.commands == [], name
+    assert not config_home.exists(), name
+
+
+def test_options_with_dry_run_emit_the_plan_and_change_nothing(
+    config_home: Path, command_runner: RecordingRunner, calls: dict
+) -> None:
+    result = runner.invoke(app, ["install", "--harness", "claude-code", "--dry-run"])
+
+    assert result.exit_code == 0, result.stderr
+    assert calls["apply"] == []
+    assert not config_home.exists()
+    assert json.loads(result.stdout)["plan"]["steps"][0]["step_id"] == "hallouminate:install"
 
 
 # ─── Invalid manifests fail first (acceptance:145) ───────────────────────────


### PR DESCRIPTION
## Why

Headless install required a TOML manifest on disk (`_headless_state`, `cli.py`), so every CI job, container, and cloud box had to write a heredoc before it could call the installer. There was no way to declare desired state on the command line.

## What

`cheese install` gains four options:

| Option | Effect |
|---|---|
| `--harness NAMES` | Harnesses to manage, comma- or space-separated. Repeatable. Runs headlessly |
| `--component NAMES` | Components to install, comma- or space-separated. Defaults to all of them |
| `--repo PATHS` | Repositories to index, comma- or space-separated. Relative paths are resolved |
| `--write-config` | Persist the resolved manifest. Options are ephemeral without it |

```bash
uvx --from git+https://github.com/paulnsorensen/cheese-flow cheese install \
  --harness "claude-code codex" --component hallouminate,easy-cheese --repo . --json
```

- `state_from_options()` in `desired_state.py` is the flag-side sibling of `load_desired_state()`, reusing the same `_describe()` formatter so a bad option reads like a bad manifest key. Each selected repository's parent becomes its search root — the narrowest root satisfying the selection-under-a-root rule.
- Options are ephemeral, matching `--config`. `--write-config` persists to the default config path *before* apply, so a partly failed install still leaves a manifest `cheese doctor` can read.
- Rejected combinations: `--config` with any state option (two sources of state), and `--write-config` with `--dry-run` (a dry run persists nothing).

Bare space-delimited values are impossible here — Click raises `TypeError: nargs=-1 is not supported for options` — so values split on commas *and* whitespace, and the options repeat.

## Decisions worth a second look

1. Omitting `--component` selects all three. Two are in `REQUIRED_COMPONENTS` anyway, so "all" is the nearest neutral default. `--harness` stays required.
2. Options imply headless, so stdout carries JSON with or without `--json` — the rule `--config` already followed.
3. `install()` now takes 8 parameters against the max of 4 in `AGENTS.md`. Typer options must be function parameters; ruff does not enforce it (`PLR0913` is not in the select list).

## Testing

`just build` — 444 passed (432 before). 12 new cases in `test_cli.py`: separator forms, the component default, relative-path resolution, ephemeral-by-default, `--write-config` round-tripping through `load_desired_state`, write-before-apply ordering, both conflict rejections, and invalid names failing before anything plans or runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)