### PR TITLE
feat(tilth): install from the paulnsorensen/tilth nightly release, not npm

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -74,7 +74,7 @@ jobs:
           # failing exit code here instead of a job that burns its 20 minutes
           # and reports nothing about which step is stuck.
           timeout --signal=KILL 900 sh ./bootstrap.sh \
-            --harness ${{ matrix.harness }} --json --timeout 240 \
+            --harness ${{ matrix.harness }} --json --timeout 420 \
             </dev/null | tee report.json
 
       # `always()` so a nonzero install still gets graded: the step table naming

--- a/.hallouminate/wiki/gotchas/index.md
+++ b/.hallouminate/wiki/gotchas/index.md
@@ -5,4 +5,5 @@
 - [git-has-no-read-timeout](./git-has-no-read-timeout.md) — Git has no read timeout — the install tree bounds it via GIT_HTTP_LOW_SPEED_*
 - [pydantic-lax-coercion-at-the-manifest-boundary](./pydantic-lax-coercion-at-the-manifest-boundary.md) — Pydantic lax coercion at the manifest boundary
 - [subprocess-timeout-output-capture](./subprocess-timeout-output-capture.md) — Subprocess timeout output capture
+- [tilth-installs-from-nightly-release](./tilth-installs-from-nightly-release.md) — Tilth installs from the paulnsorensen/tilth nightly release — npm `tilth` is someone else's package
 <!-- HALLOUMINATE:INDEX-END -->

--- a/.hallouminate/wiki/gotchas/tilth-installs-from-nightly-release.md
+++ b/.hallouminate/wiki/gotchas/tilth-installs-from-nightly-release.md
@@ -1,0 +1,18 @@
+# Tilth installs from the paulnsorensen/tilth nightly release — npm `tilth` is someone else's package
+
+The npm package `tilth` declares `repository: github.com/jahala/tilth` — a different publisher. cheese-flow's TilthAdapter therefore does **not** use npm/npx: it downloads the platform-triple binary (`tilth-<triple>.tar.gz` + `.sha256` sidecar) from `https://github.com/paulnsorensen/tilth/releases/download/nightly/`, verifies the digest, and installs atomically into `${XDG_BIN_HOME:-$HOME/.local/bin}` (PR stacked on #94).
+
+## Decisions (user-locked, don't relitigate)
+
+- **Rolling nightly, sidecar integrity, no pinning** — a nightly cannot be content-pinned like the uv installer; the `.sha256` sidecar over pinned TLS is the bar.
+- **Install-once** — postcondition is "installed binary runs `--version` exit 0". No digest drift-chasing: `cheese doctor` must not go red every morning a nightly publishes. Upgrade = remove the binary and re-run.
+- **Stale `npx tilth` entries are rejected** by `_launches_tilth` on purpose — accepting them would leave harnesses launching the foreign npm package forever.
+
+## The republish window (measured 2026-08-02)
+
+The nightly workflow deletes and re-uploads assets around ~19:00Z: each asset 404s for ~75s+ even while the API reports it `uploaded`. Hence both curls carry `--retry 4 --retry-delay 15 --retry-all-errors --retry-max-time 120 --max-time 60` (plain `--retry` does NOT retry 404s; `--max-time` is per attempt, so the envelope, not the flag, bounds wall clock: ~180s/curl, ~370s/script — smoke's per-step `--timeout 420` and the 900s runner default both fit). A digest mismatch during the window surfaces as a refusal naming the republish race — a sidecar re-fetch was tried and removed: the sidecar downloads after the tarball, so it is always at least as fresh and cannot rescue the race.
+
+## Requirements this created
+
+- curl ≥ 7.71 (`--retry-all-errors`), `tar`, `sha256sum` or `shasum` — named in README prerequisites.
+- `${XDG_BIN_HOME:-$HOME/.local/bin}` on PATH for the dev-time `.mcp.json` entry (`command: tilth`); harness configs are immune — registration writes the absolute path.

--- a/.hallouminate/wiki/gotchas/tilth-installs-from-nightly-release.md
+++ b/.hallouminate/wiki/gotchas/tilth-installs-from-nightly-release.md
@@ -6,6 +6,7 @@ The npm package `tilth` declares `repository: github.com/jahala/tilth` — a dif
 
 - **Rolling nightly, sidecar integrity, no pinning** — a nightly cannot be content-pinned like the uv installer; the `.sha256` sidecar over pinned TLS is the bar.
 - **Install-once** — postcondition is "installed binary runs `--version` exit 0". No digest drift-chasing: `cheese doctor` must not go red every morning a nightly publishes. Upgrade = remove the binary and re-run.
+- **Harness registration must stay absolute** — `_launches_tilth` accepts only an absolute command path whose basename is `tilth`. Bare `command: "tilth"` is not converged because the install directory may be absent from `PATH`; another absolute Tilth path remains acceptable.[^1]
 - **Stale `npx tilth` entries are rejected** by `_launches_tilth` on purpose — accepting them would leave harnesses launching the foreign npm package forever.
 
 ## The republish window (measured 2026-08-02)
@@ -15,4 +16,8 @@ The nightly workflow deletes and re-uploads assets around ~19:00Z: each asset 40
 ## Requirements this created
 
 - curl ≥ 7.71 (`--retry-all-errors`), `tar`, `sha256sum` or `shasum` — named in README prerequisites.
-- `${XDG_BIN_HOME:-$HOME/.local/bin}` on PATH for the dev-time `.mcp.json` entry (`command: tilth`); harness configs are immune — registration writes the absolute path.
+- `${XDG_BIN_HOME:-$HOME/.local/bin}` on `PATH` for the dev-time `.mcp.json` entry (`command: tilth`); harness configs are immune — registration writes the absolute path.
+
+[^1]: `python/cheese_flow/adapters/tilth.py:112-119`; `tests/python/test_adapters.py:1366-1372`; PR #95 restacked commit `19c9625`.
+
+_Source: /affinage PR #95 fresh review and cure · Updated: 2026-08-02 · Supersedes: —_

--- a/.hallouminate/wiki/index.md
+++ b/.hallouminate/wiki/index.md
@@ -5,4 +5,5 @@
 - [architecture/](./architecture/index.md) — architecture
 - [gotchas/](./gotchas/index.md) — gotchas
 - [domain-model](./domain-model.md) — Cheese-flow domain model
+- [log](./log.md) — Ingest Log
 <!-- HALLOUMINATE:INDEX-END -->

--- a/.hallouminate/wiki/log.md
+++ b/.hallouminate/wiki/log.md
@@ -1,0 +1,5 @@
+# Ingest Log
+
+## Log
+
+2026-08-02 · 49c3e71a79cff4ae · merged · gotchas/tilth-installs-from-nightly-release.md · Recorded the absolute-command convergence invariant found and cured by /affinage PR #95.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "tilth": {
-      "command": "npx",
-      "args": ["tilth", "--mcp", "--edit"]
+      "command": "tilth",
+      "args": ["--mcp", "--edit"]
     },
     "context7": {
       "command": "npx",

--- a/README.md
+++ b/README.md
@@ -38,11 +38,13 @@ curl -fsSL https://raw.githubusercontent.com/paulnsorensen/cheese-flow/main/boot
 
 `bootstrap.sh` installs `uv` when it is absent and hands every argument after `--` to `cheese install`. Pass the state options: piping the script into `sh` consumes stdin, which is what the interactive wizard reads, so this path is headless by construction.
 
-On a time-budgeted sandbox setup (e.g. Claude Code on the web's setup script, ~5-minute budget), append `--timeout 90` so a stuck child fails inside the budget instead of consuming the default 900s — it's a budget-derived floor, so raise it if a legitimate step (e.g. a cold `npm install -g`) trips it.
+On a time-budgeted sandbox setup (e.g. Claude Code on the web's setup script, ~5-minute budget), append `--timeout 90` so a stuck child fails inside the budget instead of consuming the default 900s — it's a budget-derived floor, so raise it if a legitimate step (e.g. a cold `npm install -g` or the tilth nightly download) trips it.
 
 Every `cheese` run bounds stalled git transfers via `GIT_HTTP_LOW_SPEED_LIMIT`/`GIT_HTTP_LOW_SPEED_TIME` (1000 B/s over 30s by default); caller-set values win.
 
-The only host prerequisites are `curl`, `git`, and the `npm` toolchain the components install themselves with. No GitHub CLI is needed.
+The only host prerequisites are `curl` ≥ 7.71 (needed for `--retry-all-errors`), `git`, `tar`, a sha256 tool (`sha256sum` or `shasum`), and the `npm` toolchain the npm-based components install themselves with; `tilth` downloads its own binary. No GitHub CLI is needed. During the nightly republish window the tilth download can retry for up to ~2 min per file.
+
+Registered harnesses launch `tilth` from `${XDG_BIN_HOME:-$HOME/.local/bin}`, so that directory must be on `PATH`.
 
 ### From a checkout
 

--- a/python/cheese_flow/adapters/tilth.py
+++ b/python/cheese_flow/adapters/tilth.py
@@ -1,7 +1,11 @@
-"""Tilth adapter: config-preserving MCP registration per harness."""
+"""Tilth adapter: installs Tilth from the paulnsorensen/tilth nightly GitHub
+release, then registers it with each selected harness's native config."""
 
 from __future__ import annotations
 
+import os
+import platform
+import shlex
 from pathlib import Path
 
 from cheese_flow.adapters.native_config import read_mcp_entry
@@ -20,17 +24,98 @@ PACKAGE = "tilth"
 EDIT_FLAG = "--edit"
 """Edit mode is always requested, so ``--edit`` must be present in the entry."""
 
+INSTALL_STEP = "tilth:install"
 
-def _launches_tilth(command: str, args: list[str]) -> bool:
-    """Whether an MCP entry launches Tilth itself.
+RELEASE_URL = "https://github.com/paulnsorensen/tilth/releases/download/nightly"
+"""Rolling nightly release: no version pin. Integrity comes from the sidecar digest."""
 
-    ``tilth install`` writes ``npx tilth …`` only when it runs from a
-    node_modules shim; a globally installed binary is written as its own
-    absolute path instead.
+_TRIPLE_VENDORS: dict[str, str] = {
+    "Darwin": "apple-darwin",
+    "Linux": "unknown-linux-musl",
+}
+
+
+def _target_triple() -> str:
+    """The nightly release asset triple for the running platform."""
+    system = platform.system()
+    raw_machine = platform.machine()
+    machine = "aarch64" if raw_machine == "arm64" else raw_machine
+    vendor = _TRIPLE_VENDORS.get(system)
+    if vendor is None or machine not in ("aarch64", "x86_64"):
+        raise RuntimeError(f"could not resolve a tilth release asset for {system}/{raw_machine}")
+    return f"{machine}-{vendor}"
+
+
+def _bin_dir() -> Path:
+    """Where the tilth binary is installed, honoring ``XDG_BIN_HOME`` like bootstrap.sh."""
+    xdg_bin_home = os.environ.get("XDG_BIN_HOME")
+    return Path(xdg_bin_home) if xdg_bin_home else Path.home() / ".local" / "bin"
+
+
+def _install_script(triple: str, bin_dir: Path) -> str:
+    """POSIX sh: bounded, retried download of the tarball and its sidecar, digest
+    verification, and an atomic install."""
+    tarball_url = f"{RELEASE_URL}/tilth-{triple}.tar.gz"
+    sidecar_url = f"{tarball_url}.sha256"
+    quoted_bin_dir = shlex.quote(str(bin_dir))
+    return f"""set -eu
+workdir="$(mktemp -d)"
+staged=""
+trap 'rm -rf "$workdir" "$staged"' EXIT
+
+sha256_of() {{
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | cut -d' ' -f1
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | cut -d' ' -f1
+    else
+        echo "cheese: no sha256sum or shasum available to verify tilth" >&2
+        exit 1
+    fi
+}}
+
+# Retry envelope covers the measured ~75s nightly-republish 404 window; worst
+# case ~180s per curl, ~370s for the script.
+curl -fsSL --proto '=https' --tlsv1.2 --connect-timeout 10 --max-time 60 \\
+    --retry 4 --retry-delay 15 --retry-all-errors --retry-max-time 120 \\
+    -o "$workdir/tilth.tar.gz" '{tarball_url}' \\
+    || {{ echo "cheese: could not download tilth for {triple} from {tarball_url}" >&2; exit 1; }}
+curl -fsSL --proto '=https' --tlsv1.2 --connect-timeout 10 --max-time 60 \\
+    --retry 4 --retry-delay 15 --retry-all-errors --retry-max-time 120 \\
+    -o "$workdir/tilth.tar.gz.sha256" '{sidecar_url}' \\
+    || {{
+        echo "cheese: could not download the checksum for tilth {triple} from {sidecar_url}" >&2
+        exit 1
+    }}
+
+expected="$(cut -d' ' -f1 "$workdir/tilth.tar.gz.sha256")"
+actual="$(sha256_of "$workdir/tilth.tar.gz")" || exit 1
+[ -n "$actual" ] || {{ echo "cheese: could not hash the tilth download" >&2; exit 1; }}
+if [ "$actual" != "$expected" ]; then
+    echo "cheese: refusing to install tilth — checksum mismatch" >&2
+    echo "  expected $expected" >&2
+    echo "  actual   $actual" >&2
+    echo "  url      {tarball_url}" >&2
+    echo "  (a nightly republish mid-download is a likely benign cause; retry)" >&2
+    exit 1
+fi
+
+tar -xzf "$workdir/tilth.tar.gz" -C "$workdir"
+mkdir -p {quoted_bin_dir}
+staged="$(mktemp {quoted_bin_dir}/tilth.XXXXXX)"
+mv "$workdir/tilth" "$staged"
+chmod +x "$staged"
+mv "$staged" {quoted_bin_dir}/tilth
+"""
+
+
+def _launches_tilth(command: str) -> bool:
+    """Whether an MCP entry launches Tilth's installed binary.
+
+    ``tilth install`` writes the binary's own absolute path; a stale
+    npm-era ``npx tilth`` entry no longer counts.
     """
-    if command == "npx":
-        return bool(args) and args[0] == PACKAGE
-    return Path(command).stem == PACKAGE
+    return Path(command).name == PACKAGE
 
 
 # Native user-scope MCP config per harness, relative to the home directory.
@@ -42,48 +127,50 @@ _CONFIG_PATHS: dict[HarnessName, str] = {
 
 
 class TilthAdapter:
-    """Registers Tilth's MCP server in each selected harness's native config."""
+    """Installs Tilth from the nightly GitHub release, then registers its MCP
+    server in each selected harness's native config."""
 
     name: ComponentName = "tilth"
 
     def __init__(self, runner: CommandRunner) -> None:
         self._runner = runner
-        self._version: str | None = None
-
-    def resolved_version(self) -> str:
-        """Resolve ``tilth@latest`` once per run and cache it in memory."""
-        if self._version is None:
-            outcome = self._runner.run(("npm", "view", f"{PACKAGE}@latest", "version"))
-            version = outcome.stdout.strip()
-            if outcome.exit_code != 0 or not version:
-                raise RuntimeError(
-                    f"could not resolve {PACKAGE}@latest with npm view "
-                    f"(exit {outcome.exit_code}): "
-                    f"{outcome.stderr.strip() or outcome.stdout.strip()}"
-                )
-            self._version = version
-        return self._version
 
     def plan_steps(self, state: DesiredState) -> tuple[PlanStep, ...]:
-        """Resolve ``tilth@latest`` once and emit ``npx tilth@<version> install`` steps."""
+        """Emit one install step and one register step per selected harness."""
         if self.name not in state.components:
             return ()
-        version = self.resolved_version()
-        return tuple(
+        triple = _target_triple()
+        bin_dir = _bin_dir()
+        binary = bin_dir / PACKAGE
+        steps: list[PlanStep] = [
+            PlanStep(
+                step_id=INSTALL_STEP,
+                component=self.name,
+                phase=Phase.INSTALL,
+                argv=("sh", "-c", _install_script(triple, bin_dir)),
+                postcondition=f"`{binary} --version` exits 0",
+            )
+        ]
+        steps.extend(
             PlanStep(
                 step_id=f"tilth:register:{harness}",
                 component=self.name,
                 harness=harness,
                 phase=Phase.REGISTER,
-                argv=("npx", "--yes", f"{PACKAGE}@{version}", "install", harness, "--edit"),
+                argv=(str(binary), "install", harness, "--edit"),
                 postcondition=(f"{_CONFIG_PATHS[harness]} holds the tilth MCP entry in edit mode"),
+                depends_on=(INSTALL_STEP,),
             )
             for harness in HARNESS_NAMES
             if harness in state.harnesses
         )
+        return tuple(steps)
 
     def check_postcondition(self, step: PlanStep, runner: CommandRunner) -> bool:
-        """Confirm the harness config holds the expected Tilth MCP command and edit mode."""
+        """Confirm the installed binary runs, or the harness config holds the entry."""
+        if step.step_id == INSTALL_STEP:
+            binary = _bin_dir() / PACKAGE
+            return runner.run((str(binary), "--version")).exit_code == 0
         if step.harness is None:
             raise ValueError(f"step {step.step_id!r} has no harness")
         entry = read_mcp_entry(Path.home() / _CONFIG_PATHS[step.harness], step.harness, PACKAGE)
@@ -94,4 +181,4 @@ class TilthAdapter:
         if not isinstance(args, list) or not isinstance(command, str):
             return False
         args = [str(arg) for arg in args]
-        return _launches_tilth(command, args) and "--mcp" in args and EDIT_FLAG in args
+        return _launches_tilth(command) and "--mcp" in args and EDIT_FLAG in args

--- a/python/cheese_flow/adapters/tilth.py
+++ b/python/cheese_flow/adapters/tilth.py
@@ -115,7 +115,8 @@ def _launches_tilth(command: str) -> bool:
     ``tilth install`` writes the binary's own absolute path; a stale
     npm-era ``npx tilth`` entry no longer counts.
     """
-    return Path(command).name == PACKAGE
+    path = Path(command)
+    return path.is_absolute() and path.name == PACKAGE
 
 
 # Native user-scope MCP config per harness, relative to the home directory.

--- a/tests/python/test_adapters.py
+++ b/tests/python/test_adapters.py
@@ -3,8 +3,14 @@ positive postconditions driven entirely through a scripted fake ``CommandRunner`
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
+import platform
 import re
+import shlex
+import stat as stat_mod
+import subprocess
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -18,6 +24,13 @@ from cheese_flow.adapters import (
 )
 from cheese_flow.adapters.easy_cheese import AGENT_TOKENS, CORE_SKILLS, skills_directory
 from cheese_flow.adapters.hallouminate import _owner_repo
+from cheese_flow.adapters.tilth import (
+    RELEASE_URL,
+    _bin_dir,
+    _install_script,
+    _launches_tilth,
+    _target_triple,
+)
 from cheese_flow.models import (
     CommandOutcome,
     ConfigEdit,
@@ -56,16 +69,13 @@ def outcome(argv: tuple[str, ...], *, exit_code: int = 0, stdout: str = "") -> C
 
 
 NPM_VIEW_HALLOUMINATE = ("npm", "view", "hallouminate@latest", "version")
-NPM_VIEW_TILTH = ("npm", "view", "tilth@latest", "version")
 
 HALLOUMINATE_VERSION = "0.42.1"
-TILTH_VERSION = "1.7.0"
 
 
 def npm_script() -> dict[tuple[str, ...], CommandOutcome]:
     return {
         NPM_VIEW_HALLOUMINATE: outcome(NPM_VIEW_HALLOUMINATE, stdout=f"{HALLOUMINATE_VERSION}\n"),
-        NPM_VIEW_TILTH: outcome(NPM_VIEW_TILTH, stdout=f"{TILTH_VERSION}\n"),
     }
 
 
@@ -1045,53 +1055,300 @@ def test_easy_cheese_postcondition_rejects_a_step_without_a_harness() -> None:
 # --------------------------------------------------------------------------
 
 
-def test_tilth_plans_versioned_npx_install_per_harness() -> None:
-    runner = FakeRunner(npm_script())
+DARWIN_ARM64_TRIPLE = "aarch64-apple-darwin"
+DARWIN_X86_64_TRIPLE = "x86_64-apple-darwin"
+LINUX_AARCH64_TRIPLE = "aarch64-unknown-linux-musl"
+LINUX_X86_64_TRIPLE = "x86_64-unknown-linux-musl"
+
+
+@pytest.mark.parametrize(
+    ("system", "machine", "expected"),
+    [
+        ("Darwin", "arm64", DARWIN_ARM64_TRIPLE),
+        ("Darwin", "x86_64", DARWIN_X86_64_TRIPLE),
+        ("Linux", "aarch64", LINUX_AARCH64_TRIPLE),
+        ("Linux", "x86_64", LINUX_X86_64_TRIPLE),
+    ],
+)
+def test_target_triple_resolves_supported_platforms(
+    system: str, machine: str, expected: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: system)
+    monkeypatch.setattr(platform, "machine", lambda: machine)
+    assert _target_triple() == expected
+
+
+def test_target_triple_rejects_an_unsupported_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(platform, "machine", lambda: "AMD64")
+    with pytest.raises(RuntimeError, match="could not resolve"):
+        _target_triple()
+
+
+def test_tilth_plans_one_install_step_and_a_register_step_per_harness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+    runner = FakeRunner()
     steps = TilthAdapter(runner).plan_steps(state())
 
     assert [s.step_id for s in steps] == [
+        "tilth:install",
         "tilth:register:claude-code",
         "tilth:register:codex",
         "tilth:register:cursor",
     ]
-    assert steps[0].argv == (
-        "npx",
-        "--yes",
-        f"tilth@{TILTH_VERSION}",
-        "install",
-        "claude-code",
-        "--edit",
-    )
-    assert steps[2].argv == (
-        "npx",
-        "--yes",
-        f"tilth@{TILTH_VERSION}",
-        "install",
-        "cursor",
-        "--edit",
-    )
-    assert steps[2].phase is Phase.REGISTER
+    install = steps[0]
+    assert install.phase is Phase.INSTALL
+    assert install.argv[:2] == ("sh", "-c")
+    assert install.depends_on == ()
 
-
-def test_tilth_resolves_npm_view_once_per_run() -> None:
-    runner = FakeRunner(npm_script())
-    adapter = TilthAdapter(runner)
-    adapter.plan_steps(state())
-    adapter.plan_steps(state())
-
-    assert runner.argvs().count(NPM_VIEW_TILTH) == 1
+    binary = str(_bin_dir() / "tilth")
+    for register in steps[1:]:
+        assert register.phase is Phase.REGISTER
+        assert register.depends_on == ("tilth:install",)
+    assert steps[1].argv == (binary, "install", "claude-code", "--edit")
+    assert steps[3].argv == (binary, "install", "cursor", "--edit")
 
 
 def test_tilth_plans_nothing_when_component_not_selected() -> None:
-    runner = FakeRunner(npm_script())
+    runner = FakeRunner()
     assert TilthAdapter(runner).plan_steps(state(components=("hallouminate", "easy-cheese"))) == ()
     assert runner.argvs() == []
 
 
+def test_tilth_install_script_downloads_both_release_assets_with_bounded_curl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    script = TilthAdapter(FakeRunner()).plan_steps(state())[0].argv[2]
+
+    tarball_url = f"{RELEASE_URL}/tilth-{LINUX_X86_64_TRIPLE}.tar.gz"
+    assert tarball_url in script
+    assert f"{tarball_url}.sha256" in script
+    assert "--proto '=https' --tlsv1.2" in script
+    assert "--connect-timeout 10 --max-time 60" in script
+    assert "--retry 4 --retry-delay 15 --retry-all-errors --retry-max-time 120" in script
+
+
+def test_tilth_install_script_installs_atomically_into_the_bin_dir() -> None:
+    script = TilthAdapter(FakeRunner()).plan_steps(state())[0].argv[2]
+
+    bin_dir = _bin_dir()
+    quoted = shlex.quote(str(bin_dir))
+    assert f"mkdir -p {quoted}" in script
+    assert f"mktemp {quoted}/tilth.XXXXXX" in script
+    assert 'mv "$workdir/tilth" "$staged"' in script
+    assert 'chmod +x "$staged"' in script
+    assert f'mv "$staged" {quoted}/tilth' in script
+
+
+@pytest.mark.parametrize(
+    "bin_dir",
+    [
+        Path("/opt/bin"),
+        Path("/opt/bin with space"),
+        Path("/opt/bin's"),
+    ],
+)
+def test_tilth_install_script_is_valid_sh_for_unusual_bin_dirs(bin_dir: Path) -> None:
+    script = _install_script(DARWIN_ARM64_TRIPLE, bin_dir)
+    result = subprocess.run(["sh", "-n"], input=script, text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr
+
+
+CURL_FIXTURE_SHIM = """#!/bin/sh
+if [ "${CURL_FAIL:-}" = "1" ]; then
+    exit 22
+fi
+dest=""
+url=""
+prev=""
+for arg in "$@"; do
+    if [ "$prev" = "-o" ]; then
+        dest="$arg"
+    fi
+    case "$arg" in
+        http*) url="$arg" ;;
+    esac
+    prev="$arg"
+done
+case "$url" in
+    *.sha256) cp "$SHA256_FIXTURE" "$dest" ;;
+    *) cp "$TARBALL_FIXTURE" "$dest" ;;
+esac
+"""
+
+
+def _write_curl_shim(bin_dir: Path) -> None:
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "curl"
+    shim.write_text(CURL_FIXTURE_SHIM, encoding="utf-8")
+    shim.chmod(shim.stat().st_mode | stat_mod.S_IEXEC | stat_mod.S_IXGRP | stat_mod.S_IXOTH)
+
+
+def _build_tarball_fixture(tmp_path: Path) -> Path:
+    """A real gzip tarball, built by the system ``tar``, holding one executable
+    ``tilth`` script that prints a version line and exits 0."""
+    payload_dir = tmp_path / "payload"
+    payload_dir.mkdir()
+    tilth_script = payload_dir / "tilth"
+    tilth_script.write_text("#!/bin/sh\necho 'tilth 0.0.0-test'\n", encoding="utf-8")
+    tilth_script.chmod(0o755)
+    tarball = tmp_path / "tilth.tar.gz"
+    subprocess.run(
+        ["tar", "czf", str(tarball), "-C", str(payload_dir), "tilth"],
+        check=True,
+    )
+    return tarball
+
+
+def test_tilth_install_script_downloads_verifies_and_installs_the_binary(
+    tmp_path: Path,
+) -> None:
+    shim_dir = tmp_path / "shims"
+    _write_curl_shim(shim_dir)
+    tarball = _build_tarball_fixture(tmp_path)
+    digest = hashlib.sha256(tarball.read_bytes()).hexdigest()
+    sidecar = tmp_path / "tilth.tar.gz.sha256"
+    sidecar.write_text(f"{digest}  tilth.tar.gz\n", encoding="utf-8")
+
+    bin_dir = tmp_path / "bin"
+    mktemp_root = tmp_path / "mktemp-root"
+    mktemp_root.mkdir()
+
+    script = _install_script(DARWIN_ARM64_TRIPLE, bin_dir)
+    env = dict(os.environ) | {
+        "PATH": f"{shim_dir}:/usr/bin:/bin",
+        "TMPDIR": str(mktemp_root),
+        "TARBALL_FIXTURE": str(tarball),
+        "SHA256_FIXTURE": str(sidecar),
+    }
+
+    result = subprocess.run(
+        ["sh", "-c", script],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    installed = bin_dir / "tilth"
+    assert installed.exists()
+    assert os.access(installed, os.X_OK)
+    run = subprocess.run([str(installed)], capture_output=True, text=True, timeout=10)
+    assert run.returncode == 0
+    assert "tilth" in run.stdout
+    assert list(mktemp_root.iterdir()) == []
+
+
+def test_tilth_install_script_refuses_and_installs_nothing_on_digest_mismatch(
+    tmp_path: Path,
+) -> None:
+    shim_dir = tmp_path / "shims"
+    _write_curl_shim(shim_dir)
+    tarball = _build_tarball_fixture(tmp_path)
+    correct_digest = hashlib.sha256(tarball.read_bytes()).hexdigest()
+    wrong_digest = "0" * 64
+    assert wrong_digest != correct_digest
+    sidecar = tmp_path / "tilth.tar.gz.sha256"
+    sidecar.write_text(f"{wrong_digest}  tilth.tar.gz\n", encoding="utf-8")
+
+    bin_dir = tmp_path / "bin"
+    mktemp_root = tmp_path / "mktemp-root"
+    mktemp_root.mkdir()
+
+    script = _install_script(DARWIN_ARM64_TRIPLE, bin_dir)
+    env = dict(os.environ) | {
+        "PATH": f"{shim_dir}:/usr/bin:/bin",
+        "TMPDIR": str(mktemp_root),
+        "TARBALL_FIXTURE": str(tarball),
+        "SHA256_FIXTURE": str(sidecar),
+    }
+
+    result = subprocess.run(
+        ["sh", "-c", script],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+    assert result.returncode != 0
+    assert not (bin_dir / "tilth").exists()
+    assert "refusing to install tilth — checksum mismatch" in result.stderr
+    assert f"  expected {wrong_digest}" in result.stderr
+    assert f"  actual   {correct_digest}" in result.stderr
+    assert list(mktemp_root.iterdir()) == []
+
+
+def test_tilth_install_script_reports_context_and_installs_nothing_on_download_failure(
+    tmp_path: Path,
+) -> None:
+    shim_dir = tmp_path / "shims"
+    _write_curl_shim(shim_dir)
+    tarball = _build_tarball_fixture(tmp_path)
+    digest = hashlib.sha256(tarball.read_bytes()).hexdigest()
+    sidecar = tmp_path / "tilth.tar.gz.sha256"
+    sidecar.write_text(f"{digest}  tilth.tar.gz\n", encoding="utf-8")
+
+    bin_dir = tmp_path / "bin"
+    mktemp_root = tmp_path / "mktemp-root"
+    mktemp_root.mkdir()
+
+    script = _install_script(DARWIN_ARM64_TRIPLE, bin_dir)
+    env = dict(os.environ) | {
+        "PATH": f"{shim_dir}:/usr/bin:/bin",
+        "TMPDIR": str(mktemp_root),
+        "TARBALL_FIXTURE": str(tarball),
+        "SHA256_FIXTURE": str(sidecar),
+        "CURL_FAIL": "1",
+    }
+
+    result = subprocess.run(
+        ["sh", "-c", script],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+    assert result.returncode != 0
+    assert not (bin_dir / "tilth").exists()
+    tarball_url = f"{RELEASE_URL}/tilth-{DARWIN_ARM64_TRIPLE}.tar.gz"
+    assert (
+        f"cheese: could not download tilth for {DARWIN_ARM64_TRIPLE} from {tarball_url}"
+        in result.stderr
+    )
+
+
+def test_tilth_bin_dir_honours_xdg_bin_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_BIN_HOME", "/opt/bin")
+    assert _bin_dir() == Path("/opt/bin")
+
+
+def test_tilth_install_postcondition_checks_the_installed_binary_version() -> None:
+    binary = str(_bin_dir() / "tilth")
+    adapter = TilthAdapter(FakeRunner())
+    install_step = steps_by_id(adapter.plan_steps(state()))["tilth:install"]
+
+    ok_runner = FakeRunner({(binary, "--version"): outcome((binary, "--version"))})
+    assert adapter.check_postcondition(install_step, ok_runner) is True
+
+    failing_runner = FakeRunner(
+        {(binary, "--version"): outcome((binary, "--version"), exit_code=1)}
+    )
+    assert adapter.check_postcondition(install_step, failing_runner) is False
+
+
 def tilth_step(harness: str) -> PlanStep:
-    return steps_by_id(TilthAdapter(FakeRunner(npm_script())).plan_steps(state()))[
-        f"tilth:register:{harness}"
-    ]
+    return steps_by_id(TilthAdapter(FakeRunner()).plan_steps(state()))[f"tilth:register:{harness}"]
 
 
 EDIT_ENTRY = {"command": "npx", "args": ["tilth", "--mcp", "--edit"], "env": {}}
@@ -1106,11 +1363,16 @@ GLOBAL_EDIT_ENTRY = {
 GLOBAL_NO_EDIT_ENTRY = {"command": "/home/paul/.local/bin/tilth", "args": ["--mcp"], "env": {}}
 
 
+def test_launches_tilth_rejects_a_staging_artifact_command() -> None:
+    assert _launches_tilth("/home/paul/.local/bin/tilth") is True
+    assert _launches_tilth("/home/paul/.local/bin/tilth.XXXXXX") is False
+
+
 def test_tilth_postcondition_accepts_a_globally_installed_absolute_command(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
-    adapter = TilthAdapter(FakeRunner(npm_script()))
+    adapter = TilthAdapter(FakeRunner())
 
     (tmp_path / ".claude.json").write_text(json.dumps({"mcpServers": {"tilth": GLOBAL_EDIT_ENTRY}}))
     assert adapter.check_postcondition(tilth_step("claude-code"), FakeRunner()) is True
@@ -1120,7 +1382,7 @@ def test_tilth_postcondition_false_when_a_global_entry_lacks_edit_mode(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
-    adapter = TilthAdapter(FakeRunner(npm_script()))
+    adapter = TilthAdapter(FakeRunner())
 
     (tmp_path / ".claude.json").write_text(
         json.dumps({"mcpServers": {"tilth": GLOBAL_NO_EDIT_ENTRY}})
@@ -1144,7 +1406,7 @@ def test_tilth_postcondition_rejects_a_foreign_command(
     monkeypatch.setenv("HOME", str(tmp_path))
     (tmp_path / ".claude.json").write_text(json.dumps({"mcpServers": {"tilth": entry}}))
 
-    adapter = TilthAdapter(FakeRunner(npm_script()))
+    adapter = TilthAdapter(FakeRunner())
     assert adapter.check_postcondition(tilth_step("claude-code"), FakeRunner()) is False
 
 
@@ -1152,15 +1414,15 @@ def test_tilth_postcondition_reads_claude_code_and_cursor_json_configs(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
-    adapter = TilthAdapter(FakeRunner(npm_script()))
+    adapter = TilthAdapter(FakeRunner())
     runner = FakeRunner()
 
     (tmp_path / ".claude.json").write_text(json.dumps({"mcpServers": {"tilth": EDIT_ENTRY}}))
     (tmp_path / ".cursor").mkdir()
     (tmp_path / ".cursor/mcp.json").write_text(json.dumps({"mcpServers": {"tilth": EDIT_ENTRY}}))
 
-    assert adapter.check_postcondition(tilth_step("claude-code"), runner) is True
-    assert adapter.check_postcondition(tilth_step("cursor"), runner) is True
+    assert adapter.check_postcondition(tilth_step("claude-code"), runner) is False
+    assert adapter.check_postcondition(tilth_step("cursor"), runner) is False
     assert runner.argvs() == []
 
 
@@ -1174,8 +1436,8 @@ def test_tilth_postcondition_reads_the_codex_toml_config(
         'command = "npx"\nargs = ["tilth", "--mcp", "--edit"]\n'
     )
 
-    adapter = TilthAdapter(FakeRunner(npm_script()))
-    assert adapter.check_postcondition(tilth_step("codex"), FakeRunner()) is True
+    adapter = TilthAdapter(FakeRunner())
+    assert adapter.check_postcondition(tilth_step("codex"), FakeRunner()) is False
 
 
 def test_tilth_postcondition_false_when_edit_mode_missing(
@@ -1184,7 +1446,7 @@ def test_tilth_postcondition_false_when_edit_mode_missing(
     monkeypatch.setenv("HOME", str(tmp_path))
     (tmp_path / ".claude.json").write_text(json.dumps({"mcpServers": {"tilth": NO_EDIT_ENTRY}}))
 
-    adapter = TilthAdapter(FakeRunner(npm_script()))
+    adapter = TilthAdapter(FakeRunner())
     assert adapter.check_postcondition(tilth_step("claude-code"), FakeRunner()) is False
 
 
@@ -1192,7 +1454,7 @@ def test_tilth_postcondition_false_when_config_absent_or_unrelated(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
-    adapter = TilthAdapter(FakeRunner(npm_script()))
+    adapter = TilthAdapter(FakeRunner())
 
     assert adapter.check_postcondition(tilth_step("claude-code"), FakeRunner()) is False
 

--- a/tests/python/test_adapters.py
+++ b/tests/python/test_adapters.py
@@ -1368,6 +1368,10 @@ def test_launches_tilth_rejects_a_staging_artifact_command() -> None:
     assert _launches_tilth("/home/paul/.local/bin/tilth.XXXXXX") is False
 
 
+def test_launches_tilth_rejects_a_bare_command() -> None:
+    assert _launches_tilth("tilth") is False
+
+
 def test_tilth_postcondition_accepts_a_globally_installed_absolute_command(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -874,6 +874,51 @@ def test_doctor_reports_failure_with_a_nonzero_exit_code(
     assert json.loads(result.stdout)["status"] == "failed"
 
 
+def test_doctor_planning_failure_exits_cleanly_without_a_traceback(
+    tmp_path: Path,
+    config_home: Path,
+    command_runner: RecordingRunner,
+    calls: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = write_manifest(tmp_path)
+
+    def failing_verify(_state: DesiredState, _adapters: object, _runner: object) -> DoctorReport:
+        raise RuntimeError("could not resolve a tilth release asset for Windows/AMD64")
+
+    monkeypatch.setattr(cli, "verify_desired_state", failing_verify)
+
+    result = runner.invoke(app, ["doctor", "--config", str(manifest)])
+
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "Planning failed: could not resolve a tilth release asset" in result.stderr
+    assert result.stdout == ""
+
+
+def test_install_planning_failure_exits_cleanly_without_a_traceback(
+    tmp_path: Path,
+    config_home: Path,
+    command_runner: RecordingRunner,
+    calls: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = write_manifest(tmp_path)
+
+    def failing_plan(_state: DesiredState, _adapters: object) -> InstallPlan:
+        raise RuntimeError("could not resolve a tilth release asset for Windows/AMD64")
+
+    monkeypatch.setattr(cli, "build_install_plan", failing_plan)
+
+    result = runner.invoke(app, ["install", "--config", str(manifest)])
+
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "Planning failed: could not resolve a tilth release asset" in result.stderr
+    assert calls["apply"] == []
+    assert result.stdout == ""
+
+
 # ─── Timeout plumbing ────────────────────────────────────────────────────────
 
 

--- a/tests/python/test_integration.py
+++ b/tests/python/test_integration.py
@@ -28,6 +28,7 @@ import pytest
 import typer
 from cheese_flow import cli
 from cheese_flow.adapters import default_component_adapters
+from cheese_flow.adapters.tilth import RELEASE_URL, _bin_dir, _install_script, _target_triple
 from cheese_flow.cli import app
 from cheese_flow.desired_state import load_desired_state, save_desired_state
 from cheese_flow.install import apply_install_plan, build_install_plan
@@ -74,7 +75,11 @@ CLAUDE_MCP_CONFIG = ".claude.json"
 CODEX_MCP_CONFIG = ".codex/config.toml"
 CURSOR_MCP_CONFIG = ".cursor/mcp.json"
 
-TILTH_ENTRY = {"command": "npx", "args": ["tilth", "--mcp", "--edit"]}
+
+def tilth_entry() -> dict:
+    return {"command": str(_bin_dir() / "tilth"), "args": ["--mcp", "--edit"]}
+
+
 HALLOUMINATE_CURSOR_ENTRY = {"command": "hallouminate", "args": ["serve"]}
 
 
@@ -137,6 +142,7 @@ class FakeWorld:
     def converge(self, *, harnesses: Sequence[str], version: str = "1.0.0") -> None:
         """Bring the world to the state a successful install would leave behind."""
         self.installed["hallouminate"] = version
+        self.installed["tilth"] = "nightly"
         self.marketplaces.add(MARKETPLACE_SOURCE)
         self.plugins.add(PLUGIN_ID)
         self.config_exists = True
@@ -161,18 +167,19 @@ class FakeWorld:
                     link.symlink_to(canonical / name, target_is_directory=True)
 
     def write_tilth_entry(self, harness: str) -> None:
-        """What ``npx tilth install <harness> --edit`` leaves in the native config."""
+        """What ``tilth install <harness> --edit`` leaves in the native config."""
+        binary = str(_bin_dir() / "tilth")
         if harness == "codex":
             path = self.home / CODEX_MCP_CONFIG
             path.parent.mkdir(parents=True, exist_ok=True)
             existing = path.read_text(encoding="utf-8") if path.exists() else ""
-            entry = '[mcp_servers.tilth]\ncommand = "npx"\nargs = ["tilth", "--mcp", "--edit"]\n'
+            entry = f'[mcp_servers.tilth]\ncommand = "{binary}"\nargs = ["--mcp", "--edit"]\n'
             path.write_text(f"{existing}\n{entry}" if existing else entry, encoding="utf-8")
             return
         path = self.home / (CLAUDE_MCP_CONFIG if harness == "claude-code" else CURSOR_MCP_CONFIG)
         path.parent.mkdir(parents=True, exist_ok=True)
         document = _read_json(path)
-        document.setdefault("mcpServers", {})["tilth"] = dict(TILTH_ENTRY)
+        document.setdefault("mcpServers", {})["tilth"] = tilth_entry()
         path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
 
     # -- Command modelling -----------------------------------------------------
@@ -233,8 +240,17 @@ class FakeWorld:
         if key[:4] == ("npx", "-y", "skills@latest", "add"):
             self.install_skills(_agent_of(key))
             return _ok(key)
-        if key[:2] == ("npx", "--yes") and key[2].startswith("tilth@"):
-            self.write_tilth_entry(key[4])
+        if key[:2] == ("sh", "-c"):
+            expected_url = f"{RELEASE_URL}/tilth-{_target_triple()}.tar.gz"
+            assert expected_url in key[2]
+            self.installed["tilth"] = "nightly"
+            return _ok(key)
+        if len(key) == 2 and Path(key[0]).name == "tilth" and key[1] == "--version":
+            if "tilth" not in self.installed:
+                return _fail(key, "tilth: command not found")
+            return _ok(key, "tilth 0.0.0-nightly")
+        if len(key) == 4 and Path(key[0]).name == "tilth" and key[1] == "install":
+            self.write_tilth_entry(key[2])
             return _ok(key)
         raise AssertionError(f"the fake world was asked to run an unmodelled command: {key}")
 
@@ -349,6 +365,7 @@ def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("HOME", str(root))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(root / ".config"))
     monkeypatch.setenv("PATH", str(empty_bin))
+    monkeypatch.delenv("XDG_BIN_HOME", raising=False)
     return root
 
 
@@ -485,7 +502,7 @@ def test_cancelling_the_wizard_writes_no_manifest_and_runs_nothing(
 def test_dry_run_emits_the_exact_plan_without_executing_package_code(
     tmp_path: Path, home: Path, config_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    world = wire(monkeypatch, FakeWorld(home, versions={"tilth": ["4.5.6"]}))
+    world = wire(monkeypatch, FakeWorld(home))
     manifest = write_manifest(
         tmp_path,
         manifest_text(harnesses=["codex"], components=["hallouminate", "easy-cheese", "tilth"]),
@@ -503,8 +520,10 @@ def test_dry_run_emits_the_exact_plan_without_executing_package_code(
         "hallouminate:plugin:codex",
         "hallouminate:config-init",
         "easy-cheese:install:codex",
+        "tilth:install",
         "tilth:register:codex",
     ]
+    tilth_binary = str(_bin_dir() / "tilth")
     assert [entry["argv"] for entry in document["plan"]["steps"]] == [
         ["npm", "install", "-g", "hallouminate@1.0.0"],
         ["codex", "plugin", "marketplace", "add", MARKETPLACE_SOURCE],
@@ -523,12 +542,12 @@ def test_dry_run_emits_the_exact_plan_without_executing_package_code(
             "--global",
             "--yes",
         ],
-        ["npx", "--yes", "tilth@4.5.6", "install", "codex", "--edit"],
+        ["sh", "-c", _install_script(_target_triple(), _bin_dir())],
+        [tilth_binary, "install", "codex", "--edit"],
     ]
     # Metadata resolution is the only thing a dry run is allowed to do.
     assert world.argvs() == [
         ("npm", "view", "hallouminate@latest", "version"),
-        ("npm", "view", "tilth@latest", "version"),
     ]
     assert snapshot(home) == {}
     assert not config_path.exists()
@@ -541,7 +560,7 @@ def test_complete_config_runs_headlessly_and_stdout_is_one_json_document(
     tmp_path: Path, home: Path, config_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     repository = make_repository(tmp_path / "code" / "alpha")
-    world = wire(monkeypatch, FakeWorld(home, versions={"tilth": ["4.5.6"]}))
+    world = wire(monkeypatch, FakeWorld(home))
     manifest = write_manifest(
         tmp_path,
         manifest_text(
@@ -582,11 +601,12 @@ def test_complete_config_runs_headlessly_and_stdout_is_one_json_document(
         # just filled, so its postcondition already holds and no second
         # `skills add` runs.
         ("easy-cheese:install:cursor", "skipped"),
+        ("tilth:install", "succeeded"),
         ("tilth:register:claude-code", "succeeded"),
         ("tilth:register:cursor", "succeeded"),
     ]
     # Every reported "succeeded" corresponds to a real mutation of the world.
-    assert world.installed == {"hallouminate": "1.0.0"}
+    assert world.installed == {"hallouminate": "1.0.0", "tilth": "nightly"}
     assert world.initialized_repos == {repository}
     assert world.indexed_repos == {repository}
     assert "hallouminate:npm-install" in result.stderr
@@ -596,28 +616,29 @@ def test_complete_config_runs_headlessly_and_stdout_is_one_json_document(
 # ─── acceptance:149 — a satisfied postcondition skips its mutation ───────────
 
 
-READ_ONLY_PROBES = [
-    ("npm", "view", "hallouminate@latest", "version"),
-    ("npm", "view", "tilth@latest", "version"),
-    ("hallouminate", "--version"),
-    ("claude", "plugin", "marketplace", "list", "--json"),
-    ("claude", "plugin", "list", "--json"),
-    ("codex", "plugin", "marketplace", "list", "--json"),
-    ("codex", "plugin", "list", "--json"),
-    ("hallouminate", "config", "validate"),
-]
-"""Every command a fully converged run may still run.
+def read_only_probes(home: Path) -> list[tuple[str, ...]]:
+    """Every command a fully converged run may still run.
 
-easy-cheese contributes none: its postcondition reads the installed files
-directly, so a converged host needs no child process to prove the pack is
-there — and a host with no GitHub CLI reaches the same verdict.
-"""
+    easy-cheese contributes none: its postcondition reads the installed files
+    directly, so a converged host needs no child process to prove the pack is
+    there — and a host with no GitHub CLI reaches the same verdict.
+    """
+    return [
+        ("npm", "view", "hallouminate@latest", "version"),
+        ("hallouminate", "--version"),
+        ("claude", "plugin", "marketplace", "list", "--json"),
+        ("claude", "plugin", "list", "--json"),
+        ("codex", "plugin", "marketplace", "list", "--json"),
+        ("codex", "plugin", "list", "--json"),
+        ("hallouminate", "config", "validate"),
+        (str(_bin_dir() / "tilth"), "--version"),
+    ]
 
 
 def test_already_satisfied_postconditions_skip_every_mutation(
     tmp_path: Path, home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    world = wire(monkeypatch, FakeWorld(home, versions={"tilth": ["4.5.6"]}))
+    world = wire(monkeypatch, FakeWorld(home))
     world.converge(harnesses=["claude-code", "codex"])
     manifest = write_manifest(
         tmp_path,
@@ -633,8 +654,8 @@ def test_already_satisfied_postconditions_skip_every_mutation(
     assert result.exit_code == 0, result.stderr
     document = json.loads(result.stdout)
     assert {status for _, status in statuses(document)} == {"skipped"}
-    assert len(document["results"]) == 10
-    assert world.argvs() == READ_ONLY_PROBES
+    assert len(document["results"]) == 11
+    assert world.argvs() == read_only_probes(home)
     assert snapshot(home) == before
 
 
@@ -655,7 +676,7 @@ def test_apply_installs_exactly_the_version_planning_resolved(
         monkeypatch,
         FakeWorld(
             home,
-            versions={"hallouminate": ["1.0.0", "9.9.9"], "tilth": ["4.5.6", "8.8.8"]},
+            versions={"hallouminate": ["1.0.0", "9.9.9"]},
         ),
     )
     manifest = write_manifest(
@@ -670,26 +691,24 @@ def test_apply_installs_exactly_the_version_planning_resolved(
     assert result.exit_code == 0, result.stderr
     document = json.loads(result.stdout)
     assert world.count(("npm", "view", "hallouminate@latest", "version")) == 1
-    assert world.count(("npm", "view", "tilth@latest", "version")) == 1
     planned = {entry["step_id"]: entry["argv"] for entry in document["plan"]["steps"]}
     assert planned["hallouminate:npm-install"] == ["npm", "install", "-g", "hallouminate@1.0.0"]
     assert planned["tilth:register:claude-code"] == [
-        "npx",
-        "--yes",
-        "tilth@4.5.6",
+        str(_bin_dir() / "tilth"),
         "install",
         "claude-code",
         "--edit",
     ]
     # The version the postcondition accepted is the version that got installed,
     # which is the version the plan declared.
-    assert world.installed == {"hallouminate": "1.0.0"}
+    assert world.installed == {"hallouminate": "1.0.0", "tilth": "nightly"}
     assert statuses(document) == [
         ("hallouminate:npm-install", "succeeded"),
         ("hallouminate:marketplace:claude-code", "succeeded"),
         ("hallouminate:plugin:claude-code", "succeeded"),
         ("hallouminate:config-init", "succeeded"),
         ("easy-cheese:install:claude-code", "succeeded"),
+        ("tilth:install", "succeeded"),
         ("tilth:register:claude-code", "succeeded"),
     ]
 
@@ -722,7 +741,7 @@ def test_failed_step_blocks_adapter_wired_dependents_and_lets_others_run(
     repository = make_repository(tmp_path / "code" / "alpha")
     world = wire(
         monkeypatch,
-        FakeWorld(home, versions={"tilth": ["4.5.6"]}, refuse=frozenset({"hallouminate-config"})),
+        FakeWorld(home, refuse=frozenset({"hallouminate-config"})),
     )
     manifest = write_manifest(
         tmp_path,
@@ -748,6 +767,7 @@ def test_failed_step_blocks_adapter_wired_dependents_and_lets_others_run(
         (f"hallouminate:init-repo:{key}", "blocked"),
         (f"hallouminate:index:{key}", "blocked"),
         ("easy-cheese:install:claude-code", "succeeded"),
+        ("tilth:install", "succeeded"),
         ("tilth:register:claude-code", "succeeded"),
     ]
     blocked = {entry["step_id"]: entry["remediation"] for entry in document["results"]}
@@ -801,7 +821,7 @@ def test_interrupt_forwards_the_signal_and_reports_the_remaining_steps(
 def test_doctor_runs_read_only_probes_and_leaves_every_file_byte_identical(
     tmp_path: Path, home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    world = wire(monkeypatch, FakeWorld(home, versions={"tilth": ["4.5.6"]}))
+    world = wire(monkeypatch, FakeWorld(home))
     world.converge(harnesses=["claude-code", "codex"])
     manifest = write_manifest(
         tmp_path,
@@ -818,7 +838,7 @@ def test_doctor_runs_read_only_probes_and_leaves_every_file_byte_identical(
     assert result.exit_code == 0, result.stderr
     document = json.loads(result.stdout)
     assert {status for _, status in statuses(document)} == {"succeeded"}
-    assert world.argvs() == READ_ONLY_PROBES
+    assert world.argvs() == read_only_probes(home)
     assert snapshot(home) == before_home
     assert manifest.read_bytes() == before_manifest
 
@@ -1028,7 +1048,7 @@ def test_cursor_selection_writes_both_mcp_entries_and_preserves_the_rest(
         ),
         encoding="utf-8",
     )
-    world = wire(monkeypatch, FakeWorld(home, versions={"tilth": ["4.5.6"]}))
+    world = wire(monkeypatch, FakeWorld(home))
     manifest = write_manifest(
         tmp_path,
         manifest_text(harnesses=["cursor"], components=["hallouminate", "easy-cheese", "tilth"]),
@@ -1043,6 +1063,7 @@ def test_cursor_selection_writes_both_mcp_entries_and_preserves_the_rest(
         ("hallouminate:mcp:cursor", "succeeded"),
         ("hallouminate:config-init", "succeeded"),
         ("easy-cheese:install:cursor", "succeeded"),
+        ("tilth:install", "succeeded"),
         ("tilth:register:cursor", "succeeded"),
     ]
     assert json.loads(cursor_config.read_text(encoding="utf-8")) == {
@@ -1050,7 +1071,7 @@ def test_cursor_selection_writes_both_mcp_entries_and_preserves_the_rest(
         "mcpServers": {
             "unrelated": {"command": "unrelated-server"},
             "hallouminate": HALLOUMINATE_CURSOR_ENTRY,
-            "tilth": TILTH_ENTRY,
+            "tilth": tilth_entry(),
         },
     }
     assert not any(argv[:2] == ("cursor", "plugin") for argv in world.argvs())


### PR DESCRIPTION
> Stacked on #94 (the git-stall bound) — its README/timeout text is the base this change edits.

## Why

The npm `tilth` package is a **different publisher's artifact** (`repository: github.com/jahala/tilth`, no nightly dist-tag), so `npm view tilth@latest` + `npx tilth@<v>` was never installing this ecosystem's tilth. `paulnsorensen/tilth` ships a rolling `nightly` GitHub release of platform binaries with `.sha256` sidecars — that is now the source of truth.

## What (semantics-altering)

- **`TilthAdapter`** — plans one install step (`sh -c` script: platform-triple resolution, bounded+retried curls over pinned TLS, sidecar digest verify with refuse-on-mismatch, per-run `mktemp` staging, atomic same-dir rename into `${XDG_BIN_HOME:-$HOME/.local/bin}`) plus per-harness registration via the **installed binary's absolute path**. Install-once semantics: a present, runnable binary satisfies the postcondition (user-locked; no daily digest drift-chasing on a rolling tag). Stale npm-era `npx tilth` entries are **rejected** so upgrades rewrite them.
- **Nightly republish race** (measured: assets 404 ~75s+ during the ~19:00Z re-upload): `--retry 4 --retry-delay 15 --retry-all-errors --retry-max-time 120 --max-time 60` on both curls — worst case ~180s/curl, ~370s/script, sized inside smoke's `--timeout 420` and the 900s runner default. A digest mismatch refuses with a republish-race hint.
- **CLI boundary** — planning `RuntimeError`s (unsupported platform, npm resolution failure) now exit cleanly with `Planning failed: …` instead of a traceback, for both `install` and `doctor`.
- **`.mcp.json`** — dev-time entry becomes `{"command": "tilth", "args": ["--mcp", "--edit"]}` (requires `~/.local/bin` on PATH — documented).
- **README** — prerequisites now name curl ≥ 7.71, `tar`, a sha256 tool, and the PATH requirement.

## Reviewer should verify

1. The install script (one constant in `tilth.py`): `set -eu` flow through the `||` guards, trap cleanup of workdir + staged file, quoting via `shlex.quote` (tested for spaces and `'`).
2. Executable test trio drives the real script through `sh` with a shimmed curl: success (installs, temp-clean), digest-mismatch (refuses, exact message), download-failure (nonzero, nothing installed). Verify-block deletion and retry-flag deletion both go red (mutation-checked).
3. `_launches_tilth` rejecting `npx` is intentional — the migration must rewrite npm-era entries, not accept them.

Residual (accepted): a stale-edge sidecar (the one case a re-fetch would rescue) surfaces as a refusal with the republish hint — a sidecar re-fetch was implemented and removed because the sidecar downloads after the tarball and is always at least as fresh. First real Linux run of the download path is smoke's next scheduled run.

Tests: full suite green vs the recorded macOS baseline (488 passed); 22 tilth adapter tests; integration suite rewritten for the new step shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
