### PR TITLE
fix(install): bound stalled git transfers so a cloud setup fails fast instead of hanging

### DIFF
--- a/.hallouminate/wiki/gotchas/git-has-no-read-timeout.md
+++ b/.hallouminate/wiki/gotchas/git-has-no-read-timeout.md
@@ -1,0 +1,24 @@
+# Git has no read timeout — the install tree bounds it via GIT_HTTP_LOW_SPEED_*
+
+`git fetch`/`clone` waits forever on a connection that is accepted and then stalls (verified empirically against an accept-then-silent server). Behind a filtering egress proxy — Claude Code on the web's sandbox is the motivating case — this hung the bootstrap one-liner unbounded, *before* `cheese install`'s per-command timeout existed to catch it (PR #94, diagnosis in `.cheese/pasteurize/cloud-setup-hang.md`).
+
+## The invariant
+
+Every git the install tree runs must inherit `GIT_HTTP_LOW_SPEED_LIMIT` / `GIT_HTTP_LOW_SPEED_TIME` (defaults 1000 B/s over 30 s). It lives in **two deliberate places** — unavoidable across the sh/Python boundary, cross-referenced in comments:
+
+- `bootstrap.sh` `main()` — covers the `uvx --from git+…` clone the script execs, which the runner can never reach.
+- `cli.py` `_default_runner` — covers child clones (`claude plugin marketplace add`, `npx skills add`) from **every** entry point: bootstrap, checkout, direct `uvx`, and `doctor`.
+
+## Semantics that matter
+
+- **Caller wins**: both sites treat a caller-set value as authoritative. `SubprocessRunner._environment` is `{**os.environ, **self._env}`, so the runner must inject only-if-absent — a plain overlay would clobber the caller.
+- **Empty counts as absent** (`not os.environ.get(key)`, matching `${VAR:-}`): git parses an exported-but-empty value as an error, warns, and silently disables the guard.
+- uv runs its git with terminal prompts disabled, so the `/dev/tty` reconnect (#92) cannot cause a credential-prompt hang — falsified hypothesis, don't re-investigate.
+
+## Known residual
+
+The pinned uv installer's *internal* curl (inside the SHA-pinned `astral.sh` script) has no `--max-time` — the pre-`cheese install` window is not fully closed. POSIX sh has no watchdog and macOS lacks `timeout(1)`; accepted as residual, not a fixable-here bug.
+
+## Cloud-sandbox facts (primary-sourced, 2026-08)
+
+Research slug: `.cheese/research/claude-code-cloud-setup-sandbox/`. Highlights: `astral.sh` is NOT on the default package-manager allowlist (github.com, objects.githubusercontent.com, pypi.org are); setup scripts get a ~5-minute soft budget and must exit 0; setup stdout/stderr is not retrievable afterwards. Hence README's advice to append `--timeout 90` on time-budgeted sandbox setups.

--- a/.hallouminate/wiki/gotchas/index.md
+++ b/.hallouminate/wiki/gotchas/index.md
@@ -2,6 +2,7 @@
 
 <!-- HALLOUMINATE:INDEX-START -->
 - [gh-skill-provenance](./gh-skill-provenance.md) — gh skill provenance
+- [git-has-no-read-timeout](./git-has-no-read-timeout.md) — Git has no read timeout — the install tree bounds it via GIT_HTTP_LOW_SPEED_*
 - [pydantic-lax-coercion-at-the-manifest-boundary](./pydantic-lax-coercion-at-the-manifest-boundary.md) — Pydantic lax coercion at the manifest boundary
 - [subprocess-timeout-output-capture](./subprocess-timeout-output-capture.md) — Subprocess timeout output capture
 <!-- HALLOUMINATE:INDEX-END -->

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ curl -fsSL https://raw.githubusercontent.com/paulnsorensen/cheese-flow/main/boot
 
 `bootstrap.sh` installs `uv` when it is absent and hands every argument after `--` to `cheese install`. Pass the state options: piping the script into `sh` consumes stdin, which is what the interactive wizard reads, so this path is headless by construction.
 
+On a time-budgeted sandbox setup (e.g. Claude Code on the web's setup script, ~5-minute budget), append `--timeout 90` so a stuck child fails inside the budget instead of consuming the default 900s — it's a budget-derived floor, so raise it if a legitimate step (e.g. a cold `npm install -g`) trips it.
+
+Every `cheese` run bounds stalled git transfers via `GIT_HTTP_LOW_SPEED_LIMIT`/`GIT_HTTP_LOW_SPEED_TIME` (1000 B/s over 30s by default); caller-set values win.
+
 The only host prerequisites are `curl`, `git`, and the `npm` toolchain the components install themselves with. No GitHub CLI is needed.
 
 ### From a checkout

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -104,6 +104,16 @@ main() {
         exit 1
     fi
 
+    # git has no read timeout of its own: a proxied host that accepts the
+    # connection and then stalls hangs the uvx clone below forever, before
+    # `cheese install`'s own per-command timeout exists to catch it. Exporting
+    # rather than flagging means every git the install tree runs — this clone
+    # and every child clone `cheese install` runs later — inherits the bound.
+    # `:-` defaults keep a caller's own tuning authoritative.
+    GIT_HTTP_LOW_SPEED_LIMIT="${GIT_HTTP_LOW_SPEED_LIMIT:-1000}"
+    GIT_HTTP_LOW_SPEED_TIME="${GIT_HTTP_LOW_SPEED_TIME:-30}"
+    export GIT_HTTP_LOW_SPEED_LIMIT GIT_HTTP_LOW_SPEED_TIME
+
     # Under `curl … | sh` this script *is* stdin, so the child inherits a pipe
     # sitting at EOF and the wizard's first read looks like the user quitting.
     # Reconnect the terminal so an argument-less run reaches the wizard. When

--- a/python/cheese_flow/cli.py
+++ b/python/cheese_flow/cli.py
@@ -11,6 +11,7 @@ nothing else. Every prompt, progress line, and diagnostic goes to stderr.
 from __future__ import annotations
 
 import json
+import os
 import sys
 import tempfile
 from collections.abc import Iterator, Mapping
@@ -46,6 +47,11 @@ from cheese_flow.tui import run_wizard
 
 _MANIFEST_EXIT_CODE = 2
 _FAILURE_EXIT_CODE = 1
+
+# git has no read timeout of its own; every child clone must abort a stalled
+# transfer instead of hanging forever. bootstrap.sh sets the same bound for the
+# uvx clone it execs directly, which this runner cannot reach.
+_GIT_LOW_SPEED_DEFAULTS = {"GIT_HTTP_LOW_SPEED_LIMIT": "1000", "GIT_HTTP_LOW_SPEED_TIME": "30"}
 
 app = typer.Typer(
     name="cheese",
@@ -198,7 +204,14 @@ def _default_runner(
     *,
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> CommandRunner:
-    return SubprocessRunner(env=env, timeout=timeout)
+    # Only fill in a default when the caller hasn't exported a non-empty value —
+    # SubprocessRunner overlays ``env`` on top of ``os.environ``, so a plain
+    # unconditional default would override a caller-set value.
+    overlay = {
+        key: value for key, value in _GIT_LOW_SPEED_DEFAULTS.items() if not os.environ.get(key)
+    }
+    overlay.update(env or {})
+    return SubprocessRunner(env=overlay, timeout=timeout)
 
 
 def _tokens(values: list[str] | None) -> tuple[str, ...]:

--- a/tests/python/test_bootstrap.py
+++ b/tests/python/test_bootstrap.py
@@ -13,6 +13,7 @@ import pty
 import re
 import stat as stat_mod
 import subprocess
+from collections.abc import Mapping
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -63,6 +64,16 @@ printf '%s' "$INSTALLER_BODY" > "$target"
 """
 
 
+# Records $0, argv, and the two git low-speed env vars the exec'd child must
+# see — argv alone can't show whether bootstrap.sh exported them.
+GIT_ENV_SHIM = """#!/bin/sh
+limit="${GIT_HTTP_LOW_SPEED_LIMIT:-unset}"
+low_speed_time="${GIT_HTTP_LOW_SPEED_TIME:-unset}"
+record="$0 $* GIT_HTTP_LOW_SPEED_LIMIT=$limit GIT_HTTP_LOW_SPEED_TIME=$low_speed_time"
+printf '%s\\n' "$record" >> "$RECORD"
+"""
+
+
 def _shim(directory: Path, name: str, body: str = RECORDING_SHIM) -> Path:
     directory.mkdir(parents=True, exist_ok=True)
     shim = directory / name
@@ -97,6 +108,7 @@ def _invoke(
     repository: str | None = None,
     script: Path | None = None,
     installer_body: str = UV_INSTALLER_BODY,
+    env_overrides: Mapping[str, str] | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     """Run the script with ``path`` at the head of ``PATH``; return it and what ran."""
     record = tmp_path / "record"
@@ -112,8 +124,12 @@ def _invoke(
     }
     env.pop("XDG_BIN_HOME", None)
     env.pop("CHEESE_REPOSITORY", None)
+    env.pop("GIT_HTTP_LOW_SPEED_LIMIT", None)
+    env.pop("GIT_HTTP_LOW_SPEED_TIME", None)
     if repository is not None:
         env["CHEESE_REPOSITORY"] = repository
+    if env_overrides is not None:
+        env.update(env_overrides)
     completed = subprocess.run(
         ["/bin/sh", str(script or SCRIPT_PATH), *args],
         capture_output=True,
@@ -131,9 +147,16 @@ def _run(
     home: Path,
     repository: str | None = None,
     script: Path | None = None,
+    env_overrides: Mapping[str, str] | None = None,
 ) -> list[str]:
     completed, ran = _invoke(
-        tmp_path, *args, path=path, home=home, repository=repository, script=script
+        tmp_path,
+        *args,
+        path=path,
+        home=home,
+        repository=repository,
+        script=script,
+        env_overrides=env_overrides,
     )
     assert completed.returncode == 0, completed.stderr
     return ran
@@ -156,6 +179,52 @@ def test_hands_every_argument_to_a_headless_cheese_install(tmp_path: Path) -> No
 
     assert ran == [
         f"{bin_dir / 'uvx'} {FROM} cheese install --harness claude-code --repo /srv/code/project"
+    ]
+
+
+def test_exports_git_low_speed_abort_for_the_exec_child(tmp_path: Path) -> None:
+    """git has no read timeout of its own; the uvx clone (and every child clone
+    `cheese install` runs later) must abort a stalled transfer instead of
+    hanging forever, before `cheese install`'s own timeout exists to catch it."""
+    bin_dir = tmp_path / "bin"
+    _shim(bin_dir, "uvx", GIT_ENV_SHIM)
+    _shim(bin_dir, "curl")
+
+    ran = _run(
+        tmp_path,
+        "--harness",
+        "claude-code",
+        path=bin_dir,
+        home=tmp_path / "home",
+    )
+
+    assert ran == [
+        f"{bin_dir / 'uvx'} {FROM} cheese install --harness claude-code "
+        "GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME=30"
+    ]
+
+
+def test_preserves_caller_supplied_git_low_speed_bounds(tmp_path: Path) -> None:
+    """A caller's own tuning stays authoritative; only the missing half fills
+    in. Overrides TIME only, so this also covers TIME-override (LIMIT-override
+    coverage lives in test_cli.py's
+    ``test_default_runner_lets_a_caller_exported_bound_win``)."""
+    bin_dir = tmp_path / "bin"
+    _shim(bin_dir, "uvx", GIT_ENV_SHIM)
+    _shim(bin_dir, "curl")
+
+    ran = _run(
+        tmp_path,
+        "--harness",
+        "claude-code",
+        path=bin_dir,
+        home=tmp_path / "home",
+        env_overrides={"GIT_HTTP_LOW_SPEED_TIME": "5"},
+    )
+
+    assert ran == [
+        f"{bin_dir / 'uvx'} {FROM} cheese install --harness claude-code "
+        "GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME=5"
     ]
 
 

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -917,3 +917,69 @@ def test_without_the_timeout_option_the_runner_gets_the_package_default(
 
     assert result.exit_code == 0, result.stderr
     assert built_timeouts == [DEFAULT_TIMEOUT_SECONDS]
+
+
+# ─── Git low-speed bound ─────────────────────────────────────────────────────
+
+
+def test_default_runner_bounds_a_stalled_git_clone_for_every_child(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """bootstrap.sh only bounds the uvx clone it execs; every child the runner
+    itself spawns (``npx skills add``, ``claude plugin marketplace add``, and
+    the checkout / uvx entry points bootstrap.sh cannot reach) must inherit the
+    same stall guard."""
+    monkeypatch.delenv("GIT_HTTP_LOW_SPEED_LIMIT", raising=False)
+    monkeypatch.delenv("GIT_HTTP_LOW_SPEED_TIME", raising=False)
+    script = 'printf "%s %s" "$GIT_HTTP_LOW_SPEED_LIMIT" "$GIT_HTTP_LOW_SPEED_TIME"'
+
+    outcome = cli._default_runner().run(("sh", "-c", script))
+
+    assert outcome.stdout == "1000 30"
+
+
+def test_default_runner_lets_a_caller_exported_bound_win(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mixed state: only LIMIT is caller-set, so this also covers the LIMIT
+    override (TIME-override coverage lives in test_bootstrap.py's
+    ``test_preserves_caller_supplied_git_low_speed_bounds``)."""
+    monkeypatch.setenv("GIT_HTTP_LOW_SPEED_LIMIT", "42")
+    monkeypatch.delenv("GIT_HTTP_LOW_SPEED_TIME", raising=False)
+    script = 'printf "%s %s" "$GIT_HTTP_LOW_SPEED_LIMIT" "$GIT_HTTP_LOW_SPEED_TIME"'
+
+    outcome = cli._default_runner().run(("sh", "-c", script))
+
+    assert outcome.stdout == "42 30"
+
+
+def test_default_runner_passes_a_caller_env_through_with_the_git_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for a mutant that drops ``overlay.update(env or {})``: the
+    dry-run npm cache override (spec:105) must survive alongside the git
+    stall guard, not get clobbered by it."""
+    monkeypatch.delenv("GIT_HTTP_LOW_SPEED_LIMIT", raising=False)
+    monkeypatch.delenv("GIT_HTTP_LOW_SPEED_TIME", raising=False)
+    script = (
+        'printf "%s %s %s" "$npm_config_cache" '
+        '"$GIT_HTTP_LOW_SPEED_LIMIT" "$GIT_HTTP_LOW_SPEED_TIME"'
+    )
+
+    outcome = cli._default_runner({"npm_config_cache": "/tmp/x"}).run(("sh", "-c", script))
+
+    assert outcome.stdout == "/tmp/x 1000 30"
+
+
+def test_default_runner_fills_the_default_when_the_caller_exported_an_empty_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exported-but-empty value must not skip the default: git 2.50.1
+    fails to parse an empty low-speed-time and disables the guard entirely."""
+    monkeypatch.setenv("GIT_HTTP_LOW_SPEED_TIME", "")
+    monkeypatch.delenv("GIT_HTTP_LOW_SPEED_LIMIT", raising=False)
+    script = 'printf "%s %s" "$GIT_HTTP_LOW_SPEED_LIMIT" "$GIT_HTTP_LOW_SPEED_TIME"'
+
+    outcome = cli._default_runner().run(("sh", "-c", script))
+
+    assert outcome.stdout == "1000 30"


### PR DESCRIPTION
## Why

Claude Code on the web environments running the bootstrap one-liner hung forever at setup. Diagnosis (full pipeline in `.cheese/pasteurize/cloud-setup-hang.md`): **git has no read timeout** — behind an egress proxy that accepts a connection and then stalls, the `uvx --from git+…` clone bootstrap execs waits unbounded, *before* `cheese install`'s per-command timeout exists. Verified empirically: `git fetch` against an accept-then-silent server never returns; with `GIT_HTTP_LOW_SPEED_*` set it aborts exactly at the configured window. Compounding factors: the 900s default child timeout triples the cloud's ~5-minute setup budget, and setup logs aren't retrievable, so everything renders as a spinner. (Falsified along the way: the `/dev/tty` reconnect from #92 causing a credential-prompt hang — uv runs git with terminal prompts disabled.)

## What (semantics-altering)

- **bootstrap.sh** — export `GIT_HTTP_LOW_SPEED_LIMIT`/`GIT_HTTP_LOW_SPEED_TIME` (1000 B/s over 30 s) before both exec paths; `:-` defaults keep caller-set values authoritative. Covers the pre-install uvx clone the runner can't reach.
- **cli.py** — inject the same defaults only-if-absent in `_default_runner`, so every entry point (bootstrap, checkout, direct `uvx`) bounds child clones (`claude plugin marketplace add`, `npx skills add`) for install, dry-run, and doctor. Exported-but-empty counts as absent, matching `${VAR:-}` (git warns and disables the guard on an empty value).
- **README** — documents the bound entry-point-neutrally; recommends `--timeout 90` on time-budgeted sandbox setups (budget-derived floor, raise if a legitimate step trips it).

## Reviewer should verify

1. Caller precedence: `SubprocessRunner._environment` is `{**os.environ, **self._env}`, so the only-if-absent overlay is what keeps a caller-exported value winning — `test_default_runner_lets_a_caller_exported_bound_win` (mixed-state, mutation-kills an all-or-nothing predicate) and `test_preserves_caller_supplied_git_low_speed_bounds` at the exec seam.
2. The dry-run throwaway npm cache still passes through the new merge — `test_default_runner_passes_a_caller_env_through_with_the_git_bound`.
3. The `1000/30` literals exist in both sh and Python deliberately (cross-referenced comments; unavoidable across the boundary).

Known residual (out of scope, documented): the pinned uv installer's internal curl is unbounded — POSIX sh offers no watchdog; the installer fetch itself is bounded (`--max-time 120`) and SHA-pinned.

Tests: 6 new regression tests, all observed red first; three predicate mutants killed. `just build`: 471 passed; the 5 failures are the pre-existing macOS-only environment gaps (stash-verified identical without this diff) and don't occur on Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
