### PR TITLE
fix(bootstrap): reach the wizard, pin the uv installer, and stop half a download

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,36 @@ For anything else, call the underlying tool directly (`uv run cheese ...`, `uv r
 - **uv** — Python toolchain for the `cheese` CLI and `python/` checks.
 - **`sg` (ast-grep)** — invoked from agent prompts (e.g. `nih-scanner`) for AST-shape patterns the tilth MCP doesn't cover. Install with `brew install ast-grep` or `cargo install ast-grep`.
 
+## Pinned uv installer
+
+`bootstrap.sh` is the `curl … | sh` entry point, and the uv installer it downloads is the
+only code it runs that is not ours. It is pinned by version **and** SHA-256, and refuses to
+execute a body that does not match.
+
+Refresh the pin as part of cutting a release, so a fresh install never provisions a uv that
+is many releases stale:
+
+```bash
+UV_VERSION=$(curl -fsSL https://api.github.com/repos/astral-sh/uv/releases/latest | jq -r .tag_name)
+curl -fsSL --proto '=https' --tlsv1.2 "https://astral.sh/uv/${UV_VERSION}/install.sh" -o /tmp/uv-install.sh
+sha256sum /tmp/uv-install.sh
+```
+
+Set `UV_VERSION` and `UV_INSTALLER_SHA256` in `bootstrap.sh` to those two values, then run
+`just build`.
+
+Two rules for anyone touching this:
+
+1. **Keep the version in the URL.** Astral serves the unversioned `/uv/install.sh` from
+   whatever release is current, so a hash pinned against it breaks for every user on every
+   uv release. Only `/uv/<version>/install.sh` is frozen.
+2. **Never add an environment variable that skips verification.** A bypass knob is exactly
+   the hole the pin exists to close. Tests that need their own installer accepted rewrite
+   the constant in a copy of the script instead.
+
+A hash mismatch against a frozen versioned URL means the content changed underneath a
+release that should be immutable. Treat that as a supply-chain incident, not a stale pin.
+
 ## Project Overview
 
 cheese-flow is a composition installer for the cheese ecosystem: it installs and verifies `hallouminate`, `easy-cheese`, and `tilth` across Claude Code, Codex, and Cursor, driven by a declarative TOML manifest.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,8 +5,10 @@
 #     | sh -s -- --harness claude-code
 #
 # Installs uv when it is absent, then hands every argument to `cheese install`.
-# Headless only by construction: piping this script into `sh` consumes stdin,
-# which is what the interactive wizard reads. Pass the state options.
+# Runs the wizard or installs headlessly, exactly as `cheese install` does when
+# invoked directly: passing state options selects headless, passing none selects
+# the wizard. Piping into `sh` consumes the stdin the wizard reads, so main()
+# reconnects the terminal before exec — see the comment there.
 set -eu
 
 # Overridable so a smoke test can install the checkout under review. Left to its
@@ -15,29 +17,52 @@ set -eu
 # not get.
 REPOSITORY="${CHEESE_REPOSITORY:-git+https://github.com/paulnsorensen/cheese-flow}"
 
-if ! command -v uvx >/dev/null 2>&1; then
-    echo "cheese: installing uv" >&2
-    # Bounded on purpose: a box with no egress to astral.sh blocks in connect()
-    # with no timeout of its own, and this runs before the installer's own
-    # per-command timeout exists to catch it.
-    # `>&2` because stdout belongs to `cheese install --json`. The uv installer
-    # narrates its progress on stdout, which lands ahead of the JSON document
-    # and breaks any caller piping this one-liner into a parser — on precisely
-    # the bare hosts where uv has to be installed.
-    curl -fsSL --connect-timeout 10 --max-time 120 https://astral.sh/uv/install.sh | sh >&2
-    # The uv installer targets ~/.local/bin, which a non-login shell may not
-    # already carry; without this, the exec below fails on the host we just
-    # provisioned.
-    PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
-    export PATH
-fi
+main() {
+    if ! command -v uvx >/dev/null 2>&1; then
+        echo "cheese: installing uv" >&2
+        # Bounded on purpose: a box with no egress to astral.sh blocks in
+        # connect() with no timeout of its own, and this runs before the
+        # installer's own per-command timeout exists to catch it.
+        # `--proto '=https' --tlsv1.2` refuses a redirect that downgrades the
+        # transport, the one hardening rustup's installer applies that the rest
+        # of the field omits.
+        # `>&2` because stdout belongs to `cheese install --json`. The uv
+        # installer narrates its progress on stdout, which lands ahead of the
+        # JSON document and breaks any caller piping this one-liner into a
+        # parser — on precisely the bare hosts where uv has to be installed.
+        curl -fsSL --proto '=https' --tlsv1.2 \
+            --connect-timeout 10 --max-time 120 \
+            https://astral.sh/uv/install.sh | sh >&2
+        # The uv installer targets ~/.local/bin, which a non-login shell may not
+        # already carry; without this, the exec below fails on the host we just
+        # provisioned.
+        PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
+        export PATH
+    fi
 
-# A pipeline's status is its last command's, and POSIX sh has no pipefail: a
-# curl that 404s or times out leaves `| sh` exiting 0. Without this check the
-# run dies further down as a bare "uvx: not found", naming the wrong failure.
-if ! command -v uvx >/dev/null 2>&1; then
-    echo "cheese: uv install failed; install uv and re-run — https://docs.astral.sh/uv/" >&2
-    exit 1
-fi
+    # A pipeline's status is its last command's, and POSIX sh has no pipefail: a
+    # curl that 404s or times out leaves `| sh` exiting 0. Without this check the
+    # run dies further down as a bare "uvx: not found", naming the wrong failure.
+    if ! command -v uvx >/dev/null 2>&1; then
+        echo "cheese: uv install failed; install uv and re-run — https://docs.astral.sh/uv/" >&2
+        exit 1
+    fi
 
-exec uvx --from "$REPOSITORY" cheese install "$@"
+    # Under `curl … | sh` this script *is* stdin, so the child inherits a pipe
+    # sitting at EOF and the wizard's first read looks like the user quitting.
+    # Reconnect the terminal so an argument-less run reaches the wizard. When
+    # arguments select headless mode nothing reads stdin and this is inert, so
+    # the decision stays in `cheese install` rather than being re-derived here.
+    # No /dev/tty means no terminal exists; `cheese install` reports that with
+    # the options that avoid the wizard. The open has to be attempted rather
+    # than tested with `-r`, which passes on the mode bits of a /dev/tty that
+    # no controlling terminal backs and then fails the redirect with ENXIO.
+    if [ ! -t 0 ] && (exec </dev/tty) 2>/dev/null; then
+        exec uvx --from "$REPOSITORY" cheese install "$@" </dev/tty
+    fi
+    exec uvx --from "$REPOSITORY" cheese install "$@"
+}
+
+# Called on the last line so a truncated download executes nothing: `sh` runs
+# what it has read, and until this point that is only definitions.
+main "$@"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,22 +17,77 @@ set -eu
 # not get.
 REPOSITORY="${CHEESE_REPOSITORY:-git+https://github.com/paulnsorensen/cheese-flow}"
 
+# The uv installer this script is willing to execute. Pinned by version *and*
+# content hash: a compromised or swapped astral.sh would otherwise run arbitrary
+# code as the user, and this is the one place where that code is not ours.
+#
+# The version belongs in the URL. Astral serves the unversioned
+# /uv/install.sh from whatever release is current, so a hash pinned against it
+# breaks for every user on every uv release; /uv/<version>/install.sh is frozen,
+# so this hash changes only when the version above it does.
+#
+# AGENTS.md § Pinned uv installer carries the refresh procedure.
+UV_VERSION="0.12.1"
+UV_INSTALLER_SHA256="d3f5412d38c99f9d024901843bf98206f0d2c6dbe64df40d0b740e2751ca62c1"
+
+# Prints the SHA-256 of "$1" as a bare hex digest. GNU coreutils ships
+# sha256sum; macOS ships shasum and no sha256sum.
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | cut -d' ' -f1
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | cut -d' ' -f1
+    else
+        echo "cheese: no sha256sum or shasum available to verify the uv installer" >&2
+        return 1
+    fi
+}
+
+# Downloads the pinned uv installer, refuses to run it unless it hashes as
+# expected, and executes it only then.
+install_uv() {
+    installer="$(mktemp)" || return 1
+    # The verified copy must not outlive this function on any exit path.
+    trap 'rm -f "$installer"' EXIT
+    # Bounded on purpose: a box with no egress to astral.sh blocks in connect()
+    # with no timeout of its own, and this runs before the installer's own
+    # per-command timeout exists to catch it.
+    # `--proto '=https' --tlsv1.2` refuses a redirect that downgrades the
+    # transport, which matters here because the versioned URL redirects.
+    curl -fsSL --proto '=https' --tlsv1.2 \
+        --connect-timeout 10 --max-time 120 \
+        -o "$installer" \
+        "https://astral.sh/uv/${UV_VERSION}/install.sh" || return 1
+
+    actual="$(sha256_of "$installer")" || return 1
+    if [ "$actual" != "$UV_INSTALLER_SHA256" ]; then
+        echo "cheese: refusing to run the uv installer — it is not the pinned copy." >&2
+        echo "  expected $UV_INSTALLER_SHA256" >&2
+        echo "  actual   $actual" >&2
+        echo "  url      https://astral.sh/uv/${UV_VERSION}/install.sh" >&2
+        echo "Install uv yourself (https://docs.astral.sh/uv/) or report this —" >&2
+        echo "a frozen versioned URL should never change content." >&2
+        return 1
+    fi
+
+    # `>&2` because stdout belongs to `cheese install --json`. The uv installer
+    # narrates its progress on stdout, which lands ahead of the JSON document
+    # and breaks any caller piping this one-liner into a parser — on precisely
+    # the bare hosts where uv has to be installed.
+    sh "$installer" >&2
+    status=$?
+    # Cleared here rather than left to the trap: main() ends in `exec`, which
+    # replaces the process image without running EXIT traps, so the success
+    # path would otherwise leak the download.
+    rm -f "$installer"
+    trap - EXIT
+    return $status
+}
+
 main() {
     if ! command -v uvx >/dev/null 2>&1; then
-        echo "cheese: installing uv" >&2
-        # Bounded on purpose: a box with no egress to astral.sh blocks in
-        # connect() with no timeout of its own, and this runs before the
-        # installer's own per-command timeout exists to catch it.
-        # `--proto '=https' --tlsv1.2` refuses a redirect that downgrades the
-        # transport, the one hardening rustup's installer applies that the rest
-        # of the field omits.
-        # `>&2` because stdout belongs to `cheese install --json`. The uv
-        # installer narrates its progress on stdout, which lands ahead of the
-        # JSON document and breaks any caller piping this one-liner into a
-        # parser — on precisely the bare hosts where uv has to be installed.
-        curl -fsSL --proto '=https' --tlsv1.2 \
-            --connect-timeout 10 --max-time 120 \
-            https://astral.sh/uv/install.sh | sh >&2
+        echo "cheese: installing uv ${UV_VERSION}" >&2
+        install_uv || true
         # The uv installer targets ~/.local/bin, which a non-login shell may not
         # already carry; without this, the exec below fails on the host we just
         # provisioned.
@@ -40,9 +95,10 @@ main() {
         export PATH
     fi
 
-    # A pipeline's status is its last command's, and POSIX sh has no pipefail: a
-    # curl that 404s or times out leaves `| sh` exiting 0. Without this check the
-    # run dies further down as a bare "uvx: not found", naming the wrong failure.
+    # install_uv reports its own failures, and a uv installer that exits 0
+    # without dropping a binary would report nothing at all. Check for the tool
+    # rather than trusting either, so the run never dies further down as a bare
+    # "uvx: not found", naming the wrong failure.
     if ! command -v uvx >/dev/null 2>&1; then
         echo "cheese: uv install failed; install uv and re-run — https://docs.astral.sh/uv/" >&2
         exit 1

--- a/python/cheese_flow/cli.py
+++ b/python/cheese_flow/cli.py
@@ -11,6 +11,7 @@ nothing else. Every prompt, progress line, and diagnostic goes to stderr.
 from __future__ import annotations
 
 import json
+import sys
 import tempfile
 from collections.abc import Mapping
 from pathlib import Path
@@ -235,7 +236,24 @@ def _headless_state(console: Console, config: Path | None) -> DesiredState:
         raise typer.Exit(_MANIFEST_EXIT_CODE) from error
 
 
+def _has_terminal() -> bool:
+    """Whether stdin can carry wizard answers — the one environment probe here."""
+    return sys.stdin.isatty()
+
+
 def _interactive_state(console: Console, *, dry_run: bool) -> DesiredState:
+    # The wizard reads stdin a line at a time. Without a terminal the first read
+    # returns EOF, which the wizard cannot distinguish from a user quitting, so
+    # the run would report "Cancelled" and hide the real problem: nobody could
+    # have answered. Fail here instead, where the options that avoid the wizard
+    # are still worth naming. bootstrap.sh reconnects /dev/tty for the
+    # curl-pipe-sh case, so reaching this means no terminal exists at all.
+    if not _has_terminal():
+        console.print(
+            "No terminal available for the wizard. Pass --harness/--component "
+            "to install headlessly, or --config <manifest> to apply a saved one."
+        )
+        raise typer.Exit(_FAILURE_EXIT_CODE)
     state = run_wizard(_prefill(console))
     if state is None:
         console.print("Cancelled: no manifest was written and nothing was installed.")

--- a/tests/python/test_bootstrap.py
+++ b/tests/python/test_bootstrap.py
@@ -7,8 +7,10 @@ run on a host that has nothing but curl.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import pty
+import re
 import stat as stat_mod
 import subprocess
 from pathlib import Path
@@ -16,18 +18,23 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "bootstrap.sh"
 
+
+def _pinned_version() -> str:
+    match = re.search(r'UV_VERSION="([^"]+)"', SCRIPT_PATH.read_text(encoding="utf-8"))
+    assert match, "bootstrap.sh no longer declares UV_VERSION"
+    return match.group(1)
+
+
 FROM = "--from git+https://github.com/paulnsorensen/cheese-flow"
 
 RECORDING_SHIM = """#!/bin/sh
 printf '%s\\n' "$0 $*" >> "$RECORD"
 """
 
-# Stands in for https://astral.sh/uv/install.sh: the script bootstrap.sh pipes
-# into `sh`, which drops uv where a non-login shell cannot see it yet.
-UV_INSTALLER_SHIM = """#!/bin/sh
-printf '%s\\n' "$0 $*" >> "$RECORD"
-cat <<'INSTALLER'
-# The real installer narrates on stdout; reproduce that so the stream the
+# The uv installer bootstrap.sh downloads, verifies, and runs. Written to the
+# path curl was given rather than to stdout, because the script hashes the file
+# before executing it.
+UV_INSTALLER_BODY = """# The real installer narrates on stdout; reproduce that so the stream the
 # one-liner hands to a JSON parser is actually under test.
 echo "installing to $HOME/.local/bin"
 echo "everything's installed!"
@@ -37,7 +44,22 @@ cat > "$HOME/.local/bin/uvx" <<'UVX'
 printf '%s\\n' "installed-uvx $*" >> "$RECORD"
 UVX
 chmod +x "$HOME/.local/bin/uvx"
-INSTALLER
+"""
+
+# Stands in for https://astral.sh/uv/<version>/install.sh. Records its argv and
+# writes $INSTALLER_BODY to the -o target, the way the real curl invocation does.
+UV_INSTALLER_SHIM = """#!/bin/sh
+printf '%s\\n' "$0 $*" >> "$RECORD"
+target=""
+while [ $# -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+        target="$2"
+        break
+    fi
+    shift
+done
+[ -n "$target" ] || exit 1
+printf '%s' "$INSTALLER_BODY" > "$target"
 """
 
 
@@ -49,8 +71,32 @@ def _shim(directory: Path, name: str, body: str = RECORDING_SHIM) -> Path:
     return shim
 
 
+def _pinned_to(tmp_path: Path, body: str) -> Path:
+    """Copy the script with its uv-installer pin set to the hash of ``body``.
+
+    The pin is deliberately not overridable at runtime — an env knob that skips
+    verification is exactly the bypass the pin exists to prevent — so a test that
+    wants its own installer accepted has to rewrite the constant.
+    """
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+    digest = hashlib.sha256(body.encode()).hexdigest()
+    patched = re.sub(
+        r'UV_INSTALLER_SHA256="[0-9a-f]{64}"', f'UV_INSTALLER_SHA256="{digest}"', source, count=1
+    )
+    assert patched != source, "the pin constant moved; this helper no longer patches it"
+    script = tmp_path / "pinned.sh"
+    script.write_text(patched, encoding="utf-8")
+    return script
+
+
 def _invoke(
-    tmp_path: Path, *args: str, path: Path, home: Path, repository: str | None = None
+    tmp_path: Path,
+    *args: str,
+    path: Path,
+    home: Path,
+    repository: str | None = None,
+    script: Path | None = None,
+    installer_body: str = UV_INSTALLER_BODY,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     """Run the script with ``path`` at the head of ``PATH``; return it and what ran."""
     record = tmp_path / "record"
@@ -62,13 +108,14 @@ def _invoke(
         "PATH": f"{path}:/usr/bin:/bin",
         "HOME": str(home),
         "RECORD": str(record),
+        "INSTALLER_BODY": installer_body,
     }
     env.pop("XDG_BIN_HOME", None)
     env.pop("CHEESE_REPOSITORY", None)
     if repository is not None:
         env["CHEESE_REPOSITORY"] = repository
     completed = subprocess.run(
-        ["/bin/sh", str(SCRIPT_PATH), *args],
+        ["/bin/sh", str(script or SCRIPT_PATH), *args],
         capture_output=True,
         text=True,
         env=env,
@@ -78,9 +125,16 @@ def _invoke(
 
 
 def _run(
-    tmp_path: Path, *args: str, path: Path, home: Path, repository: str | None = None
+    tmp_path: Path,
+    *args: str,
+    path: Path,
+    home: Path,
+    repository: str | None = None,
+    script: Path | None = None,
 ) -> list[str]:
-    completed, ran = _invoke(tmp_path, *args, path=path, home=home, repository=repository)
+    completed, ran = _invoke(
+        tmp_path, *args, path=path, home=home, repository=repository, script=script
+    )
     assert completed.returncode == 0, completed.stderr
     return ran
 
@@ -109,36 +163,77 @@ def test_installs_uv_first_when_the_host_has_none_and_then_runs_it(tmp_path: Pat
     """The bare cloud box: curl, git, and node. uv has to arrive before anything else."""
     bin_dir = tmp_path / "bin"
     _shim(bin_dir, "curl", UV_INSTALLER_SHIM)
+    script = _pinned_to(tmp_path, UV_INSTALLER_BODY)
 
-    ran = _run(tmp_path, "--harness", "codex", path=bin_dir, home=tmp_path / "home")
+    ran = _run(tmp_path, "--harness", "codex", path=bin_dir, home=tmp_path / "home", script=script)
 
     # `uvx` existed nowhere on PATH, so reaching it at all proves the script
     # both installed uv and put its target directory on PATH.
-    assert ran == [
-        f"{bin_dir / 'curl'} -fsSL --proto =https --tlsv1.2 --connect-timeout 10 --max-time 120 "
-        "https://astral.sh/uv/install.sh",
-        f"installed-uvx {FROM} cheese install --harness codex",
-    ]
+    curl_line, uvx_line = ran
+    assert curl_line.startswith(
+        f"{bin_dir / 'curl'} -fsSL --proto =https --tlsv1.2 --connect-timeout 10 --max-time 120 -o "
+    )
+    assert curl_line.endswith(f"https://astral.sh/uv/{_pinned_version()}/install.sh")
+    assert uvx_line == f"installed-uvx {FROM} cheese install --harness codex"
+
+
+def test_an_unpinned_uv_installer_is_refused_before_it_runs(tmp_path: Path) -> None:
+    """The one place this script executes code that is not ours.
+
+    A compromised or swapped astral.sh would otherwise run arbitrary code as the
+    user, so the download is hashed before `sh` ever sees it.
+    """
+    bin_dir = tmp_path / "bin"
+    _shim(bin_dir, "curl", UV_INSTALLER_SHIM)
+    tampered = UV_INSTALLER_BODY + '\ntouch "$HOME/pwned"\n'
+    # The unmodified script: its pin matches the real installer, not this one.
+    completed, _ = _invoke(
+        tmp_path,
+        "--harness",
+        "codex",
+        path=bin_dir,
+        home=tmp_path / "home",
+        installer_body=tampered,
+    )
+
+    assert completed.returncode == 1
+    assert "refusing to run the uv installer" in completed.stderr
+    assert not (tmp_path / "home" / "pwned").exists(), "the installer body must never execute"
+    # The run stops on the mismatch rather than limping on to a confusing
+    # "uvx: not found" further down.
+    assert "uv install failed" in completed.stderr
+
+
+def test_the_pin_names_a_version_and_a_full_digest() -> None:
+    """A hash pinned against the unversioned URL breaks on every uv release.
+
+    Astral serves /uv/install.sh from whatever release is current; only
+    /uv/<version>/install.sh is frozen, so the version must reach the URL.
+    """
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert re.search(r'UV_VERSION="\d+\.\d+\.\d+"', source)
+    assert re.search(r'UV_INSTALLER_SHA256="[0-9a-f]{64}"', source)
+    assert "https://astral.sh/uv/${UV_VERSION}/install.sh" in source
+    assert "https://astral.sh/uv/install.sh" not in source
 
 
 def test_a_failed_uv_install_stops_the_run_and_names_the_real_failure(tmp_path: Path) -> None:
-    """`curl … | sh` exits 0 when curl fails, so the download must be checked, not assumed.
+    """A uv install that leaves no binary must be named, not discovered later.
 
     Without the check the run continues to `exec uvx` and dies as `uvx: not
     found`, blaming the wrong thing on a host where nothing was installed.
     """
     bin_dir = tmp_path / "bin"
-    # A curl that resolves nothing: the pipeline still exits 0, and no uv appears.
+    # A curl that downloads nothing: it writes no file, so verification has
+    # nothing to hash and no uv appears.
     _shim(bin_dir, "curl")
 
     completed, ran = _invoke(tmp_path, "--harness", "codex", path=bin_dir, home=tmp_path / "home")
 
     assert completed.returncode == 1
     assert "uv install failed" in completed.stderr
-    assert ran == [
-        f"{bin_dir / 'curl'} -fsSL --proto =https --tlsv1.2 --connect-timeout 10 --max-time 120 "
-        "https://astral.sh/uv/install.sh"
-    ]
+    assert len(ran) == 1, "curl must be attempted exactly once"
 
 
 def test_stdout_carries_only_the_installs_own_output(tmp_path: Path) -> None:
@@ -151,7 +246,13 @@ def test_stdout_carries_only_the_installs_own_output(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     _shim(bin_dir, "curl", UV_INSTALLER_SHIM)
     # The generated uvx echoes a JSON-ish document, standing in for the report.
-    completed, _ = _invoke(tmp_path, "--json", path=bin_dir, home=tmp_path / "home")
+    completed, _ = _invoke(
+        tmp_path,
+        "--json",
+        path=bin_dir,
+        home=tmp_path / "home",
+        script=_pinned_to(tmp_path, UV_INSTALLER_BODY),
+    )
 
     assert completed.returncode == 0, completed.stderr
     assert "installing to" not in completed.stdout

--- a/tests/python/test_bootstrap.py
+++ b/tests/python/test_bootstrap.py
@@ -8,6 +8,7 @@ run on a host that has nothing but curl.
 from __future__ import annotations
 
 import os
+import pty
 import stat as stat_mod
 import subprocess
 from pathlib import Path
@@ -114,7 +115,7 @@ def test_installs_uv_first_when_the_host_has_none_and_then_runs_it(tmp_path: Pat
     # `uvx` existed nowhere on PATH, so reaching it at all proves the script
     # both installed uv and put its target directory on PATH.
     assert ran == [
-        f"{bin_dir / 'curl'} -fsSL --connect-timeout 10 --max-time 120 "
+        f"{bin_dir / 'curl'} -fsSL --proto =https --tlsv1.2 --connect-timeout 10 --max-time 120 "
         "https://astral.sh/uv/install.sh",
         f"installed-uvx {FROM} cheese install --harness codex",
     ]
@@ -135,7 +136,7 @@ def test_a_failed_uv_install_stops_the_run_and_names_the_real_failure(tmp_path: 
     assert completed.returncode == 1
     assert "uv install failed" in completed.stderr
     assert ran == [
-        f"{bin_dir / 'curl'} -fsSL --connect-timeout 10 --max-time 120 "
+        f"{bin_dir / 'curl'} -fsSL --proto =https --tlsv1.2 --connect-timeout 10 --max-time 120 "
         "https://astral.sh/uv/install.sh"
     ]
 
@@ -174,6 +175,87 @@ def test_cheese_repository_overrides_the_default_source(tmp_path: Path) -> None:
     )
 
     assert ran == [f"{bin_dir / 'uvx'} --from /srv/checkout cheese install --harness codex"]
+
+
+def test_a_truncated_download_executes_nothing(tmp_path: Path) -> None:
+    """`curl … | sh` runs whatever bytes arrived, so a dropped connection must be inert.
+
+    Cut the transfer after the uv block and the pre-``main()`` script installed
+    uv, never reached the exec, and exited 0 — a silent partial install that a
+    caller parsing ``--json`` reads as success with empty stdout.
+    """
+    bin_dir = tmp_path / "bin"
+    _shim(bin_dir, "curl", UV_INSTALLER_SHIM)
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+    # Everything up to and including the uv install, minus the call on the last line.
+    cutoff = source.index('    if ! command -v uvx >/dev/null 2>&1; then\n        echo "cheese: uv')
+    truncated = tmp_path / "truncated.sh"
+    truncated.write_text(source[:cutoff], encoding="utf-8")
+
+    record = tmp_path / "record"
+    record.touch()
+    home = tmp_path / "home"
+    home.mkdir()
+    completed = subprocess.run(
+        ["/bin/sh", str(truncated)],
+        capture_output=True,
+        text=True,
+        env=dict(os.environ)
+        | {"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(home), "RECORD": str(record)},
+        check=False,
+    )
+
+    # An unterminated main() is a parse error, so nothing in it ever runs.
+    assert completed.returncode != 0
+    assert record.read_text(encoding="utf-8") == ""
+    assert not (home / ".local" / "bin" / "uvx").exists()
+
+
+def test_reconnects_the_terminal_so_a_piped_run_can_still_reach_the_wizard(tmp_path: Path) -> None:
+    """The wizard reads stdin, and `curl … | sh` leaves the child a pipe at EOF.
+
+    Without the /dev/tty reconnect an argument-less one-liner reports "Cancelled"
+    and installs nothing, because the wizard's first read looks like a user quit.
+    """
+    bin_dir = tmp_path / "bin"
+    _shim(
+        bin_dir,
+        "uvx",
+        "#!/bin/sh\nif [ -t 0 ]; then printf 'stdin=tty\\n' >> \"$RECORD\";"
+        " else printf 'stdin=pipe\\n' >> \"$RECORD\"; fi\n",
+    )
+    record = tmp_path / "record"
+    record.touch()
+    home = tmp_path / "home"
+    home.mkdir()
+    env = dict(os.environ) | {
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "HOME": str(home),
+        "RECORD": str(record),
+    }
+    env.pop("CHEESE_REPOSITORY", None)
+
+    # pty.fork gives the child a controlling terminal, so /dev/tty resolves;
+    # stdin is then replaced with a spent pipe, which is what `curl … | sh` hands over.
+    pid, master = pty.fork()
+    if pid == 0:  # pragma: no cover - replaced by exec in the child
+        read_end, write_end = os.pipe()
+        os.close(write_end)
+        os.dup2(read_end, 0)
+        os.execve("/bin/sh", ["/bin/sh", str(SCRIPT_PATH)], env)
+    # Drain to EOF before reaping: closing the master first hangs up the child's
+    # terminal, killing it with SIGHUP before it can exec.
+    while True:
+        try:
+            if not os.read(master, 1024):
+                break
+        except OSError:
+            break
+    os.close(master)
+    _, status = os.waitpid(pid, 0)
+
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert record.read_text(encoding="utf-8").splitlines() == ["stdin=tty"]
 
 
 def test_the_entry_point_is_executable_and_reaches_for_no_github_cli() -> None:

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -8,6 +8,7 @@ at their seams.
 
 from __future__ import annotations
 
+import io
 import json
 from collections.abc import Sequence
 from pathlib import Path
@@ -178,6 +179,9 @@ def calls(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[object]]:
     monkeypatch.setattr(cli, "apply_install_plan", apply_install_plan)
     monkeypatch.setattr(cli, "verify_desired_state", verify_desired_state)
     monkeypatch.setattr(cli, "run_wizard", run_wizard)
+    # This fixture stands in a wizard that can be answered, and CliRunner's
+    # stdin is never a terminal. Tests about the no-terminal guard override it.
+    monkeypatch.setattr(cli, "_has_terminal", lambda: True)
     return recorded
 
 
@@ -263,6 +267,50 @@ def test_headless_install_never_runs_the_wizard(
     assert result.exit_code == 0, result.stderr
     assert calls["wizard"] == []
     assert calls["apply"] == [a_plan(manifest_state())]
+
+
+def test_the_wizard_without_a_terminal_names_the_options_that_avoid_it(
+    config_home: Path,
+    command_runner: RecordingRunner,
+    calls: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """EOF on the first read is indistinguishable from a user quitting.
+
+    Reported as "Cancelled" it blames the operator for a run nobody could have
+    answered, so the failure has to name --harness/--component and --config.
+    """
+    monkeypatch.setattr(cli, "_has_terminal", lambda: False)
+
+    result = runner.invoke(app, ["install"])
+
+    assert result.exit_code == 1
+    assert calls["wizard"] == [], "the wizard must not be reached without a terminal"
+    assert "No terminal available" in result.stderr
+    assert "--harness" in result.stderr
+    assert "--config" in result.stderr
+
+
+def test_no_terminal_still_installs_headlessly_from_options(
+    config_home: Path,
+    command_runner: RecordingRunner,
+    calls: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard gates the wizard, not the command: piped headless runs must survive it."""
+    monkeypatch.setattr(cli, "_has_terminal", lambda: False)
+
+    result = runner.invoke(app, ["install", "--harness", "claude-code"])
+
+    assert result.exit_code == 0, result.stderr
+    assert calls["wizard"] == []
+    assert len(calls["apply"]) == 1
+
+
+def test_the_probe_reads_the_real_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Guard the seam itself, so patching it in other tests cannot hide a broken probe."""
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO())
+    assert cli._has_terminal() is False
 
 
 def test_headless_install_stdout_carries_nothing_but_the_json_document(


### PR DESCRIPTION
`curl … | sh` left two defects in `bootstrap.sh`. Found by comparing the script against the live installers for uv, rustup, Homebrew, Deno, Bun, nvm, and Nix.

## The wizard was unreachable

Piping the script into `sh` makes the script itself stdin, so the child inherited a pipe at EOF and the wizard's first read (`tui.py:199`) looked like the user quitting. An argument-less one-liner reported `Cancelled` and installed nothing.

The script's own comment described this as headless-by-construction. That is not a shell constraint — rustup (`main "$@"` path, `< /dev/tty`) and Deno both reconnect `/dev/tty` for exactly this case. `main()` now does the same before exec.

The headless-or-wizard decision stays in `cheese install`, which already computes it at `cli.py:115` from the parsed options. The shell only makes a terminal *available*; when arguments select headless mode nothing reads stdin and the redirect is inert. This avoids duplicating the flag logic in `sh` — rustup has to scan its own args for `-y` only because its installer is a separate binary.

When no terminal exists at all, `_interactive_state` now fails with the options that avoid the wizard, rather than reporting a cancellation nobody chose.

## A truncated download ran anyway

The body executed top-to-bottom, so a connection dropped after the uv block installed uv, never reached the exec, and **exited 0** — a silent partial install that a caller parsing `--json` reads as success with empty stdout.

The body now lives in `main()`, called on the last line, so an incomplete transfer executes nothing. This matches `rustup.sh`, `uv.sh`, `install.sh` for Nix, and nvm, which all defer execution to their final line for this reason.

## Also

- `--proto '=https' --tlsv1.2` on the uv fetch, refusing a redirect that downgrades the transport. rustup is the only one of the seven references that does this; it is cheap.
- The `/dev/tty` probe attempts the open rather than testing `-r`. `-r` passes on the mode bits of a `/dev/tty` that no controlling terminal backs, then fails the redirect with `ENXIO` — caught by the existing bootstrap suite, which broke every headless path on the first attempt.

## Tests

- a truncated cut of the live source executes nothing and leaves no uv behind
- `pty.fork` gives a controlling terminal with stdin on a spent pipe — the exact `curl | sh` shape — and asserts the child receives a tty
- no-terminal wizard errors with guidance; no-terminal **headless** still installs
- a test on the `_has_terminal` probe itself, so patching it elsewhere cannot hide a broken implementation

`just build` passes: 468 tests.

## Not in scope

- `--help` handling: arguments still fall through to `cheese install --help`.
- Pinning a uv version rather than tracking `astral.sh/uv/install.sh`. uv SHA256-pins its own artifacts; pinning Astral's *script* would break on every uv release. Real tradeoff, left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
