### PR TITLE
Fail cleanly when version resolution cannot run npm

### DIFF
--- a/python/cheese_flow/cli.py
+++ b/python/cheese_flow/cli.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 import json
 import sys
 import tempfile
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Annotated
 
@@ -125,7 +126,8 @@ def install(
         # spec:105 — resolve metadata against a throwaway npm cache, removed on exit.
         with tempfile.TemporaryDirectory(prefix="cheese-npm-cache-") as cache:
             runner = _default_runner({"npm_config_cache": cache}, timeout=timeout)
-            plan = build_install_plan(state, default_component_adapters(runner))
+            with _resolution_failure_reported(console):
+                plan = build_install_plan(state, default_component_adapters(runner))
         console.print("Dry run: emitting the plan without executing it.")
         _announce(console, plan)
         report = ApplyReport(status=ReportStatus.SUCCEEDED, manifest=state, plan=plan)
@@ -134,7 +136,8 @@ def install(
         # One adapter set for planning and apply: apply must reuse the versions
         # planning resolved (acceptance:150).
         adapters = default_component_adapters(runner)
-        plan = build_install_plan(state, adapters)
+        with _resolution_failure_reported(console):
+            plan = build_install_plan(state, adapters)
         if write_config or not headless:
             save_desired_state(state, default_config_path())
             console.print(f"Wrote {default_config_path()}")
@@ -164,8 +167,25 @@ def doctor(
     runner = _default_runner(timeout=timeout)
     adapters = default_component_adapters(runner)
     console.print("Verifying declared managed state.")
-    report = verify_desired_state(state, adapters, runner)
+    with _resolution_failure_reported(console):
+        report = verify_desired_state(state, adapters, runner)
     _emit(console, report, headless=True)
+
+
+@contextmanager
+def _resolution_failure_reported(console: Console) -> Iterator[None]:
+    """Report a version-resolution failure as a diagnostic, not a traceback.
+
+    Adapters raise RuntimeError while planning when ``npm view`` cannot answer —
+    npm missing on a bare host, or no route to the registry. Nothing has been
+    planned or mutated yet, so this fails like an invalid manifest does: one
+    message on stderr, nothing on stdout, and a nonzero exit.
+    """
+    try:
+        yield
+    except RuntimeError as error:
+        console.print(f"Planning failed: {error}")
+        raise typer.Exit(_FAILURE_EXIT_CODE) from error
 
 
 def _console() -> Console:

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -667,6 +667,78 @@ def test_failed_apply_exits_nonzero_and_still_emits_one_json_document(
     assert [entry["status"] for entry in document["results"]] == ["failed"]
 
 
+def test_version_resolution_failure_exits_cleanly_with_empty_stdout(
+    tmp_path: Path,
+    config_home: Path,
+    command_runner: RecordingRunner,
+    calls: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bare host without npm must fail like an invalid manifest, not crash.
+
+    Adapters raise RuntimeError when ``npm view`` cannot resolve a version;
+    unhandled, that is a traceback and a stdout no JSON consumer can parse.
+    """
+    manifest = write_manifest(tmp_path)
+
+    def exploding_plan(state: DesiredState, _adapters: object) -> InstallPlan:
+        raise RuntimeError("could not run npm: No such file or directory")
+
+    monkeypatch.setattr(cli, "build_install_plan", exploding_plan)
+
+    result = runner.invoke(app, ["install", "--config", str(manifest)])
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, SystemExit), "the failure must be a clean exit"
+    assert calls["apply"] == []
+    assert result.stdout == ""
+    assert "could not run npm" in result.stderr
+
+
+def test_version_resolution_failure_during_dry_run_exits_cleanly(
+    tmp_path: Path,
+    config_home: Path,
+    command_runner: RecordingRunner,
+    calls: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = write_manifest(tmp_path)
+
+    def exploding_plan(state: DesiredState, _adapters: object) -> InstallPlan:
+        raise RuntimeError("could not resolve hallouminate@latest with npm view")
+
+    monkeypatch.setattr(cli, "build_install_plan", exploding_plan)
+
+    result = runner.invoke(app, ["install", "--config", str(manifest), "--dry-run"])
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, SystemExit)
+    assert result.stdout == ""
+    assert "could not resolve" in result.stderr
+
+
+def test_doctor_version_resolution_failure_exits_cleanly(
+    tmp_path: Path,
+    config_home: Path,
+    command_runner: RecordingRunner,
+    calls: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = write_manifest(tmp_path)
+
+    def exploding_verify(state: DesiredState, _adapters: object, _runner: object) -> DoctorReport:
+        raise RuntimeError("could not run npm: No such file or directory")
+
+    monkeypatch.setattr(cli, "verify_desired_state", exploding_verify)
+
+    result = runner.invoke(app, ["doctor", "--config", str(manifest)])
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, SystemExit)
+    assert result.stdout == ""
+    assert "could not run npm" in result.stderr
+
+
 # ─── Interactive install: persistence and cancellation ───────────────────────
 
 


### PR DESCRIPTION
## What

Dogfooding `bootstrap.sh` on a simulated bare host (no npm on PATH) surfaced a crash: `cheese install --json` died with a raw RuntimeError traceback and emitted **no JSON document on stdout**, breaking the headless output contract ("stdout carries exactly one JSON document and nothing else"). Both `install` and `doctor` were exposed, since both funnel version resolution through `build_install_plan`, where the hallouminate/tilth adapters shell out to `npm view`.

## Fix

Catch the adapters' resolution `RuntimeError` at the CLI boundary (`_resolution_failure_reported` context manager) and fail the way an invalid manifest already does: one diagnostic on stderr, empty stdout, exit 1. Nothing has been planned or mutated at that point, so there is no partial state to report.

Before:
```
╭───── Traceback (most recent call last) ─────╮
│ ... 40 lines of rich traceback ...          │
RuntimeError: could not resolve hallouminate@latest with npm view (exit 127): could not run npm: ...
```

After:
```
Planning failed: could not resolve hallouminate@latest with npm view (exit 127): could not run npm: No such file or directory
```

## Dogfood results (what else was exercised)

- `curl-pipe-sh` path from the local checkout via `CHEESE_REPOSITORY`: succeeded; second run skipped all six steps (idempotent).
- Bare-host path (uvx hidden from PATH): pinned-installer download → SHA-256 verify → uv install → PATH fixup → exec — worked end to end with a stubbed installer pinned per the AGENTS.md test convention.
- Tamper test (installer body not matching the pin): refused with expected/actual hashes printed, tampered body never executed, exit 1.
- Note: on this sandbox's network policy `astral.sh` is blocked (403 at the egress proxy); bootstrap failed with the correct "uv install failed; install uv and re-run" message — behavior as designed, no change needed.

## Testing

- 3 new regression tests in `tests/python/test_cli.py` (install, install --dry-run, doctor).
- Build gate run via the recipe's underlying commands (`just` unavailable in this sandbox): ruff format/check clean, pytest green except pre-existing `test_writability_reflects_filesystem_permission`, which fails on any tree here because the sandbox runs as root and root ignores directory permission bits.
- Verified the real bare-host scenario post-fix: clean one-line diagnostic, empty stdout, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvUUfq1C5LTp3Z2ymWTHHK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvUUfq1C5LTp3Z2ymWTHHK)_