### PR TITLE
test(smoke): real bounded install on a bare host — and the bug it found

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -52,12 +52,24 @@ jobs:
             fi
           done
 
+      # Registering a plugin with a harness needs that harness's CLI present.
+      # It is a prerequisite of the composition, not something cheese-flow
+      # installs — the cloud box this job models is one already running the
+      # agent. Without it the run fails on `could not run claude`.
+      - name: Install the harness CLI
+        run: npm install -g ${{ matrix.harness == 'codex' && '@openai/codex' || '@anthropic-ai/claude-code' }}
+
       - name: Install through bootstrap.sh
+        shell: bash
         env:
           # Without this the run installs the default branch and this job passes
           # on code nobody is reviewing.
           CHEESE_REPOSITORY: ${{ github.workspace }}
         run: |
+          # pipefail because a pipeline's status is its last command's: without
+          # it `tee` reports success and a failed install passes this step. That
+          # is the same trap bootstrap.sh guards against after `curl … | sh`.
+          set -o pipefail
           # `timeout` is the point: a child that waits on stdin turns into a
           # failing exit code here instead of a job that burns its 20 minutes
           # and reports nothing about which step is stuck.
@@ -65,7 +77,11 @@ jobs:
             --harness ${{ matrix.harness }} --json --timeout 240 \
             </dev/null | tee report.json
 
+      # `always()` so a nonzero install still gets graded: the step table naming
+      # which postcondition went unmet is the whole diagnostic value, and a bare
+      # failed exit code from the step above says nothing about where.
       - name: Verify every step converged
+        if: always()
         run: python3 tests/smoke/assert_report.py report.json
 
       - name: Upload the report

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,77 @@
+name: Smoke
+
+# A real `cheese install` on a runner stripped of gh and uv — the bare cloud box
+# the curl-pipe-sh one-liner claims to support. The unit suite shims every child
+# process, so it can prove control flow but never that the children terminate;
+# this job is the only gate that would catch a step sitting on a prompt.
+#
+# Scoped to the install path because it depends on npm and GitHub being
+# reachable, and an unrelated PR should not go red over a registry blip.
+
+on:
+  pull_request:
+    paths:
+      - bootstrap.sh
+      - python/cheese_flow/runner.py
+      - python/cheese_flow/install.py
+      - python/cheese_flow/adapters/**
+      - tests/smoke/**
+      - .github/workflows/smoke.yml
+  schedule:
+    # Catches breakage that arrives from outside the repository — a published
+    # `skills` release, an npm change — which no PR trigger ever would.
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        harness: [claude-code, codex]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.2
+
+      # Deliberately no astral-sh/setup-uv: bootstrap.sh installing uv itself is
+      # half of what this job verifies.
+      - name: Strip the tools a bare host would not have
+        run: |
+          sudo rm -f "$(command -v gh)" || true
+          sudo rm -rf "$HOME/.cargo/bin/uv" "$HOME/.cargo/bin/uvx" || true
+          for tool in gh uv uvx; do
+            if command -v "$tool" >/dev/null 2>&1; then
+              echo "::error::$tool is still on PATH at $(command -v "$tool")"
+              exit 1
+            fi
+          done
+
+      - name: Install through bootstrap.sh
+        env:
+          # Without this the run installs the default branch and this job passes
+          # on code nobody is reviewing.
+          CHEESE_REPOSITORY: ${{ github.workspace }}
+        run: |
+          # `timeout` is the point: a child that waits on stdin turns into a
+          # failing exit code here instead of a job that burns its 20 minutes
+          # and reports nothing about which step is stuck.
+          timeout --signal=KILL 900 sh ./bootstrap.sh \
+            --harness ${{ matrix.harness }} --json --timeout 240 \
+            </dev/null | tee report.json
+
+      - name: Verify every step converged
+        run: python3 tests/smoke/assert_report.py report.json
+
+      - name: Upload the report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-report-${{ matrix.harness }}
+          path: report.json
+          if-no-files-found: warn

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,11 @@ if ! command -v uvx >/dev/null 2>&1; then
     # Bounded on purpose: a box with no egress to astral.sh blocks in connect()
     # with no timeout of its own, and this runs before the installer's own
     # per-command timeout exists to catch it.
-    curl -fsSL --connect-timeout 10 --max-time 120 https://astral.sh/uv/install.sh | sh
+    # `>&2` because stdout belongs to `cheese install --json`. The uv installer
+    # narrates its progress on stdout, which lands ahead of the JSON document
+    # and breaks any caller piping this one-liner into a parser — on precisely
+    # the bare hosts where uv has to be installed.
+    curl -fsSL --connect-timeout 10 --max-time 120 https://astral.sh/uv/install.sh | sh >&2
     # The uv installer targets ~/.local/bin, which a non-login shell may not
     # already carry; without this, the exec below fails on the host we just
     # provisioned.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,7 +9,11 @@
 # which is what the interactive wizard reads. Pass the state options.
 set -eu
 
-REPOSITORY="git+https://github.com/paulnsorensen/cheese-flow"
+# Overridable so a smoke test can install the checkout under review. Left to its
+# default this resolves to the repository's default branch, which is what the
+# curl-pipe-sh line above wants and what a CI job testing a pull request must
+# not get.
+REPOSITORY="${CHEESE_REPOSITORY:-git+https://github.com/paulnsorensen/cheese-flow}"
 
 if ! command -v uvx >/dev/null 2>&1; then
     echo "cheese: installing uv" >&2

--- a/justfile
+++ b/justfile
@@ -27,6 +27,24 @@ build-ci:
     uv run --group dev pytest
     @echo "CI build passed"
 
+# Real install into a throwaway HOME, bounded and non-interactive (default: claude-code)
+smoke harness="claude-code":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # A shimmed test proves control flow; only a real run proves the children
+    # terminate. `timeout` turns the hang this exists to catch into a failing
+    # exit code, and </dev/null makes a prompt fail rather than wait forever.
+    sandbox=$(mktemp -d)
+    trap 'rm -rf "$sandbox"' EXIT
+    echo "smoke: installing --harness {{harness}} into $sandbox" >&2
+    CHEESE_REPOSITORY="$PWD" \
+    HOME="$sandbox" \
+    XDG_BIN_HOME="$sandbox/bin" \
+        timeout --signal=KILL 600 sh ./bootstrap.sh \
+            --harness {{harness}} --json --timeout 180 </dev/null \
+        | tee "$sandbox/report.json"
+    python3 tests/smoke/assert_report.py "$sandbox/report.json"
+
 # Run the Python test suite (passes args through to pytest)
 test *args:
     uv run --group dev pytest {{args}}

--- a/python/cheese_flow/adapters/hallouminate.py
+++ b/python/cheese_flow/adapters/hallouminate.py
@@ -147,7 +147,14 @@ class HallouminateAdapter:
                 step_id=_CONFIG_STEP,
                 component=self.name,
                 phase=Phase.CONFIGURE,
-                argv=("hallouminate", "config", "init"),
+                # `--force` because this step runs only when validation already
+                # failed. Without it, `config init` exits 1 on an existing
+                # config — "pass --force to overwrite" — naming a flag the user
+                # has no way to supply, and it fails identically on every
+                # retry. The postcondition is what makes forcing safe: a config
+                # that validates skips the step, so this can only ever overwrite
+                # one that is already broken.
+                argv=("hallouminate", "config", "init", "--force"),
                 postcondition="`hallouminate config validate` succeeds",
                 depends_on=(_INSTALL_STEP,),
             )

--- a/tests/python/test_adapters.py
+++ b/tests/python/test_adapters.py
@@ -168,13 +168,20 @@ def test_hallouminate_omits_the_cursor_mcp_step_when_cursor_is_not_selected() ->
     assert "hallouminate:mcp:cursor" not in steps_by_id(steps)
 
 
-def test_hallouminate_config_init_never_forces_and_depends_on_install() -> None:
+def test_hallouminate_config_init_forces_and_depends_on_install() -> None:
+    """The step runs only when validation already failed, so overwriting is the fix.
+
+    Real `hallouminate config init` exits 1 on an existing config with "pass
+    --force to overwrite". Planning it without the flag leaves anyone whose
+    config is present but invalid with an install that fails the same way on
+    every retry, citing a flag they cannot supply.
+    """
     runner = FakeRunner(npm_script())
     config = steps_by_id(HallouminateAdapter(runner).plan_steps(state()))[
         "hallouminate:config-init"
     ]
 
-    assert config.argv == ("hallouminate", "config", "init")
+    assert config.argv == ("hallouminate", "config", "init", "--force")
     assert config.phase is Phase.CONFIGURE
     assert config.depends_on == ("hallouminate:npm-install",)
 
@@ -1276,10 +1283,27 @@ def test_default_component_adapters_cover_every_component() -> None:
     assert all(name == adapter.name for name, adapter in adapters.items())
 
 
-def test_no_planned_argv_passes_force() -> None:
+# The single step allowed to overwrite, and why: `hallouminate config init`
+# refuses an existing config without `--force`, and its postcondition
+# (`config validate` succeeds) means the step is skipped unless that config is
+# already broken. Every other step must reach its postcondition without
+# destroying user state — a new entry here needs the same guarantee.
+FORCING_STEPS = frozenset({"hallouminate:config-init"})
+
+
+def test_no_planned_argv_passes_force_except_the_declared_step() -> None:
     for step in all_planned_steps():
+        if step.step_id in FORCING_STEPS:
+            continue
         assert "--force" not in step.argv, step.step_id
         assert "-f" not in step.argv, step.step_id
+
+
+def test_every_forcing_step_is_guarded_by_a_postcondition_that_skips_it() -> None:
+    """`--force` is only safe where a satisfied postcondition prevents the mutation."""
+    for step in all_planned_steps():
+        if step.step_id in FORCING_STEPS:
+            assert step.postcondition, step.step_id
 
 
 def test_planned_step_ids_are_unique_and_dependencies_resolve_in_order() -> None:

--- a/tests/python/test_bootstrap.py
+++ b/tests/python/test_bootstrap.py
@@ -45,7 +45,7 @@ def _shim(directory: Path, name: str, body: str = RECORDING_SHIM) -> Path:
 
 
 def _invoke(
-    tmp_path: Path, *args: str, path: Path, home: Path
+    tmp_path: Path, *args: str, path: Path, home: Path, repository: str | None = None
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     """Run the script with ``path`` at the head of ``PATH``; return it and what ran."""
     record = tmp_path / "record"
@@ -59,6 +59,9 @@ def _invoke(
         "RECORD": str(record),
     }
     env.pop("XDG_BIN_HOME", None)
+    env.pop("CHEESE_REPOSITORY", None)
+    if repository is not None:
+        env["CHEESE_REPOSITORY"] = repository
     completed = subprocess.run(
         ["/bin/sh", str(SCRIPT_PATH), *args],
         capture_output=True,
@@ -69,8 +72,10 @@ def _invoke(
     return completed, record.read_text(encoding="utf-8").splitlines()
 
 
-def _run(tmp_path: Path, *args: str, path: Path, home: Path) -> list[str]:
-    completed, ran = _invoke(tmp_path, *args, path=path, home=home)
+def _run(
+    tmp_path: Path, *args: str, path: Path, home: Path, repository: str | None = None
+) -> list[str]:
+    completed, ran = _invoke(tmp_path, *args, path=path, home=home, repository=repository)
     assert completed.returncode == 0, completed.stderr
     return ran
 
@@ -129,6 +134,25 @@ def test_a_failed_uv_install_stops_the_run_and_names_the_real_failure(tmp_path: 
         f"{bin_dir / 'curl'} -fsSL --connect-timeout 10 --max-time 120 "
         "https://astral.sh/uv/install.sh"
     ]
+
+
+def test_cheese_repository_overrides_the_default_source(tmp_path: Path) -> None:
+    """Without this the smoke job installs the default branch and passes on code
+    nobody is reviewing — a green gate that never saw the change."""
+    bin_dir = tmp_path / "bin"
+    _shim(bin_dir, "uvx")
+    _shim(bin_dir, "curl")
+
+    ran = _run(
+        tmp_path,
+        "--harness",
+        "codex",
+        path=bin_dir,
+        home=tmp_path / "home",
+        repository="/srv/checkout",
+    )
+
+    assert ran == [f"{bin_dir / 'uvx'} --from /srv/checkout cheese install --harness codex"]
 
 
 def test_the_entry_point_is_executable_and_reaches_for_no_github_cli() -> None:

--- a/tests/python/test_bootstrap.py
+++ b/tests/python/test_bootstrap.py
@@ -26,6 +26,10 @@ printf '%s\\n' "$0 $*" >> "$RECORD"
 UV_INSTALLER_SHIM = """#!/bin/sh
 printf '%s\\n' "$0 $*" >> "$RECORD"
 cat <<'INSTALLER'
+# The real installer narrates on stdout; reproduce that so the stream the
+# one-liner hands to a JSON parser is actually under test.
+echo "installing to $HOME/.local/bin"
+echo "everything's installed!"
 mkdir -p "$HOME/.local/bin"
 cat > "$HOME/.local/bin/uvx" <<'UVX'
 #!/bin/sh
@@ -134,6 +138,23 @@ def test_a_failed_uv_install_stops_the_run_and_names_the_real_failure(tmp_path: 
         f"{bin_dir / 'curl'} -fsSL --connect-timeout 10 --max-time 120 "
         "https://astral.sh/uv/install.sh"
     ]
+
+
+def test_stdout_carries_only_the_installs_own_output(tmp_path: Path) -> None:
+    """`--json` is the documented headless interface, so nothing may precede it.
+
+    The uv installer narrates on stdout. Left there it lands ahead of the JSON
+    document and breaks any caller piping the one-liner into a parser — only on
+    the bare hosts that need uv installed, which is where it matters most.
+    """
+    bin_dir = tmp_path / "bin"
+    _shim(bin_dir, "curl", UV_INSTALLER_SHIM)
+    # The generated uvx echoes a JSON-ish document, standing in for the report.
+    completed, _ = _invoke(tmp_path, "--json", path=bin_dir, home=tmp_path / "home")
+
+    assert completed.returncode == 0, completed.stderr
+    assert "installing to" not in completed.stdout
+    assert "everything's installed" not in completed.stdout
 
 
 def test_cheese_repository_overrides_the_default_source(tmp_path: Path) -> None:

--- a/tests/python/test_integration.py
+++ b/tests/python/test_integration.py
@@ -109,6 +109,7 @@ class FakeWorld:
         self.marketplaces: set[str] = set()
         self.plugins: set[str] = set()
         self.config_initialized = False
+        self.config_exists = False
         self.initialized_repos: set[Path] = set()
         self.indexed_repos: set[Path] = set()
         self.skills: dict[str, list[str]] = {}
@@ -138,6 +139,7 @@ class FakeWorld:
         self.installed["hallouminate"] = version
         self.marketplaces.add(MARKETPLACE_SOURCE)
         self.plugins.add(PLUGIN_ID)
+        self.config_exists = True
         self.config_initialized = True
         for harness in harnesses:
             self.install_skills(harness)
@@ -199,9 +201,20 @@ class FakeWorld:
             return _ok(key)
         if key[1:] == ("plugin", "list", "--json"):
             return _ok(key, self._plugin_listing(key[0]))
-        if key == ("hallouminate", "config", "init"):
+        if key[:3] == ("hallouminate", "config", "init"):
             if "hallouminate-config" in self._refuse:
                 return _fail(key, "config init refused")
+            # The real CLI refuses to overwrite: `config init` on an existing
+            # config exits 1 with "pass --force to overwrite". A fake that
+            # always succeeds hides the one case where this step is reached
+            # with a config already on disk.
+            if self.config_exists and "--force" not in key:
+                return _fail(
+                    key,
+                    f"config already exists at {self.home}/.config/hallouminate/config.toml;"
+                    " pass --force to overwrite",
+                )
+            self.config_exists = True
             self.config_initialized = True
             return _ok(key)
         if key == ("hallouminate", "config", "validate"):
@@ -496,7 +509,7 @@ def test_dry_run_emits_the_exact_plan_without_executing_package_code(
         ["npm", "install", "-g", "hallouminate@1.0.0"],
         ["codex", "plugin", "marketplace", "add", MARKETPLACE_SOURCE],
         ["codex", "plugin", "add", PLUGIN_ID],
-        ["hallouminate", "config", "init"],
+        ["hallouminate", "config", "init", "--force"],
         [
             "npx",
             "-y",
@@ -885,6 +898,35 @@ def test_install_converges_every_easy_cheese_step_with_gh_absent(
     for name in EASY_CHEESE_SKILLS:
         assert (home / CANONICAL_SKILLS_DIR / name / "SKILL.md").is_file()
         assert (home / CLAUDE_SKILLS_DIR / name / "SKILL.md").is_file()
+
+
+def test_install_repairs_a_config_that_exists_but_does_not_validate(
+    tmp_path: Path, home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broken config must not leave an install that fails the same way forever.
+
+    The configure step runs only when `config validate` fails, and the real CLI
+    refuses to overwrite without `--force` — so planning it unforced turns a
+    stale config into a permanently stuck install whose error names a flag the
+    user cannot supply.
+    """
+    world = wire(monkeypatch, FakeWorld(home))
+    # On disk but not valid: exactly the state that reaches the mutation.
+    world.config_exists = True
+    manifest = write_manifest(
+        tmp_path,
+        manifest_text(harnesses=["claude-code"], components=["hallouminate", "easy-cheese"]),
+    )
+
+    result = cli_runner.invoke(app, ["install", "--config", str(manifest)])
+
+    assert result.exit_code == 0, result.stderr
+    document = json.loads(result.stdout)
+    config_step = next(
+        entry for entry in document["results"] if entry["step_id"] == "hallouminate:config-init"
+    )
+    assert config_step["status"] == "succeeded", config_step.get("stderr_tail")
+    assert world.config_initialized
 
 
 def test_a_repo_option_that_is_not_a_repository_exits_two_before_planning(

--- a/tests/smoke/assert_report.py
+++ b/tests/smoke/assert_report.py
@@ -1,0 +1,58 @@
+"""Grade the JSON report from a real ``cheese install`` run.
+
+The smoke test's whole value is that it ran the real children, so its
+assertion has to read what they actually did. A nonzero exit from
+``bootstrap.sh`` catches a crash or a timeout; this catches the quieter
+failure where the run exits 0 with a step that never converged.
+
+Deliberately dependency-free: the smoke job installs cheese-flow into a
+throwaway HOME and must be able to grade the result without importing it.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+CONVERGED = frozenset({"succeeded", "skipped"})
+
+
+def main(report_path: Path) -> int:
+    try:
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"smoke: no readable report at {report_path}: {error}", file=sys.stderr)
+        return 1
+
+    results = report.get("results", ())
+    if not results:
+        print("smoke: the run planned nothing — no step was executed", file=sys.stderr)
+        return 1
+
+    for result in results:
+        print(f"  {result['status']:12} {result['component']:14} {result['phase']}")
+
+    unconverged = [result for result in results if result["status"] not in CONVERGED]
+    status = report.get("status")
+    if status != "succeeded" or unconverged:
+        print(f"\nsmoke: run reported {status!r}", file=sys.stderr)
+        for result in unconverged:
+            print(
+                f"\n  {result['component']} / {result['phase']}: {result['status']}",
+                file=sys.stderr,
+            )
+            print(f"    argv: {' '.join(result.get('argv') or ())}", file=sys.stderr)
+            print(f"    postcondition: {result['postcondition']}", file=sys.stderr)
+            if result.get("stderr_tail"):
+                print(f"    stderr: {result['stderr_tail']}", file=sys.stderr)
+            if result.get("remediation"):
+                print(f"    remediation: {result['remediation']}", file=sys.stderr)
+        return 1
+
+    print(f"\nsmoke: {len(results)} steps converged")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(Path(sys.argv[1])))


### PR DESCRIPTION
**Semantics-altering.** One planned command changes (`hallouminate config init` now passes `--force`), and a repo-wide test invariant is narrowed rather than removed.

## Why

#90 stopped a prompting child from hanging the install. It could not tell us whether anything actually prompts — the unit suite replaces every child process with a recording shim, so a green build proves control flow and nothing about whether the children terminate. The container hang was invisible to CI by construction.

This adds the missing tier, and the missing tier immediately found a bug.

## What changed

### A real bounded install

`just smoke [harness]` installs into a throwaway `HOME` under `timeout --signal=KILL` with stdin closed, then grades the JSON report. Exit 0 is not the same as converged — a run can exit clean with a `failed` step — so `tests/smoke/assert_report.py` checks every step and prints the argv, postcondition, and `stderr_tail` of whatever did not converge.

`.github/workflows/smoke.yml` runs the same thing on a runner with `gh`, `uv`, and `uvx` deleted from `PATH`, erroring loudly if any survive. That is the bare host the curl-pipe-sh line claims to support, tested on every relevant PR instead of on someone's cloud container at 11pm.

Scoped to the install path plus a nightly, deliberately: it depends on npm and GitHub being reachable, and an unrelated PR should not go red over a registry blip. **The nightly is the trigger that matters** — breakage here can arrive from a published `skills` release with no commit in this repo at all, and no path filter can see that.

`bootstrap.sh` takes a `CHEESE_REPOSITORY` override. Without it the job installs the default branch and passes on code nobody is reviewing.

### The bug it found

Auditing the six planned commands for headlessness: five are fine (two carry explicit `--yes`, `npm` is non-interactive, and the two `claude plugin` commands have no such flag but demonstrably do not prompt). The sixth, `hallouminate config init`, omits an available `--force`.

It does not prompt — verified directly:

```
1st exit: 0    wrote …/config.toml
2nd exit: 1    Error: config already exists at …; pass --force to overwrite
```

So there is no hang. But the configure step's postcondition is ```hallouminate config validate` succeeds``, so the step runs **only when validation already failed**. The one state that reaches the mutation is a config that exists and is invalid — and there the step failed, and failed identically on every retry, citing a flag the user had no way to supply.

## What a reviewer should push on

**This reverses a deliberate prior decision.** `test_no_planned_argv_passes_force` asserted that *no* planned argv anywhere passes `--force` — a blanket safety rule, and blanket rules exist precisely to stop case-by-case reasoning like the paragraph above. I narrowed it to a declared `FORCING_STEPS` set instead of deleting it, so any new forcing step still has to justify itself, but the hole is real and worth arguing about.

**The tradeoff I am proposing.** Today: a stale config means an install that can never converge. After: `config init --force` overwrites it. The overwritten config was invalid by definition, and the postcondition means a config that validates is never touched — but if someone hand-edited `config.toml` into a state `validate` rejects, their edits are discarded without a backup. I think a permanently stuck install is the worse failure, and `config init` writes a recoverable default. Reasonable to disagree; writing a `.bak` first is the obvious alternative and I did not do it because it was not asked for.

**That the regression test has teeth.** `FakeWorld` previously answered `config init` with unconditional success, which is exactly why this was never caught. It now models the real CLI's refusal. Confirmed by reverting `--force`:

```
FAILED test_install_repairs_a_config_that_exists_but_does_not_validate
        assert 1 == 0  (the whole install exits 1)
```

### The second bug it found

The first CI run failed, which is the point. Its captured report began:

```
installing to /home/runner/.local/bin
  uv
  uvx
everything's installed!
{
```

The uv installer narrates on **stdout**, so on any host without uv that text lands ahead of the JSON document and `cheese install --json` cannot be parsed — only on the bare hosts the one-liner exists for. Fixed by sending the installer's stdout to stderr, where `bootstrap.sh` already puts its own progress messages.

That run also exposed two faults in the smoke workflow itself, both worth naming:

- **No `pipefail`** — `| tee` reported success and a failed install passed the step. The identical trap `bootstrap.sh` already guards against after `curl … | sh`, reproduced in my own YAML.
- **No harness CLI on the runner** — registration died on `could not run claude`. A harness CLI is a prerequisite of registering plugins *with that harness*, not something cheese-flow installs; the cloud box this job models is one already running the agent. The job now installs it.

## Verification

- `just build` — 463 passed.
- Smoke CI green on both matrix legs. `hallouminate install` **ran** rather than skipping, so the bare-host path is genuinely exercised.
- `just smoke` run for real: 6 steps converged against live npm, the `skills` CLI, and tilth MCP registration.
- Red-first confirmed for `CHEESE_REPOSITORY`, the stdout-cleanliness test, and the config-repair regression test.
- `assert_report.py` verified to exit 1 on a failed step and on a missing report.

## Known limits

`just smoke` locally exercised 4 of 6 steps — `HOME` does not sandbox npm's global prefix, so `hallouminate install` and `configure` were already satisfied on my machine and reported `skipped`. A fresh CI runner has nothing preinstalled and will run all six.

`hallouminate config init` still reported `skipped` on a fresh runner — its postcondition held without the step running — so the `--force` change is covered by the integration test but has not executed on a real machine.

Neither run covers the **second** install on the same machine, which is where every "already exists" branch lives. Running the smoke install twice and asserting the second converges would close that, and would be the first real test of the positive-postcondition design. Not done here.

Follow-up to #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
