### PR TITLE
feat(easy-cheese): install through the skills CLI instead of gh

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,22 @@ A composition installer for the cheese ecosystem: it installs and verifies `hall
 - `references/` — long-form architectural references (Sliced Bread, etc.)
 - `.claude-plugin/` / `.cursor-plugin/` — this repo's own Claude Code / Cursor plugin manifests
 - `.mcp.json` — shared MCP server declarations (tilth, Context7, Tavily)
+- `bootstrap.sh` — the curl-pipe-sh entry point: installs `uv` when absent, then runs `cheese install`
 
 ## Getting started
+
+On a bare box — a cloud sandbox, a fresh VM, a container with nothing but curl, git, and node — one line does the whole install:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/paulnsorensen/cheese-flow/main/bootstrap.sh \
+  | sh -s -- --harness claude-code
+```
+
+`bootstrap.sh` installs `uv` when it is absent and hands every argument after `--` to `cheese install`. Pass the state options: piping the script into `sh` consumes stdin, which is what the interactive wizard reads, so this path is headless by construction.
+
+The only host prerequisites are `curl`, `git`, and the `npm` toolchain the components install themselves with. No GitHub CLI is needed.
+
+### From a checkout
 
 Host prerequisite: `uv` on `PATH`.
 
@@ -78,7 +92,7 @@ Installs the selected components for the selected harnesses and repositories.
 | `--config PATH` | Apply this manifest headlessly instead of running the wizard |
 | `--harness NAMES` | Harnesses to manage, comma- or space-separated. Repeatable. Runs headlessly |
 | `--component NAMES` | Components to install, comma- or space-separated. Defaults to all of them |
-| `--repo PATHS` | Repositories to index, comma- or space-separated. Relative paths are resolved |
+| `--repo PATHS` | Repositories to index, comma- or space-separated. Relative paths are resolved. Each must be a git repository |
 | `--write-config` | Persist the resolved manifest. Options are ephemeral without it |
 | `--dry-run` | Emit the plan without changing managed state |
 | `--json` | Write one JSON document to stdout (also runs headlessly) |
@@ -86,7 +100,7 @@ Installs the selected components for the selected harnesses and repositories.
 
 With no `--config`/`--json` and no state options, `install` runs the interactive wizard and, on acceptance, persists the manifest to the default config path before applying it.
 
-`--harness`/`--component`/`--repo` declare the desired state without a manifest file, which is the CI and cloud path — nothing is persisted unless you pass `--write-config`. Each selected repository's parent becomes its search root. Two combinations are rejected: `--config` with any state option (two sources of state), and `--write-config` with `--dry-run` (a dry run persists nothing).
+`--harness`/`--component`/`--repo` declare the desired state without a manifest file, which is the CI and cloud path — nothing is persisted unless you pass `--write-config`. Each selected repository's parent becomes its search root, and a `--repo` path that is not a git repository is rejected before anything is planned. Two combinations are rejected: `--config` with any state option (two sources of state), and `--write-config` with `--dry-run` (a dry run persists nothing).
 
 ### `cheese doctor`
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# One-line entry point for a bare host:
+#
+#   curl -fsSL https://raw.githubusercontent.com/paulnsorensen/cheese-flow/main/bootstrap.sh \
+#     | sh -s -- --harness claude-code
+#
+# Installs uv when it is absent, then hands every argument to `cheese install`.
+# Headless only by construction: piping this script into `sh` consumes stdin,
+# which is what the interactive wizard reads. Pass the state options.
+set -eu
+
+REPOSITORY="git+https://github.com/paulnsorensen/cheese-flow"
+
+if ! command -v uvx >/dev/null 2>&1; then
+    echo "cheese: installing uv" >&2
+    curl -fsSL https://astral.sh/uv/install.sh | sh
+    # The uv installer targets ~/.local/bin, which a non-login shell may not
+    # already carry; without this, the exec below fails on the host we just
+    # provisioned.
+    PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
+    export PATH
+fi
+
+# A pipeline's status is its last command's, and POSIX sh has no pipefail: a
+# curl that 404s or times out leaves `| sh` exiting 0. Without this check the
+# run dies further down as a bare "uvx: not found", naming the wrong failure.
+if ! command -v uvx >/dev/null 2>&1; then
+    echo "cheese: uv install failed; install uv and re-run — https://docs.astral.sh/uv/" >&2
+    exit 1
+fi
+
+exec uvx --from "$REPOSITORY" cheese install "$@"

--- a/python/cheese_flow/adapters/easy_cheese.py
+++ b/python/cheese_flow/adapters/easy_cheese.py
@@ -1,9 +1,9 @@
-"""easy-cheese adapter: ``gh skill`` install and verification."""
+"""easy-cheese adapter: ``skills`` CLI install and on-disk verification."""
 
 from __future__ import annotations
 
-import json
-from typing import Any
+import os
+from pathlib import Path
 
 from cheese_flow.models import (
     HARNESS_NAMES,
@@ -16,31 +16,80 @@ from cheese_flow.models import (
 )
 
 SOURCE_REPOSITORY = "paulnsorensen/easy-cheese"
-SCOPE = "user"
+PACKAGE = "skills@latest"
 
-_LIST_FIELDS = "agentHosts,scope,skillName,sourceURL"
+AGENT_TOKENS: dict[HarnessName, str] = {
+    "claude-code": "claude-code",
+    "codex": "codex",
+    "cursor": "cursor",
+}
+"""``skills --agent`` tokens the CLI accepts, keyed by harness.
+
+Taken from the CLI's own agent registry. A harness that has no accepted token
+belongs nowhere in this table: it then contributes no step at all, rather than
+one that could only ever fail.
+"""
 
 CORE_SKILLS = frozenset({"mold", "cook", "press", "age", "cure", "plate", "cheese"})
 """The pipeline skills easy-cheese always ships; a full quorum identifies the pack."""
 
+SKILL_FILE = "SKILL.md"
+"""The file every installed skill directory carries."""
 
-def _normalize_source(raw: str) -> str:
-    """Reduce a ``gh skill list`` sourceURL to its ``owner/repo`` identity."""
-    trimmed = raw.strip().removesuffix(".git").rstrip("/")
-    parts = [part for part in trimmed.replace(":", "/").split("/") if part]
-    return "/".join(parts[-2:]) if len(parts) >= 2 else ""
+_CLAUDE_CONFIG_DIR = "CLAUDE_CONFIG_DIR"
+"""Claude Code's config-directory override, which the ``skills`` CLI honours."""
+
+_SKILLS_DIRS: dict[HarnessName, str] = {
+    "claude-code": ".claude/skills",
+    "codex": ".agents/skills",
+    "cursor": ".agents/skills",
+}
+"""Where a global ``skills add`` leaves each harness's pack, relative to home.
+
+``.agents/skills`` is the CLI's one canonical store; a harness that declares
+that shared layout as its own — Codex and Cursor — is served from it directly,
+with no second copy and no link. Claude Code declares a directory of its own
+and additionally receives a symlink per skill into it.
+
+Every harness needs an entry here and in :data:`AGENT_TOKENS`. Both lookups
+raise on a harness that has neither, which is the point: verifying the wrong
+directory would report an install that never reached the harness.
+"""
+
+
+def skills_directory(harness: HarnessName) -> Path:
+    """Where ``skills add --global`` leaves the pack for ``harness``.
+
+    Claude Code's location moves with ``CLAUDE_CONFIG_DIR``, exactly as the CLI
+    reads it.
+
+    Symlinking is the CLI's default and is kept deliberately: one copy of the
+    pack is updated in place, and a chezmoi-managed ``~/.claude/skills`` gains
+    links rather than eighteen duplicated skill trees.
+    """
+    if harness == "claude-code":
+        configured = os.environ.get(_CLAUDE_CONFIG_DIR, "").strip()
+        if configured:
+            return Path(configured) / "skills"
+    return Path.home() / _SKILLS_DIRS[harness]
 
 
 class EasyCheeseAdapter:
-    """Installs the easy-cheese skill pack per harness through ``gh skill``."""
+    """Installs the easy-cheese skill pack per harness through the ``skills`` CLI."""
 
     name: ComponentName = "easy-cheese"
 
     def __init__(self, runner: CommandRunner) -> None:
-        self._runner = runner
+        # Constructed uniformly with every other adapter, but this one resolves
+        # no versions and probes with no command, so the runner is not kept.
+        del runner
 
     def plan_steps(self, state: DesiredState) -> tuple[PlanStep, ...]:
-        """Emit one ``gh skill install`` step per selected harness."""
+        """Emit one ``skills add`` step per selected harness the CLI can target.
+
+        ``npx`` runs the CLI, so the only host prerequisite is the ``npm``
+        toolchain hallouminate's own install already requires.
+        """
         if self.name not in state.components:
             return ()
         return tuple(
@@ -50,74 +99,44 @@ class EasyCheeseAdapter:
                 harness=harness,
                 phase=Phase.REGISTER,
                 argv=(
-                    "gh",
-                    "skill",
-                    "install",
+                    "npx",
+                    "-y",
+                    PACKAGE,
+                    "add",
                     SOURCE_REPOSITORY,
-                    "--all",
+                    "--skill",
+                    "*",
                     "--agent",
-                    harness,
-                    "--scope",
-                    SCOPE,
+                    AGENT_TOKENS[harness],
+                    "--global",
+                    "--yes",
                 ),
                 postcondition=(
-                    f"`gh skill list` reports {SOURCE_REPOSITORY} skills for {harness} at "
-                    f"{SCOPE} scope"
+                    f"the easy-cheese core skills are installed under {skills_directory(harness)}"
                 ),
             )
             for harness in HARNESS_NAMES
-            if harness in state.harnesses
+            if harness in state.harnesses and harness in AGENT_TOKENS
         )
 
     def check_postcondition(self, step: PlanStep, runner: CommandRunner) -> bool:
-        """Confirm the pack is installed for the harness at the expected scope.
+        """Confirm the whole core quorum is on disk for the harness.
 
-        ``gh skill install`` records provenance in the installed ``SKILL.md``'s
-        ``metadata.github-repo`` frontmatter, which ``gh skill list`` surfaces
-        as ``sourceURL``. The field is empty exactly when gh did not install the
-        skill, so it is authoritative identity: locally authored skills that
-        merely share easy-cheese's names never count. The step installs
-        ``--all``, so convergence needs the whole core quorum from our source.
+        The ``skills`` CLI records no provenance any listing could report, so
+        identity is the pack's own layout: every core skill present as
+        ``<skills dir>/<name>/SKILL.md``. That is a name-based check — a
+        machine whose author keeps hand-written skills under all seven names
+        reads as installed — and it is knowingly weaker than the provenance
+        field the previous listing-based check read, which issue #86 found
+        empty in practice anyway. It spawns no child process, so a host with no
+        GitHub CLI verifies exactly as well as one that has it.
         """
-        if step.harness is None:
-            raise ValueError(f"step {step.step_id!r} has no harness")
-        outcome = runner.run(
-            (
-                "gh",
-                "skill",
-                "list",
-                "--agent",
-                step.harness,
-                "--scope",
-                SCOPE,
-                "--json",
-                _LIST_FIELDS,
-            )
-        )
-        if outcome.exit_code != 0:
-            return False
-        try:
-            entries = json.loads(outcome.stdout)
-        except json.JSONDecodeError:
-            return False
-        if not isinstance(entries, list):
-            return False
-        ours = {
-            str(entry["skillName"]).strip()
-            for entry in entries
-            if _is_skill_for(entry, step.harness)
-            and _normalize_source(str(entry.get("sourceURL", ""))) == SOURCE_REPOSITORY
-        }
-        return ours >= CORE_SKILLS
+        del runner  # The end state is on disk; no command can report it better.
+        directory = skills_directory(_harness_of(step))
+        return all((directory / name / SKILL_FILE).is_file() for name in CORE_SKILLS)
 
 
-def _is_skill_for(entry: Any, harness: HarnessName) -> bool:
-    """Whether a listing entry is a named skill installed for this harness and scope."""
-    if not isinstance(entry, dict):
-        return False
-    if entry.get("scope") != SCOPE:
-        return False
-    hosts = entry.get("agentHosts")
-    if not isinstance(hosts, list) or harness not in hosts:
-        return False
-    return bool(str(entry.get("skillName", "")).strip())
+def _harness_of(step: PlanStep) -> HarnessName:
+    if step.harness is None:
+        raise ValueError(f"step {step.step_id!r} has no harness")
+    return step.harness

--- a/python/cheese_flow/desired_state.py
+++ b/python/cheese_flow/desired_state.py
@@ -18,6 +18,7 @@ from cheese_flow.models import (
     RepositorySelection,
     canonicalize,
 )
+from cheese_flow.repositories import is_repository
 
 
 class ManifestError(Exception):
@@ -60,8 +61,15 @@ def state_from_options(
     Repository paths are resolved against the working directory, so a caller may
     name one relatively; each selection's parent becomes its search root, which
     is the narrowest root that satisfies the selection-under-a-root rule.
+
+    A path that is not a git repository is rejected here, before planning: the
+    installer can only index repositories, so accepting one would buy nothing
+    but a blocked step in the middle of an otherwise applied run.
     """
     selected = tuple(dict.fromkeys(canonicalize(path) for path in repositories))
+    strangers = [str(path) for path in selected if not is_repository(path)]
+    if strangers:
+        raise OptionError(f"not a git repository: {', '.join(strangers)}")
     search_roots = tuple(dict.fromkeys(path.parent for path in selected))
     try:
         return DesiredState(

--- a/python/cheese_flow/install.py
+++ b/python/cheese_flow/install.py
@@ -304,7 +304,7 @@ class _RepositoryRevalidation:
             self._rediscover()
             cached = self._verdicts.get(canonical)
         if cached is None:
-            return f"{repository} is no longer a repository at its planned path"
+            return _absent_reason(repository)
         return cached[1]
 
     def _rediscover(self) -> None:
@@ -321,9 +321,22 @@ class _RepositoryRevalidation:
         }
 
 
+def _absent_reason(repository: Path) -> str:
+    """Why discovery no longer answers for a planned repository.
+
+    Discovery reports a single absence, but the two causes need different
+    fixes and only one of them is a path that moved. A directory that is still
+    there and simply is not a git repository must not be described as one that
+    stopped being a repository — it may never have been one.
+    """
+    if not repository.is_dir():
+        return f"{repository} is not present at its planned path"
+    return f"{repository} is not a git repository"
+
+
 def _drift_reason(candidate: RepositoryCandidate | None, repository: Path) -> str | None:
     if candidate is None:
-        return f"{repository} is no longer a repository at its planned path"
+        return _absent_reason(repository)
     if not candidate.writable:
         return f"{repository} is not writable"
     if candidate.collision is not CollisionClass.NONE:

--- a/python/cheese_flow/repositories.py
+++ b/python/cheese_flow/repositories.py
@@ -74,7 +74,7 @@ def _scan(root: Path, max_depth: int, boundaries: tuple[Path, ...]) -> list[Path
             canonical = _resolve(directory)
             if canonical is None or not _within(canonical, boundaries):
                 continue
-            if _is_repository(canonical):
+            if is_repository(canonical):
                 repos.append(canonical)
                 continue
             if depth < max_depth:
@@ -98,7 +98,8 @@ def _child_directories(directory: Path) -> list[Path]:
     return children
 
 
-def _is_repository(directory: Path) -> bool:
+def is_repository(directory: Path) -> bool:
+    """Whether ``directory`` is a git repository — a checkout or a linked worktree."""
     try:
         return (directory / ".git").exists()
     except OSError:

--- a/tests/python/test_adapters.py
+++ b/tests/python/test_adapters.py
@@ -4,6 +4,7 @@ positive postconditions driven entirely through a scripted fake ``CommandRunner`
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -13,8 +14,9 @@ from cheese_flow.adapters import (
     HallouminateAdapter,
     TilthAdapter,
     default_component_adapters,
+    easy_cheese,
 )
-from cheese_flow.adapters.easy_cheese import CORE_SKILLS, _normalize_source
+from cheese_flow.adapters.easy_cheese import AGENT_TOKENS, CORE_SKILLS, skills_directory
 from cheese_flow.adapters.hallouminate import _owner_repo
 from cheese_flow.models import (
     CommandOutcome,
@@ -801,7 +803,22 @@ def test_hallouminate_repo_postcondition_rejects_an_empty_target_from_inside_the
 # --------------------------------------------------------------------------
 
 
-def test_easy_cheese_plans_one_gh_skill_install_per_harness() -> None:
+SKILLS_ADD_ARGV = (
+    "npx",
+    "-y",
+    "skills@latest",
+    "add",
+    "paulnsorensen/easy-cheese",
+    "--skill",
+    "*",
+    "--agent",
+    "cursor",
+    "--global",
+    "--yes",
+)
+
+
+def test_easy_cheese_plans_one_skills_add_per_harness() -> None:
     runner = FakeRunner()
     steps = EasyCheeseAdapter(runner).plan_steps(state())
 
@@ -810,160 +827,210 @@ def test_easy_cheese_plans_one_gh_skill_install_per_harness() -> None:
         "easy-cheese:install:codex",
         "easy-cheese:install:cursor",
     ]
-    assert steps[2].argv == (
-        "gh",
-        "skill",
-        "install",
-        "paulnsorensen/easy-cheese",
-        "--all",
-        "--agent",
-        "cursor",
-        "--scope",
-        "user",
-    )
+    assert steps[2].argv == SKILLS_ADD_ARGV
     assert steps[2].phase is Phase.REGISTER
     assert steps[2].depends_on == ()
     assert runner.argvs() == []
 
 
-LIST_ARGV = (
-    "gh",
-    "skill",
-    "list",
-    "--agent",
-    "claude-code",
-    "--scope",
-    "user",
-    "--json",
-    "agentHosts,scope,skillName,sourceURL",
-)
+def test_easy_cheese_uses_the_agent_token_the_skills_cli_accepts() -> None:
+    steps = steps_by_id(EasyCheeseAdapter(FakeRunner()).plan_steps(state()))
+
+    assert [_agent_token(step) for step in steps.values()] == ["claude-code", "codex", "cursor"]
+    assert set(AGENT_TOKENS) == set(ALL_HARNESSES)
 
 
-def gh_list(entries: list[dict[str, object]], *, exit_code: int = 0) -> FakeRunner:
-    return FakeRunner(
-        {LIST_ARGV: outcome(LIST_ARGV, exit_code=exit_code, stdout=json.dumps(entries))}
-    )
+def _agent_token(step: PlanStep) -> str:
+    return step.argv[step.argv.index("--agent") + 1]
 
 
-def easy_cheese_step() -> PlanStep:
-    return steps_by_id(EasyCheeseAdapter(FakeRunner()).plan_steps(state()))[
-        "easy-cheese:install:claude-code"
+def test_easy_cheese_needs_no_gh_anywhere_in_the_adapter() -> None:
+    """acceptance:21 — `gh` is an undeclared prerequisite a cloud box does not have."""
+    source = Path(easy_cheese.__file__).read_text(encoding="utf-8")
+
+    assert re.search(r"\bgh\b", source) is None
+
+
+def test_easy_cheese_skips_a_harness_the_skills_cli_cannot_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A harness with no accepted `--agent` token gets no step, not one that cannot converge."""
+    monkeypatch.delitem(AGENT_TOKENS, "cursor")
+
+    steps = EasyCheeseAdapter(FakeRunner()).plan_steps(state())
+
+    assert [s.step_id for s in steps] == [
+        "easy-cheese:install:claude-code",
+        "easy-cheese:install:codex",
     ]
 
 
-def sourced_entry(
-    name: str, *, harness: str = "claude-code", source: str = "paulnsorensen/easy-cheese"
-) -> dict[str, object]:
-    """A `gh skill list --json` row for a skill gh installed from a repository."""
-    return {
-        "agentHosts": [harness],
-        "scope": "user",
-        "skillName": name,
-        "sourceURL": f"https://github.com/{source}",
-    }
+@pytest.fixture
+def sandbox_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    return home
 
 
-def test_easy_cheese_postcondition_confirms_source_agent_scope_and_skills() -> None:
-    adapter = EasyCheeseAdapter(FakeRunner())
-    runner = gh_list([sourced_entry(name) for name in CORE_SKILLS])
-    assert adapter.check_postcondition(easy_cheese_step(), runner) is True
-    assert runner.argvs() == [LIST_ARGV]
+def easy_cheese_step(harness: str = "claude-code") -> PlanStep:
+    return steps_by_id(EasyCheeseAdapter(FakeRunner()).plan_steps(state()))[
+        f"easy-cheese:install:{harness}"
+    ]
 
 
-def test_easy_cheese_postcondition_requires_the_full_core_quorum_from_our_source() -> None:
-    # `--all` installs the whole pack; a partial install is not convergence.
-    partial = gh_list([sourced_entry(name) for name in sorted(CORE_SKILLS)[:-1]])
-    assert EasyCheeseAdapter(FakeRunner()).check_postcondition(easy_cheese_step(), partial) is False
-
-
-def test_easy_cheese_postcondition_ignores_a_foreign_pack_carrying_a_source() -> None:
-    # M-A1: an unrelated pack reporting its own sourceURL must not veto ours.
-    entries = [sourced_entry(name) for name in CORE_SKILLS]
-    entries.append(sourced_entry("terraform", source="hashicorp/skills"))
-    runner = gh_list(entries)
-    assert EasyCheeseAdapter(FakeRunner()).check_postcondition(easy_cheese_step(), runner) is True
+def install_skills(directory: Path, names: Sequence[str]) -> Path:
+    """What `skills add --global` leaves on disk: one directory per skill."""
+    for name in names:
+        (directory / name).mkdir(parents=True, exist_ok=True)
+        (directory / name / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+    return directory
 
 
 @pytest.mark.parametrize(
-    "override",
+    ("harness", "relative"),
     [
-        pytest.param({"scope": "project"}, id="wrong-scope"),
-        pytest.param({"agentHosts": ["codex"]}, id="wrong-agent"),
-        pytest.param({"sourceURL": "https://github.com/someone/other-skills"}, id="wrong-source"),
-        pytest.param({"skillName": ""}, id="no-skill-installed"),
+        pytest.param("claude-code", ".claude/skills", id="claude-code"),
+        pytest.param("codex", ".agents/skills", id="codex"),
+        pytest.param("cursor", ".agents/skills", id="cursor"),
     ],
 )
-def test_easy_cheese_postcondition_rejects_wrong_end_state(override: dict[str, object]) -> None:
-    # A full core quorum is present in every case; `gh skill list` exits 0 in
-    # every case. Only the parsed end state distinguishes them.
-    entries = [sourced_entry(name) | override for name in CORE_SKILLS]
+def test_easy_cheese_postcondition_reads_the_harness_skills_directory(
+    harness: str, relative: str, sandbox_home: Path
+) -> None:
+    """Each harness is verified where the `skills` CLI actually writes its pack.
+
+    Codex and Cursor read the shared `.agents/skills` store the CLI treats as
+    canonical; Claude Code gets its own directory, linked per skill.
+    """
+    step = easy_cheese_step(harness)
+    adapter = EasyCheeseAdapter(FakeRunner())
+    assert adapter.check_postcondition(step, FakeRunner()) is False
+
+    install_skills(sandbox_home / relative, sorted(CORE_SKILLS))
+
+    assert adapter.check_postcondition(step, FakeRunner()) is True
+    assert str(sandbox_home / relative) in step.postcondition
+
+
+def test_easy_cheese_raises_rather_than_guessing_a_directory_for_an_unlisted_harness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A harness with no recorded directory must not fall through to another one's.
+
+    Defaulting would verify a directory the install never wrote and report a
+    harness as converged that the pack never reached.
+    """
+    monkeypatch.delitem(easy_cheese._SKILLS_DIRS, "cursor")
+
+    with pytest.raises(KeyError):
+        skills_directory("cursor")
+
+
+def test_easy_cheese_postcondition_does_not_read_another_harnesss_directory(
+    sandbox_home: Path,
+) -> None:
+    """One harness's pack must never satisfy a harness that reads elsewhere.
+
+    Claude Code's directory and the canonical store are distinct places, and
+    collapsing them — in either direction — would report an install that never
+    reached the harness the step names.
+    """
+    adapter = EasyCheeseAdapter(FakeRunner())
+    install_skills(sandbox_home / ".claude" / "skills", sorted(CORE_SKILLS))
+
+    assert adapter.check_postcondition(easy_cheese_step("claude-code"), FakeRunner()) is True
+    assert adapter.check_postcondition(easy_cheese_step("codex"), FakeRunner()) is False
+    assert adapter.check_postcondition(easy_cheese_step("cursor"), FakeRunner()) is False
+
+
+def test_easy_cheese_postcondition_runs_no_command_so_a_host_without_gh_converges(
+    sandbox_home: Path,
+) -> None:
+    """acceptance:24 — the check is a filesystem read; an unreachable `gh` cannot break it."""
+    install_skills(sandbox_home / ".claude" / "skills", sorted(CORE_SKILLS))
+    runner = FakeRunner()
+
+    assert EasyCheeseAdapter(FakeRunner()).check_postcondition(easy_cheese_step(), runner) is True
+    assert runner.argvs() == []
+
+
+def test_easy_cheese_postcondition_requires_the_full_core_quorum(sandbox_home: Path) -> None:
+    # The step installs the whole pack; a partial install is not convergence.
+    install_skills(sandbox_home / ".claude" / "skills", sorted(CORE_SKILLS)[:-1])
+
     assert (
-        EasyCheeseAdapter(FakeRunner()).check_postcondition(easy_cheese_step(), gh_list(entries))
+        EasyCheeseAdapter(FakeRunner()).check_postcondition(easy_cheese_step(), FakeRunner())
         is False
     )
 
 
-def test_easy_cheese_postcondition_false_on_empty_listing_and_bad_json() -> None:
-    adapter = EasyCheeseAdapter(FakeRunner())
-    assert adapter.check_postcondition(easy_cheese_step(), gh_list([])) is False
+def test_easy_cheese_postcondition_rejects_a_skill_directory_without_its_skill_file(
+    sandbox_home: Path,
+) -> None:
+    """An empty directory of the right name is not an installed skill."""
+    skills = install_skills(sandbox_home / ".claude" / "skills", sorted(CORE_SKILLS))
+    (skills / "cook" / "SKILL.md").unlink()
 
-    garbage = FakeRunner({LIST_ARGV: outcome(LIST_ARGV, stdout="not json")})
-    assert adapter.check_postcondition(easy_cheese_step(), garbage) is False
-
-    failed = gh_list([], exit_code=1)
-    assert adapter.check_postcondition(easy_cheese_step(), failed) is False
-
-
-def blank_source_entry(name: str, *, harness: str = "claude-code") -> dict[str, object]:
-    """A locally authored skill: gh wrote no install metadata, so no source."""
-    return {"agentHosts": [harness], "scope": "user", "skillName": name, "sourceURL": ""}
-
-
-def test_easy_cheese_postcondition_rejects_locally_authored_core_skills() -> None:
-    # M-A2: `gh skill list --scope user` reports every hand-written skill in the
-    # harness directory with `sourceURL: ""`. A machine whose author happens to
-    # keep skills named `mold`/`cook`/... must not read as an installed pack.
-    runner = gh_list([blank_source_entry(name) for name in CORE_SKILLS])
-    assert EasyCheeseAdapter(FakeRunner()).check_postcondition(easy_cheese_step(), runner) is False
-
-
-def test_easy_cheese_postcondition_rejects_a_harness_missing_core_skills() -> None:
-    runner = gh_list([blank_source_entry(name) for name in ("chezmoi", "prek", "explain")])
-    assert EasyCheeseAdapter(FakeRunner()).check_postcondition(easy_cheese_step(), runner) is False
-
-
-def test_easy_cheese_postcondition_keeps_source_matching_authoritative() -> None:
-    # A full core quorum from a foreign pack must not satisfy the step.
-    runner = gh_list([sourced_entry(name, source="someone/other-skills") for name in CORE_SKILLS])
-    assert EasyCheeseAdapter(FakeRunner()).check_postcondition(easy_cheese_step(), runner) is False
-
-
-def test_easy_cheese_postcondition_ignores_core_skills_owned_by_another_harness() -> None:
-    entries = [sourced_entry(name, harness="codex") for name in CORE_SKILLS]
-    runner = gh_list(entries)
-    assert EasyCheeseAdapter(FakeRunner()).check_postcondition(easy_cheese_step(), runner) is False
-
-
-def test_easy_cheese_accepts_bare_owner_repo_source() -> None:
-    entries = [
-        {
-            "agentHosts": ["claude-code", "cursor"],
-            "scope": "user",
-            "skillName": name,
-            "sourceURL": "paulnsorensen/easy-cheese.git",
-        }
-        for name in CORE_SKILLS
-    ]
     assert (
-        EasyCheeseAdapter(FakeRunner()).check_postcondition(easy_cheese_step(), gh_list(entries))
+        EasyCheeseAdapter(FakeRunner()).check_postcondition(easy_cheese_step(), FakeRunner())
+        is False
+    )
+
+
+def test_easy_cheese_postcondition_ignores_skills_outside_the_core_quorum(
+    sandbox_home: Path,
+) -> None:
+    install_skills(sandbox_home / ".claude" / "skills", [*sorted(CORE_SKILLS), "chezmoi", "prek"])
+
+    assert (
+        EasyCheeseAdapter(FakeRunner()).check_postcondition(easy_cheese_step(), FakeRunner())
         is True
     )
 
 
-def test_normalize_source_normalizes_scp_https_and_git_suffix_forms() -> None:
-    assert _normalize_source("git@github.com:owner/repo.git") == "owner/repo"
-    assert _normalize_source("https://github.com/owner/repo.git") == "owner/repo"
-    assert _normalize_source("https://github.com/owner/repo") == "owner/repo"
+def test_easy_cheese_postcondition_resolves_a_symlinked_skill(sandbox_home: Path) -> None:
+    """The CLI symlinks into the harness directory by default; the check follows links."""
+    canonical = install_skills(sandbox_home / ".agents" / "skills", sorted(CORE_SKILLS))
+    linked = sandbox_home / ".claude" / "skills"
+    linked.mkdir(parents=True)
+    for name in sorted(CORE_SKILLS):
+        (linked / name).symlink_to(canonical / name, target_is_directory=True)
+
+    assert (
+        EasyCheeseAdapter(FakeRunner()).check_postcondition(easy_cheese_step(), FakeRunner())
+        is True
+    )
+
+
+def test_easy_cheese_postcondition_honours_the_claude_config_dir_override(
+    sandbox_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The `skills` CLI writes where `CLAUDE_CONFIG_DIR` points, so the check reads there."""
+    elsewhere = tmp_path / "claude-config"
+    install_skills(elsewhere / "skills", sorted(CORE_SKILLS))
+    install_skills(sandbox_home / ".claude" / "skills", ["cook"])
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(elsewhere))
+
+    assert skills_directory("claude-code") == elsewhere / "skills"
+    assert (
+        EasyCheeseAdapter(FakeRunner()).check_postcondition(easy_cheese_step(), FakeRunner())
+        is True
+    )
+
+
+def test_easy_cheese_postcondition_rejects_a_step_without_a_harness() -> None:
+    orphan = PlanStep(
+        step_id="easy-cheese:install:none",
+        component="easy-cheese",
+        phase=Phase.REGISTER,
+        argv=("npx", "-y", "skills@latest"),
+        postcondition="never",
+    )
+
+    with pytest.raises(ValueError, match="has no harness"):
+        EasyCheeseAdapter(FakeRunner()).check_postcondition(orphan, FakeRunner())
 
 
 # --------------------------------------------------------------------------

--- a/tests/python/test_bootstrap.py
+++ b/tests/python/test_bootstrap.py
@@ -1,0 +1,135 @@
+"""Black-box tests for ``bootstrap.sh``, the curl-pipe-sh entry point.
+
+The script runs for real; only the executables it reaches for are shimmed.
+Each shim records its own argv, so the test asserts what would actually have
+run on a host that has nothing but curl.
+"""
+
+from __future__ import annotations
+
+import os
+import stat as stat_mod
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "bootstrap.sh"
+
+FROM = "--from git+https://github.com/paulnsorensen/cheese-flow"
+
+RECORDING_SHIM = """#!/bin/sh
+printf '%s\\n' "$0 $*" >> "$RECORD"
+"""
+
+# Stands in for https://astral.sh/uv/install.sh: the script bootstrap.sh pipes
+# into `sh`, which drops uv where a non-login shell cannot see it yet.
+UV_INSTALLER_SHIM = """#!/bin/sh
+printf '%s\\n' "$0 $*" >> "$RECORD"
+cat <<'INSTALLER'
+mkdir -p "$HOME/.local/bin"
+cat > "$HOME/.local/bin/uvx" <<'UVX'
+#!/bin/sh
+printf '%s\\n' "installed-uvx $*" >> "$RECORD"
+UVX
+chmod +x "$HOME/.local/bin/uvx"
+INSTALLER
+"""
+
+
+def _shim(directory: Path, name: str, body: str = RECORDING_SHIM) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    shim = directory / name
+    shim.write_text(body, encoding="utf-8")
+    shim.chmod(shim.stat().st_mode | stat_mod.S_IEXEC | stat_mod.S_IXGRP | stat_mod.S_IXOTH)
+    return shim
+
+
+def _invoke(
+    tmp_path: Path, *args: str, path: Path, home: Path
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    """Run the script with ``path`` at the head of ``PATH``; return it and what ran."""
+    record = tmp_path / "record"
+    record.touch()
+    home.mkdir(parents=True, exist_ok=True)
+    env = dict(os.environ) | {
+        # The system directories keep `sh` itself resolvable; nothing the
+        # script looks for lives there.
+        "PATH": f"{path}:/usr/bin:/bin",
+        "HOME": str(home),
+        "RECORD": str(record),
+    }
+    env.pop("XDG_BIN_HOME", None)
+    completed = subprocess.run(
+        ["/bin/sh", str(SCRIPT_PATH), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    return completed, record.read_text(encoding="utf-8").splitlines()
+
+
+def _run(tmp_path: Path, *args: str, path: Path, home: Path) -> list[str]:
+    completed, ran = _invoke(tmp_path, *args, path=path, home=home)
+    assert completed.returncode == 0, completed.stderr
+    return ran
+
+
+def test_hands_every_argument_to_a_headless_cheese_install(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    _shim(bin_dir, "uvx")
+    _shim(bin_dir, "curl")
+
+    ran = _run(
+        tmp_path,
+        "--harness",
+        "claude-code",
+        "--repo",
+        "/srv/code/project",
+        path=bin_dir,
+        home=tmp_path / "home",
+    )
+
+    assert ran == [
+        f"{bin_dir / 'uvx'} {FROM} cheese install --harness claude-code --repo /srv/code/project"
+    ]
+
+
+def test_installs_uv_first_when_the_host_has_none_and_then_runs_it(tmp_path: Path) -> None:
+    """The bare cloud box: curl, git, and node. uv has to arrive before anything else."""
+    bin_dir = tmp_path / "bin"
+    _shim(bin_dir, "curl", UV_INSTALLER_SHIM)
+
+    ran = _run(tmp_path, "--harness", "codex", path=bin_dir, home=tmp_path / "home")
+
+    # `uvx` existed nowhere on PATH, so reaching it at all proves the script
+    # both installed uv and put its target directory on PATH.
+    assert ran == [
+        f"{bin_dir / 'curl'} -fsSL https://astral.sh/uv/install.sh",
+        f"installed-uvx {FROM} cheese install --harness codex",
+    ]
+
+
+def test_a_failed_uv_install_stops_the_run_and_names_the_real_failure(tmp_path: Path) -> None:
+    """`curl … | sh` exits 0 when curl fails, so the download must be checked, not assumed.
+
+    Without the check the run continues to `exec uvx` and dies as `uvx: not
+    found`, blaming the wrong thing on a host where nothing was installed.
+    """
+    bin_dir = tmp_path / "bin"
+    # A curl that resolves nothing: the pipeline still exits 0, and no uv appears.
+    _shim(bin_dir, "curl")
+
+    completed, ran = _invoke(tmp_path, "--harness", "codex", path=bin_dir, home=tmp_path / "home")
+
+    assert completed.returncode == 1
+    assert "uv install failed" in completed.stderr
+    assert ran == [f"{bin_dir / 'curl'} -fsSL https://astral.sh/uv/install.sh"]
+
+
+def test_the_entry_point_is_executable_and_reaches_for_no_github_cli() -> None:
+    """The whole point: the one-liner works on a host that has no `gh`."""
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert "gh " not in source
+    assert SCRIPT_PATH.stat().st_mode & stat_mod.S_IXUSR

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -70,6 +70,12 @@ class RecordingRunner:
         return CommandOutcome(argv=tuple(argv), exit_code=0, stdout="", stderr="", elapsed_ms=0)
 
 
+def make_repository(path: Path) -> Path:
+    """A real git repository, which ``--repo`` now requires its paths to be."""
+    (path / ".git").mkdir(parents=True)
+    return path
+
+
 def manifest_state() -> DesiredState:
     return DesiredState(
         harnesses=("claude-code",),
@@ -304,8 +310,7 @@ def test_json_flag_without_config_runs_headless_from_the_default_manifest(
 def test_options_build_the_desired_state_without_a_manifest(
     tmp_path: Path, config_home: Path, command_runner: RecordingRunner, calls: dict
 ) -> None:
-    project = tmp_path / "code" / "project"
-    project.mkdir(parents=True)
+    project = make_repository(tmp_path / "code" / "project")
 
     result = runner.invoke(
         app,
@@ -370,8 +375,7 @@ def test_a_relative_repo_option_resolves_against_the_working_directory(
     calls: dict,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    project = tmp_path / "code" / "project"
-    project.mkdir(parents=True)
+    project = make_repository(tmp_path / "code" / "project")
     monkeypatch.chdir(project.parent)
 
     result = runner.invoke(app, ["install", "--harness", "claude-code", "--repo", "project"])
@@ -392,8 +396,7 @@ def test_options_are_ephemeral_unless_write_config_is_passed(
 def test_write_config_persists_the_option_built_manifest(
     tmp_path: Path, config_home: Path, command_runner: RecordingRunner, calls: dict
 ) -> None:
-    project = tmp_path / "code" / "project"
-    project.mkdir(parents=True)
+    project = make_repository(tmp_path / "code" / "project")
 
     result = runner.invoke(
         app,

--- a/tests/python/test_desired_state.py
+++ b/tests/python/test_desired_state.py
@@ -8,9 +8,11 @@ import pytest
 from cheese_flow import desired_state as ds
 from cheese_flow.desired_state import (
     ManifestError,
+    OptionError,
     default_config_path,
     load_desired_state,
     save_desired_state,
+    state_from_options,
 )
 from cheese_flow.models import DEFAULT_MAX_DEPTH, DesiredState, RepositorySelection
 from pydantic import ValidationError
@@ -481,3 +483,57 @@ def test_the_wizard_cannot_build_a_state_the_loader_would_reject() -> None:
         )
 
     assert "selected repositories are not under any search root: /srv/b/foo" in str(caught.value)
+
+
+# ─── Options, not a manifest ─────────────────────────────────────────────────
+
+
+def a_repository(path: Path) -> Path:
+    (path / ".git").mkdir(parents=True)
+    return path.resolve()
+
+
+def test_state_from_options_accepts_repositories_and_roots_them_at_their_parents(
+    tmp_path: Path,
+) -> None:
+    repository = a_repository(tmp_path / "code" / "project")
+
+    state = state_from_options(("codex",), ("hallouminate", "easy-cheese"), (repository,))
+
+    assert state.repositories.selected == (repository,)
+    assert state.repositories.search_roots == (repository.parent,)
+
+
+def test_state_from_options_rejects_a_repo_path_that_is_not_a_repository(tmp_path: Path) -> None:
+    """A path the installer cannot index fails here, not as a blocked step mid-apply."""
+    stranger = tmp_path / "not-a-repository"
+    stranger.mkdir()
+
+    with pytest.raises(OptionError) as caught:
+        state_from_options(("codex",), ("hallouminate", "easy-cheese"), (stranger,))
+
+    assert str(caught.value) == f"not a git repository: {stranger.resolve()}"
+
+
+def test_state_from_options_names_every_rejected_path(tmp_path: Path) -> None:
+    """A directory that is not a repository and a path that is not there at all."""
+    first = tmp_path / "one"
+    second = tmp_path / "two"
+    first.mkdir()  # `second` is never created: the mistyped-path case.
+    repository = a_repository(tmp_path / "real")
+
+    with pytest.raises(OptionError) as caught:
+        state_from_options(("codex",), ("hallouminate", "easy-cheese"), (first, repository, second))
+
+    assert str(caught.value) == f"not a git repository: {first.resolve()}, {second.resolve()}"
+
+
+def test_state_from_options_accepts_a_linked_worktree(tmp_path: Path) -> None:
+    """A worktree's ``.git`` is a file, not a directory; it is still a repository."""
+    worktree = tmp_path / "code" / "linked"
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text("gitdir: /elsewhere/.git/worktrees/linked\n", encoding="utf-8")
+
+    state = state_from_options(("codex",), ("hallouminate", "easy-cheese"), (worktree,))
+
+    assert state.repositories.selected == (worktree.resolve(),)

--- a/tests/python/test_doctor.py
+++ b/tests/python/test_doctor.py
@@ -116,24 +116,9 @@ def _readonly_script(version: str) -> dict[tuple[str, ...], CommandOutcome]:
     def ok(argv: tuple[str, ...], stdout: str) -> CommandOutcome:
         return CommandOutcome(argv=argv, exit_code=0, stdout=stdout, stderr="", elapsed_ms=1)
 
-    # `gh skill list` reports the whole pack; the postcondition needs the full
-    # core quorum, and each entry carries the sourceURL gh derives from the
-    # installed SKILL.md frontmatter.
-    skills = json.dumps(
-        [
-            {
-                "agentHosts": ["claude-code", "cursor"],
-                "scope": "user",
-                "skillName": name,
-                "sourceURL": "https://github.com/paulnsorensen/easy-cheese",
-            }
-            for name in sorted(CORE_SKILLS)
-        ]
-    )
     marketplaces = json.dumps(
         [{"name": "hallouminate", "source": "github", "repo": "paulnsorensen/hallouminate"}]
     )
-    fields = "agentHosts,scope,skillName,sourceURL"
     return {
         ("npm", "view", "hallouminate@latest", "version"): ok(
             ("npm", "view", "hallouminate@latest", "version"), version
@@ -147,21 +132,27 @@ def _readonly_script(version: str) -> dict[tuple[str, ...], CommandOutcome]:
             json.dumps([{"id": "hallouminate@hallouminate", "scope": "user", "enabled": True}]),
         ),
         ("hallouminate", "config", "validate"): ok(("hallouminate", "config", "validate"), "ok"),
-        ("gh", "skill", "list", "--agent", "claude-code", "--scope", "user", "--json", fields): ok(
-            ("gh", "skill", "list", "--agent", "claude-code", "--scope", "user", "--json", fields),
-            skills,
-        ),
-        ("gh", "skill", "list", "--agent", "cursor", "--scope", "user", "--json", fields): ok(
-            ("gh", "skill", "list", "--agent", "cursor", "--scope", "user", "--json", fields),
-            skills,
-        ),
     }
+
+
+def install_core_skills(home: Path) -> None:
+    """Put the easy-cheese pack where a global `skills add` leaves it.
+
+    Claude Code reads its own directory, Cursor the canonical store both share.
+    """
+    for relative in (".claude/skills", ".agents/skills"):
+        for name in sorted(CORE_SKILLS):
+            directory = home / relative / name
+            directory.mkdir(parents=True, exist_ok=True)
+            (directory / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
 
 
 def test_doctor_with_real_adapters_runs_only_read_only_commands(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    install_core_skills(tmp_path)
     cursor_config = tmp_path / ".cursor" / "mcp.json"
     cursor_config.parent.mkdir()
     cursor_config.write_text(
@@ -190,28 +181,6 @@ def test_doctor_with_real_adapters_runs_only_read_only_commands(
         ("claude", "plugin", "marketplace", "list", "--json"),
         ("claude", "plugin", "list", "--json"),
         ("hallouminate", "config", "validate"),
-        (
-            "gh",
-            "skill",
-            "list",
-            "--agent",
-            "claude-code",
-            "--scope",
-            "user",
-            "--json",
-            "agentHosts,scope,skillName,sourceURL",
-        ),
-        (
-            "gh",
-            "skill",
-            "list",
-            "--agent",
-            "cursor",
-            "--scope",
-            "user",
-            "--json",
-            "agentHosts,scope,skillName,sourceURL",
-        ),
     ]
     assert cursor_config.read_bytes() == before
     assert [result.step_id for result in report.results] == [

--- a/tests/python/test_install.py
+++ b/tests/python/test_install.py
@@ -499,6 +499,57 @@ def test_repository_is_revalidated_at_its_own_first_use_not_once_per_run(tmp_pat
     assert str(later) in (report.results[1].remediation or "")
 
 
+@pytest.mark.parametrize(
+    ("name", "drift", "expected"),
+    [
+        pytest.param(
+            "gone",
+            lambda repository: _rename(repository),
+            "is not present at its planned path",
+            id="path-disappeared",
+        ),
+        pytest.param(
+            "stranger",
+            lambda repository: (repository / ".git").rmdir(),
+            "is not a git repository",
+            id="directory-that-is-not-a-repository",
+        ),
+    ],
+)
+def test_blocked_repository_says_which_of_the_two_absences_it_hit(
+    name: str,
+    drift: Callable[[Path], None],
+    expected: str,
+    tmp_path: Path,
+) -> None:
+    """Discovery reports one absence; the remediation must not guess at the cause.
+
+    A directory that is simply not a repository — one a user may have named by
+    mistake and that was never a repository — must not be reported as one that
+    stopped being a repository at its planned path.
+    """
+    early = make_repository(tmp_path / "early")
+    later = make_repository(tmp_path / name)
+    steps = (
+        step("init-early", repository=early, phase=Phase.INITIALIZE),
+        step("init-later", repository=later, phase=Phase.INITIALIZE),
+    )
+    adapter = ScriptedAdapter("hallouminate", steps)
+    runner = MutatingRunner(("run", "init-early"), lambda: drift(later))
+
+    report = apply_install_plan(plan_of(*steps), runner, adapters={"hallouminate": adapter})
+
+    assert statuses(report) == [
+        ("init-early", StepStatus.SUCCEEDED),
+        ("init-later", StepStatus.BLOCKED),
+    ]
+    assert report.results[1].remediation == f"{later} {expected}"
+
+
+def _rename(repository: Path) -> None:
+    repository.rename(repository.with_name(f"{repository.name}-moved"))
+
+
 def test_per_repository_revalidation_still_sees_cross_repository_name_collisions(
     tmp_path: Path,
 ) -> None:

--- a/tests/python/test_integration.py
+++ b/tests/python/test_integration.py
@@ -55,15 +55,17 @@ DECOY_MARKETPLACE_ROOT = "/home/paul/Dev/paulnsorensen/hallouminate"
 # without this user ever having installed it.
 FOREIGN_PROJECT_PLUGIN = PLUGIN_ID
 
-# A skill the user wrote by hand that shares an easy-cheese name. `gh skill
-# install` never touched it, so gh reports no sourceURL for it.
-LOCAL_LOOKALIKE_SKILL = "cook"
-
-# What `gh skill install <repo> --all` puts on disk, and the repo gh records as
-# each skill's provenance. Spelled out rather than imported: dropping one of
-# these must fail the postcondition, not follow it.
+# What `skills add <repo> --skill '*' --global` puts on disk. Spelled out
+# rather than imported: dropping one of these must fail the postcondition, not
+# follow it.
 EASY_CHEESE_SOURCE = "paulnsorensen/easy-cheese"
 EASY_CHEESE_SKILLS = ("mold", "cook", "press", "age", "cure", "plate", "cheese")
+
+# Where the `skills` CLI writes a global install: one canonical store, plus a
+# per-skill symlink into the directory of every agent that does not read the
+# canonical layout already. Codex and Cursor do read it; Claude Code does not.
+CANONICAL_SKILLS_DIR = ".agents/skills"
+CLAUDE_SKILLS_DIR = ".claude/skills"
 
 # The harness-native MCP config files the adapters read. Spelled out here on
 # purpose: if production moves one of these, the fake writes the old path and
@@ -138,8 +140,23 @@ class FakeWorld:
         self.plugins.add(PLUGIN_ID)
         self.config_initialized = True
         for harness in harnesses:
-            self.skills[harness] = list(EASY_CHEESE_SKILLS)
+            self.install_skills(harness)
             self.write_tilth_entry(harness)
+
+    def install_skills(self, harness: str) -> None:
+        """What ``skills add <repo> --skill '*' --agent <harness> --global`` leaves on disk."""
+        self.skills[harness] = list(EASY_CHEESE_SKILLS)
+        canonical = self.home / CANONICAL_SKILLS_DIR
+        for name in EASY_CHEESE_SKILLS:
+            (canonical / name).mkdir(parents=True, exist_ok=True)
+            (canonical / name / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+        if harness == "claude-code":
+            linked = self.home / CLAUDE_SKILLS_DIR
+            linked.mkdir(parents=True, exist_ok=True)
+            for name in EASY_CHEESE_SKILLS:
+                link = linked / name
+                if not link.exists():
+                    link.symlink_to(canonical / name, target_is_directory=True)
 
     def write_tilth_entry(self, harness: str) -> None:
         """What ``npx tilth install <harness> --edit`` leaves in the native config."""
@@ -200,11 +217,9 @@ class FakeWorld:
             if cwd in self.indexed_repos:
                 return _ok(key, '[{"path": ".hallouminate/wiki/index.md"}]')
             return _fail(key, "no corpus")
-        if key[:3] == ("gh", "skill", "install"):
-            self.skills[_agent_of(key)] = list(EASY_CHEESE_SKILLS)
+        if key[:4] == ("npx", "-y", "skills@latest", "add"):
+            self.install_skills(_agent_of(key))
             return _ok(key)
-        if key[:3] == ("gh", "skill", "list"):
-            return _ok(key, json.dumps(self._skill_entries(_agent_of(key))))
         if key[:2] == ("npx", "--yes") and key[2].startswith("tilth@"):
             self.write_tilth_entry(key[4])
             return _ok(key)
@@ -283,34 +298,6 @@ class FakeWorld:
         if cwd in self.initialized_repos:
             return _ok(key, f"  - repo:{cwd.name}:wiki  → {cwd}/./.hallouminate/wiki")
         return _fail(key, f"{cwd} has no corpus")
-
-    def _skill_entries(self, harness: str) -> list[dict[str, object]]:
-        """Rows a real `gh skill list --json` returns.
-
-        ``gh skill install`` records provenance in the installed SKILL.md's
-        ``metadata.github-repo`` frontmatter, which gh surfaces as ``sourceURL``
-        — so only skills gh installed carry one. A hand-written skill sharing an
-        easy-cheese name is always present with an empty ``sourceURL``, and it
-        must never contribute to the quorum.
-        """
-        entries: list[dict[str, object]] = [
-            {
-                "skillName": LOCAL_LOOKALIKE_SKILL,
-                "scope": "user",
-                "agentHosts": [harness],
-                "sourceURL": "",
-            }
-        ]
-        entries += [
-            {
-                "skillName": name,
-                "scope": "user",
-                "agentHosts": [harness],
-                "sourceURL": f"https://github.com/{EASY_CHEESE_SOURCE}",
-            }
-            for name in self.skills.get(harness, [])
-        ]
-        return entries
 
     def _next_version(self, package: str) -> str:
         answers = self._versions.setdefault(package, ["1.0.0"])
@@ -511,15 +498,17 @@ def test_dry_run_emits_the_exact_plan_without_executing_package_code(
         ["codex", "plugin", "add", PLUGIN_ID],
         ["hallouminate", "config", "init"],
         [
-            "gh",
-            "skill",
-            "install",
-            "paulnsorensen/easy-cheese",
-            "--all",
+            "npx",
+            "-y",
+            "skills@latest",
+            "add",
+            EASY_CHEESE_SOURCE,
+            "--skill",
+            "*",
             "--agent",
             "codex",
-            "--scope",
-            "user",
+            "--global",
+            "--yes",
         ],
         ["npx", "--yes", "tilth@4.5.6", "install", "codex", "--edit"],
     ]
@@ -576,7 +565,10 @@ def test_complete_config_runs_headlessly_and_stdout_is_one_json_document(
         (f"hallouminate:init-repo:{key}", "succeeded"),
         (f"hallouminate:index:{key}", "succeeded"),
         ("easy-cheese:install:claude-code", "succeeded"),
-        ("easy-cheese:install:cursor", "succeeded"),
+        # Cursor reads the same canonical skills store Claude Code's install
+        # just filled, so its postcondition already holds and no second
+        # `skills add` runs.
+        ("easy-cheese:install:cursor", "skipped"),
         ("tilth:register:claude-code", "succeeded"),
         ("tilth:register:cursor", "succeeded"),
     ]
@@ -600,29 +592,13 @@ READ_ONLY_PROBES = [
     ("codex", "plugin", "marketplace", "list", "--json"),
     ("codex", "plugin", "list", "--json"),
     ("hallouminate", "config", "validate"),
-    (
-        "gh",
-        "skill",
-        "list",
-        "--agent",
-        "claude-code",
-        "--scope",
-        "user",
-        "--json",
-        "agentHosts,scope,skillName,sourceURL",
-    ),
-    (
-        "gh",
-        "skill",
-        "list",
-        "--agent",
-        "codex",
-        "--scope",
-        "user",
-        "--json",
-        "agentHosts,scope,skillName,sourceURL",
-    ),
 ]
+"""Every command a fully converged run may still run.
+
+easy-cheese contributes none: its postcondition reads the installed files
+directly, so a converged host needs no child process to prove the pack is
+there — and a host with no GitHub CLI reaches the same verdict.
+"""
 
 
 def test_already_satisfied_postconditions_skip_every_mutation(
@@ -857,6 +833,79 @@ def test_doctor_reports_every_unsatisfied_postcondition_independently(
     assert snapshot(home) == {}
 
 
+# ─── A bare cloud box: no `gh`, no repository at the named path ──────────────
+
+
+class GhlessWorld(FakeWorld):
+    """A host where ``gh`` is not installed, exactly as a cloud box answers.
+
+    Anything reaching for ``gh`` dies the way ``execvp`` does — exit 127 with
+    the kernel's message — so a step that still depends on it cannot converge
+    and cannot hide behind a modelled success.
+    """
+
+    def _dispatch(self, key: tuple[str, ...], cwd: Path | None) -> CommandOutcome:
+        if key[0] == "gh":
+            return CommandOutcome(
+                argv=key,
+                exit_code=127,
+                stdout="",
+                stderr="could not run gh: No such file or directory",
+                elapsed_ms=1,
+            )
+        return super()._dispatch(key, cwd)
+
+
+def test_install_converges_every_easy_cheese_step_with_gh_absent(
+    tmp_path: Path, home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The failure this whole change exists for: `gh` was an ambient prerequisite."""
+    world = wire(monkeypatch, GhlessWorld(home))
+    manifest = write_manifest(
+        tmp_path,
+        manifest_text(
+            harnesses=["claude-code", "codex", "cursor"],
+            components=["hallouminate", "easy-cheese"],
+        ),
+    )
+
+    result = cli_runner.invoke(app, ["install", "--config", str(manifest)])
+
+    assert result.exit_code == 0, result.stderr
+    document = json.loads(result.stdout)
+    easy_cheese = [entry for entry in document["results"] if entry["component"] == "easy-cheese"]
+    assert [entry["step_id"] for entry in easy_cheese] == [
+        "easy-cheese:install:claude-code",
+        "easy-cheese:install:codex",
+        "easy-cheese:install:cursor",
+    ]
+    assert {entry["status"] for entry in easy_cheese} <= {"succeeded", "skipped"}
+    assert not any(argv[0] == "gh" for argv in world.argvs())
+    # The pack really is on disk for each harness, not merely reported so.
+    for name in EASY_CHEESE_SKILLS:
+        assert (home / CANONICAL_SKILLS_DIR / name / "SKILL.md").is_file()
+        assert (home / CLAUDE_SKILLS_DIR / name / "SKILL.md").is_file()
+
+
+def test_a_repo_option_that_is_not_a_repository_exits_two_before_planning(
+    tmp_path: Path, home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """acceptance:25 — a stranger path fails at parse time, not as a blocked step mid-apply."""
+    stranger = tmp_path / "not-a-repository"
+    stranger.mkdir()
+    world = wire(monkeypatch, FakeWorld(home))
+
+    result = cli_runner.invoke(
+        app, ["install", "--harness", "claude-code", "--repo", str(stranger)]
+    )
+
+    assert result.exit_code == 2
+    assert str(stranger) in result.stderr
+    assert result.stdout == "", "nothing was planned, so there is no report to emit"
+    assert world.calls == []
+    assert snapshot(home) == {}
+
+
 # ─── acceptance:154 — discovered repositories start unchecked ────────────────
 
 
@@ -1045,9 +1094,14 @@ def test_wizard_state_round_trips_through_disk_to_an_identical_plan(
 
     report = apply_install_plan(from_disk, apply_world, adapters=adapters)
 
-    assert [result.status for result in report.results] == [StepStatus.SUCCEEDED] * len(
-        from_disk.steps
-    )
+    # Cursor's easy-cheese step is the one exception: Claude Code's install
+    # already filled the canonical skills store Cursor reads, so it converges
+    # without running.
+    reached = {StepStatus.SUCCEEDED, StepStatus.SKIPPED}
+    assert {result.status for result in report.results} <= reached
+    assert [result.step_id for result in report.results if result.status is StepStatus.SKIPPED] == [
+        "easy-cheese:install:cursor"
+    ]
     assert apply_world.initialized_repos == {repository}
 
 


### PR DESCRIPTION
**Semantics-altering.** The easy-cheese component installs and verifies itself a different way, `--repo` rejects more inputs, and one remediation message changed.

## Why

`cheese install` could not converge on a bare cloud box. `easy-cheese` declared no install step — its first and only step was `gh skill install` — so the GitHub CLI was an undeclared ambient prerequisite. Two cloud-environment runs both ended:

```
easy-cheese:install:claude-code   status: failed   exit_code: 127
stderr_tail: "could not run gh: No such file or directory"
```

`easy-cheese` is in `REQUIRED_COMPONENTS`, so no manifest could route around it.

## What changed

**Install through the `skills` npm CLI.** Each selected harness now runs:

```
npx -y skills@latest add paulnsorensen/easy-cheese --skill '*' --agent <token> --global --yes
```

`npm` is already a hard dependency — `hallouminate` installs itself with `npm install -g` — so this adds no prerequisite. `AGENT_TOKENS` records the `--agent` tokens the CLI accepts; a harness with no token contributes no step rather than one that could never converge. All three of `claude-code`, `codex`, and `cursor` are accepted, read from the published package's own agent registry.

**Verify on disk, not through `gh skill list --json`.** The postcondition asserts the core-skill quorum is present as `<skills dir>/<name>/SKILL.md`. It spawns no child process, so a host with no GitHub CLI verifies exactly as well as one that has it. The directories mirror what the CLI actually writes for a global install: Codex and Cursor read the canonical `~/.agents/skills` store; Claude Code reads `$CLAUDE_CONFIG_DIR|~/.claude/skills`, which receives a symlink per skill.

This is a knowingly weaker check — it is name-based, so hand-written skills sharing all seven names read as installed. `sourceURL` was the only provenance signal and #86 established it reads empty in practice; the spec accepted the trade explicitly.

**Two adjacent failures from the same cloud run.** A `--repo` path that is not a git repository is now rejected at parse time with the path named (`cheese install --repo /tmp` exits 2 before planning) instead of becoming a `blocked` step mid-apply. And a blocked repository says which absence it hit: a path that is gone versus a directory that is not a repository — the old message claimed a path was "no longer a repository" when it may never have been one.

**`bootstrap.sh`.** One line on a bare host:

```bash
curl -fsSL https://raw.githubusercontent.com/paulnsorensen/cheese-flow/main/bootstrap.sh \
  | sh -s -- --harness claude-code
```

It installs `uv` when absent and verifies the install landed — a failed `curl` in a POSIX pipeline exits 0, so without the check the run would die later as a bare `uvx: not found`. Headless-only by construction: `curl | sh` consumes the stdin the wizard reads.

## What a reviewer should verify

1. **The install paths are right.** `skills_directory` claims Codex and Cursor are served from `~/.agents/skills` and only Claude Code gets its own directory. That comes from reading `skills@1.5.21`'s `getAgentBaseDir` / `installSkillForAgent`, not from an observed install — the sandboxed live run was declined by this session's permission gate. If those paths are wrong, the postcondition never converges.
2. **The Cursor "skipped" status is expected.** Codex and Cursor share the canonical store, so installing for one satisfies the other's postcondition and the second step reports `skipped`, not `succeeded`. That is the installer's declared semantics — the CLI would write identical files — but it is a visible report change.
3. **The weaker postcondition is acceptable.** Named-based identity, per the spec's non-goals.

## Verification

- `just build-ci` — 457 passed.
- Regression for the original failure: `test_install_converges_every_easy_cheese_step_with_gh_absent` runs a full headless install through a `CommandRunner` that answers every `gh` call with exit 127 and the kernel's own message, then asserts the pack is really on disk.
- `bootstrap.sh` is covered black-box: argument forwarding, the install-uv-first path, and the failed-download path.

Refs #86, #87. Does not touch #88 (whether `easy-cheese` belongs in `REQUIRED_COMPONENTS`) — removing the `gh` prerequisite is what made that question urgent; it is not answered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
