### PR TITLE
fix(runner): close stdin so a prompting child fails instead of hanging

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,7 +13,10 @@ REPOSITORY="git+https://github.com/paulnsorensen/cheese-flow"
 
 if ! command -v uvx >/dev/null 2>&1; then
     echo "cheese: installing uv" >&2
-    curl -fsSL https://astral.sh/uv/install.sh | sh
+    # Bounded on purpose: a box with no egress to astral.sh blocks in connect()
+    # with no timeout of its own, and this runs before the installer's own
+    # per-command timeout exists to catch it.
+    curl -fsSL --connect-timeout 10 --max-time 120 https://astral.sh/uv/install.sh | sh
     # The uv installer targets ~/.local/bin, which a non-login shell may not
     # already carry; without this, the exec below fails on the host we just
     # provisioned.

--- a/python/cheese_flow/runner.py
+++ b/python/cheese_flow/runner.py
@@ -67,6 +67,13 @@ class SubprocessRunner:
                 command,
                 cwd=cwd,
                 env=self._environment(),
+                # Nothing cheese-flow runs is interactive, and an inherited
+                # stdin makes that a hope rather than a fact: a child that
+                # decides to prompt — a plugin CLI asking to trust a source, an
+                # installer confirming a scope — sits on the terminal until the
+                # timeout kills it, once per step. Reading EOF instead, it
+                # fails immediately and the report names it.
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,

--- a/tests/python/test_bootstrap.py
+++ b/tests/python/test_bootstrap.py
@@ -105,7 +105,8 @@ def test_installs_uv_first_when_the_host_has_none_and_then_runs_it(tmp_path: Pat
     # `uvx` existed nowhere on PATH, so reaching it at all proves the script
     # both installed uv and put its target directory on PATH.
     assert ran == [
-        f"{bin_dir / 'curl'} -fsSL https://astral.sh/uv/install.sh",
+        f"{bin_dir / 'curl'} -fsSL --connect-timeout 10 --max-time 120 "
+        "https://astral.sh/uv/install.sh",
         f"installed-uvx {FROM} cheese install --harness codex",
     ]
 
@@ -124,7 +125,10 @@ def test_a_failed_uv_install_stops_the_run_and_names_the_real_failure(tmp_path: 
 
     assert completed.returncode == 1
     assert "uv install failed" in completed.stderr
-    assert ran == [f"{bin_dir / 'curl'} -fsSL https://astral.sh/uv/install.sh"]
+    assert ran == [
+        f"{bin_dir / 'curl'} -fsSL --connect-timeout 10 --max-time 120 "
+        "https://astral.sh/uv/install.sh"
+    ]
 
 
 def test_the_entry_point_is_executable_and_reaches_for_no_github_cli() -> None:

--- a/tests/python/test_runner.py
+++ b/tests/python/test_runner.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import signal
 import subprocess
 import threading
 import time
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -65,6 +67,58 @@ def test_env_overlay_adds_variables_without_dropping_the_inherited_environment()
 
     assert outcome.exit_code == 0
     assert outcome.stdout == "brie|set"
+
+
+@contextlib.contextmanager
+def readable_stdin(content: bytes) -> Iterator[None]:
+    """Give this process a stdin holding ``content``, then hand it back.
+
+    Asserting a child cannot reach the parent's stdin needs a parent stdin
+    worth reaching. Under pytest fd 0 is already spent, so a child that
+    inherits it sees the same EOF the fix produces and the assertion proves
+    nothing. The write end closes before the child starts, so a leak shows up
+    as content rather than as a hung test.
+    """
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, content)
+    os.close(write_fd)
+    saved = os.dup(0)
+    try:
+        os.dup2(read_fd, 0)
+        os.close(read_fd)
+        yield
+    finally:
+        os.dup2(saved, 0)
+        os.close(saved)
+
+
+def test_a_child_cannot_read_the_parents_stdin() -> None:
+    """Nothing cheese-flow runs is interactive, and the runner must enforce that.
+
+    With stdin inherited, a plugin CLI asking to trust a source or an installer
+    confirming a scope holds the terminal until the timeout kills it — 15
+    minutes per step by default, with no progress output naming the step that
+    is stuck.
+    """
+    runner = SubprocessRunner(timeout=5.0)
+
+    with readable_stdin(b"leaked\n"):
+        outcome = runner.run(("cat",))
+
+    assert outcome.exit_code == 0
+    assert outcome.stdout == "", "the child read the parent's stdin"
+
+
+def test_a_child_prompting_for_input_fails_fast_instead_of_waiting() -> None:
+    """The shape of the real failure: the prompt gets EOF and the step reports it."""
+    runner = SubprocessRunner(timeout=5.0)
+
+    with readable_stdin(b"yes\n"):
+        outcome = runner.run(("sh", "-c", 'printf "trust this source? " >&2; read answer'))
+
+    assert outcome.exit_code != 0
+    assert outcome.exit_code != TIMEOUT_EXIT_CODE
+    assert "trust this source?" in outcome.stderr
 
 
 def test_forward_signal_without_an_active_child_is_a_no_op() -> None:


### PR DESCRIPTION
**Semantics-altering.** Child processes no longer receive the parent's stdin, so a command that prompts fails instead of blocking.

## Why

A cloud container running the `bootstrap.sh` one-liner from #89 hung. The easy-cheese step was not the cause — every prompt in the `skills add` path is guarded by the flags we pass. The cause is structural, and it predates #89:

- `SubprocessRunner` passed `stdout` and `stderr` as pipes and said nothing about `stdin`, so **every child inherited the parent's terminal**. "Nothing cheese-flow runs is interactive" was a hope, not a property the runner enforced.
- `DEFAULT_TIMEOUT_SECONDS` is 900. A child sitting on a prompt burns fifteen minutes per step, across up to eleven steps.
- `_announce` prints the whole plan *before* apply starts and nothing during it, so the output cannot say which step is stuck.

Together those three read, from outside the container, as an indefinite hang.

## What changed

**`stdin=subprocess.DEVNULL` for every child** (`runner.py`). A prompt now reads EOF, the step fails in milliseconds, and the prompt text lands in the step's `stderr_tail` — so the offending command names itself in the JSON report instead of dying silently at the timeout.

**Bounded the uv download** (`bootstrap.sh`): `--connect-timeout 10 --max-time 120`. A host with no egress to `astral.sh` blocks in `connect()` with no timeout of its own, and that runs before the installer's per-command timeout exists to catch it.

## What a reviewer should verify

**That the tests have teeth.** Both new runner tests establish a readable stdin with `os.dup2` before running the child. That is the whole point: under pytest fd 0 is already at EOF, so a child that inherits it sees exactly what the fix produces and the assertion proves nothing. My first attempt at these tests passed with the fix reverted — including under a real pty — which is why the pipe is there.

Confirmed by reverting `stdin=subprocess.DEVNULL` and re-running:

```
FAILED test_a_child_cannot_read_the_parents_stdin
        assert outcome.stdout == ""  ->  'leaked\n'
FAILED test_a_child_prompting_for_input_fails_fast_instead_of_waiting
        assert outcome.exit_code != 0  ->  0
```

**That no step legitimately wants stdin.** Every command the adapters emit is an install or a probe — `npm install -g`, `npx`, plugin registration, `hallouminate config validate`. The interactive wizard reads `sys.stdin` in the parent process and is untouched by this.

## Verification

- `just build` — 459 passed.
- Red-first confirmed for both new tests, output above.

Follow-up to #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
