### PR TITLE
feat: allow MCPs across supported harnesses

### DIFF
--- a/.hallouminate/wiki/gotchas/claude-mcp-permissions.md
+++ b/.hallouminate/wiki/gotchas/claude-mcp-permissions.md
@@ -1,5 +1,9 @@
 # Claude MCP permissions
 
-Cheese-flow appends server-wide Claude Code permission rules for the MCP servers it installs: `mcp__hallouminate` after the Hallouminate plugin and `mcp__tilth` after Tilth registration. The append-unique edit preserves existing `~/.claude/settings.json` `permissions.allow` entries and each adapter verifies its own rule before reporting success.[^1]
+Cheese-flow writes canonical server-wide wildcard rules to Claude Code's `permissions.allow`: `mcp__plugin_hallouminate_hallouminate__*` for Hallouminate's plugin-bundled MCP server and `mcp__tilth__*` for the directly registered Tilth server. Bare names such as `mcp__tilth` are invalid permission rules because Claude requires the `__<tool>` suffix, with `__*` selecting every tool on the server.[^1]
 
-[^1]: python/cheese_flow/adapters/hallouminate.py; python/cheese_flow/adapters/tilth.py; python/cheese_flow/install.py.
+The edit targets `$CLAUDE_CONFIG_DIR/settings.json` when that nonblank override exists, otherwise `~/.claude/settings.json`. It preserves existing allow entries and follows a symlink to update its referent without replacing the link (`python/cheese_flow/adapters/native_config.py:36-61`, `python/cheese_flow/install.py:121-146`). Hallouminate supplies its plugin-qualified server name; Tilth uses its direct registration name (`python/cheese_flow/adapters/hallouminate.py:149-166`, `python/cheese_flow/adapters/tilth.py:172-186`).
+
+A successful postcondition means the requested rule is configured, not that it wins every effective-policy layer. Claude deny, ask, enterprise-managed, and command-line policy can still take precedence.[^1]
+
+[^1]: https://code.claude.com/docs/en/permissions

--- a/.hallouminate/wiki/gotchas/claude-mcp-permissions.md
+++ b/.hallouminate/wiki/gotchas/claude-mcp-permissions.md
@@ -1,0 +1,5 @@
+# Claude MCP permissions
+
+Cheese-flow appends server-wide Claude Code permission rules for the MCP servers it installs: `mcp__hallouminate` after the Hallouminate plugin and `mcp__tilth` after Tilth registration. The append-unique edit preserves existing `~/.claude/settings.json` `permissions.allow` entries and each adapter verifies its own rule before reporting success.[^1]
+
+[^1]: python/cheese_flow/adapters/hallouminate.py; python/cheese_flow/adapters/tilth.py; python/cheese_flow/install.py.

--- a/.hallouminate/wiki/gotchas/index.md
+++ b/.hallouminate/wiki/gotchas/index.md
@@ -1,6 +1,7 @@
 # gotchas
 
 <!-- HALLOUMINATE:INDEX-START -->
+- [claude-mcp-permissions](./claude-mcp-permissions.md) — Claude MCP permissions
 - [gh-skill-provenance](./gh-skill-provenance.md) — gh skill provenance
 - [git-has-no-read-timeout](./git-has-no-read-timeout.md) — Git has no read timeout — the install tree bounds it via GIT_HTTP_LOW_SPEED_*
 - [pydantic-lax-coercion-at-the-manifest-boundary](./pydantic-lax-coercion-at-the-manifest-boundary.md) — Pydantic lax coercion at the manifest boundary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
   "pydantic==2.13.4",
   "rich>=15.0.0",
+  "tomlkit>=0.15.1",
   "typer==0.25.1",
 ]
 

--- a/python/cheese_flow/adapters/easy_cheese.py
+++ b/python/cheese_flow/adapters/easy_cheese.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
+from cheese_flow.adapters.native_config import claude_config_dir
 from cheese_flow.models import (
     HARNESS_NAMES,
     CommandRunner,
@@ -36,8 +36,6 @@ CORE_SKILLS = frozenset({"mold", "cook", "press", "age", "cure", "plate", "chees
 SKILL_FILE = "SKILL.md"
 """The file every installed skill directory carries."""
 
-_CLAUDE_CONFIG_DIR = "CLAUDE_CONFIG_DIR"
-"""Claude Code's config-directory override, which the ``skills`` CLI honours."""
 
 _SKILLS_DIRS: dict[HarnessName, str] = {
     "claude-code": ".claude/skills",
@@ -68,9 +66,7 @@ def skills_directory(harness: HarnessName) -> Path:
     links rather than eighteen duplicated skill trees.
     """
     if harness == "claude-code":
-        configured = os.environ.get(_CLAUDE_CONFIG_DIR, "").strip()
-        if configured:
-            return Path(configured) / "skills"
+        return claude_config_dir() / "skills"
     return Path.home() / _SKILLS_DIRS[harness]
 
 

--- a/python/cheese_flow/adapters/hallouminate.py
+++ b/python/cheese_flow/adapters/hallouminate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from cheese_flow.adapters.native_config import read_mcp_entry
+from cheese_flow.adapters.native_config import has_allowed_mcp_server, read_mcp_entry
 from cheese_flow.models import (
     HARNESS_NAMES,
     CommandRunner,
@@ -40,6 +40,8 @@ CURSOR_MCP_ENTRY: dict[str, object] = {"command": PACKAGE, "args": ["serve"]}
 _INSTALL_STEP = "hallouminate:npm-install"
 _CONFIG_STEP = "hallouminate:config-init"
 _CURSOR_MCP_STEP = "hallouminate:mcp:cursor"
+_CLAUDE_PERMISSION_STEP = "hallouminate:permission:claude-code"
+_CLAUDE_SETTINGS_CONFIG = ".claude/settings.json"
 
 
 def _corpus_name(repository: Path) -> str:
@@ -142,6 +144,23 @@ class HallouminateAdapter:
                 )
             )
 
+        if "claude-code" in harnesses:
+            steps.append(
+                PlanStep(
+                    step_id=_CLAUDE_PERMISSION_STEP,
+                    component=self.name,
+                    harness="claude-code",
+                    phase=Phase.REGISTER,
+                    config_edit=ConfigEdit(
+                        target=Path.home() / _CLAUDE_SETTINGS_CONFIG,
+                        pointer="permissions.allow",
+                        value=f"mcp__{PACKAGE}",
+                        mode="append_unique",
+                    ),
+                    postcondition=f"~/{_CLAUDE_SETTINGS_CONFIG} allows mcp__{PACKAGE}",
+                    depends_on=("hallouminate:plugin:claude-code",),
+                )
+            )
         steps.append(
             PlanStep(
                 step_id=_CONFIG_STEP,
@@ -214,6 +233,8 @@ class HallouminateAdapter:
             return self._check_plugin(step, runner)
         if step.step_id == _CURSOR_MCP_STEP:
             return _check_cursor_mcp(step)
+        if step.step_id == _CLAUDE_PERMISSION_STEP:
+            return has_allowed_mcp_server(Path.home() / _CLAUDE_SETTINGS_CONFIG, PACKAGE)
         if step.step_id == _CONFIG_STEP:
             return runner.run(("hallouminate", "config", "validate")).exit_code == 0
         if step.step_id.startswith("hallouminate:init-repo:"):
@@ -269,10 +290,10 @@ class HallouminateAdapter:
 
 
 def _check_cursor_mcp(step: PlanStep) -> bool:
-    """Confirm Cursor's MCP config declares the entry the step's edit specifies."""
+    """Confirm Cursor MCP config declares the entry the step specifies."""
     edit = step.config_edit
-    if edit is None:
-        raise ValueError(f"step {step.step_id!r} has no config edit")
+    if edit is None or not isinstance(edit.value, dict):
+        raise ValueError(f"step {step.step_id!r} has no MCP config entry")
     entry = read_mcp_entry(edit.target, "cursor", PACKAGE)
     if not isinstance(entry, dict):
         return False

--- a/python/cheese_flow/adapters/hallouminate.py
+++ b/python/cheese_flow/adapters/hallouminate.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from cheese_flow.adapters.native_config import has_allowed_mcp_server, read_mcp_entry
+from cheese_flow.adapters.native_config import (
+    config_edit_holds,
+    mcp_permission_edit,
+    read_mcp_entry,
+)
 from cheese_flow.models import (
     HARNESS_NAMES,
     CommandRunner,
@@ -40,8 +44,6 @@ CURSOR_MCP_ENTRY: dict[str, object] = {"command": PACKAGE, "args": ["serve"]}
 _INSTALL_STEP = "hallouminate:npm-install"
 _CONFIG_STEP = "hallouminate:config-init"
 _CURSOR_MCP_STEP = "hallouminate:mcp:cursor"
-_CLAUDE_PERMISSION_STEP = "hallouminate:permission:claude-code"
-_CLAUDE_SETTINGS_CONFIG = ".claude/settings.json"
 
 
 def _corpus_name(repository: Path) -> str:
@@ -144,21 +146,25 @@ class HallouminateAdapter:
                 )
             )
 
-        if "claude-code" in harnesses:
+        for harness in harnesses:
+            dependency = (
+                _CURSOR_MCP_STEP if harness == "cursor" else f"hallouminate:plugin:{harness}"
+            )
+            edit = mcp_permission_edit(
+                harness,
+                PACKAGE,
+                claude_server="plugin_hallouminate_hallouminate",
+                codex_plugin=PACKAGE,
+            )
             steps.append(
                 PlanStep(
-                    step_id=_CLAUDE_PERMISSION_STEP,
+                    step_id=f"hallouminate:permission:{harness}",
                     component=self.name,
-                    harness="claude-code",
+                    harness=harness,
                     phase=Phase.REGISTER,
-                    config_edit=ConfigEdit(
-                        target=Path.home() / _CLAUDE_SETTINGS_CONFIG,
-                        pointer="permissions.allow",
-                        value=f"mcp__{PACKAGE}",
-                        mode="append_unique",
-                    ),
-                    postcondition=f"~/{_CLAUDE_SETTINGS_CONFIG} allows mcp__{PACKAGE}",
-                    depends_on=("hallouminate:plugin:claude-code",),
+                    config_edit=edit,
+                    postcondition=f"{edit.target} configures {edit.pointer} as {edit.value!r}",
+                    depends_on=(dependency,),
                 )
             )
         steps.append(
@@ -233,8 +239,8 @@ class HallouminateAdapter:
             return self._check_plugin(step, runner)
         if step.step_id == _CURSOR_MCP_STEP:
             return _check_cursor_mcp(step)
-        if step.step_id == _CLAUDE_PERMISSION_STEP:
-            return has_allowed_mcp_server(Path.home() / _CLAUDE_SETTINGS_CONFIG, PACKAGE)
+        if step.step_id.startswith("hallouminate:permission:"):
+            return step.config_edit is not None and config_edit_holds(step.config_edit)
         if step.step_id == _CONFIG_STEP:
             return runner.run(("hallouminate", "config", "validate")).exit_code == 0
         if step.step_id.startswith("hallouminate:init-repo:"):

--- a/python/cheese_flow/adapters/native_config.py
+++ b/python/cheese_flow/adapters/native_config.py
@@ -1,19 +1,18 @@
-"""Reading MCP entries out of a harness's own user-scope config file.
+"""Read and declare harness-native MCP configuration.
 
-Adapters verify registration by reading the native config directly rather than
-asking a harness CLI, so a postcondition never depends on a command that may not
-exist. Claude Code and Cursor store JSON under ``mcpServers``; Codex stores TOML
-under ``[mcp_servers.<name>]``.
+Adapters inspect config directly so postconditions never depend on a harness CLI
+that may not exist. Claude Code and Cursor store JSON; Codex stores TOML.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import tomllib
 from pathlib import Path
 from typing import Any
 
-from cheese_flow.models import HarnessName
+from cheese_flow.models import ConfigEdit, HarnessName
 
 
 def read_mcp_entry(path: Path, harness: HarnessName, server: str) -> Any:
@@ -34,16 +33,64 @@ def read_mcp_entry(path: Path, harness: HarnessName, server: str) -> Any:
     return servers.get(server) if isinstance(servers, dict) else None
 
 
-def has_allowed_mcp_server(path: Path, server: str) -> bool:
-    """Return whether Claude Code may invoke every tool exposed by a server."""
+def claude_config_dir() -> Path:
+    """Claude's user config directory, including its documented override."""
+    configured = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
+    return Path(configured).expanduser() if configured else Path.home() / ".claude"
+
+
+def codex_config_dir() -> Path:
+    """Codex's user config directory, including its documented override."""
+    configured = os.environ.get("CODEX_HOME", "").strip()
+    return Path(configured).expanduser() if configured else Path.home() / ".codex"
+
+
+def mcp_permission_edit(
+    harness: HarnessName,
+    server: str,
+    *,
+    claude_server: str | None = None,
+    codex_plugin: str | None = None,
+) -> ConfigEdit:
+    """Declare the native server-wide MCP approval for one supported harness."""
+    if harness == "claude-code":
+        return ConfigEdit(
+            target=claude_config_dir() / "settings.json",
+            pointer="permissions.allow",
+            value=f"mcp__{claude_server or server}__*",
+            mode="append_unique",
+        )
+    if harness == "codex":
+        prefix = f"plugins.{codex_plugin}.mcp_servers" if codex_plugin else "mcp_servers"
+        return ConfigEdit(
+            target=codex_config_dir() / "config.toml",
+            pointer=f"{prefix}.{server}.default_tools_approval_mode",
+            value="approve",
+            mode="toml_set",
+        )
+    return ConfigEdit(
+        target=Path.home() / ".cursor/cli-config.json",
+        pointer="permissions.allow",
+        value=f"Mcp({server}:*)",
+        mode="append_unique",
+    )
+
+
+def config_edit_holds(edit: ConfigEdit) -> bool:
+    """Return whether the declared target contains the declared value."""
     try:
-        document = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        if edit.mode == "toml_set":
+            document: Any = tomllib.loads(edit.target.read_text(encoding="utf-8"))
+        else:
+            document = json.loads(edit.target.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError, json.JSONDecodeError):
         return False
-    if not isinstance(document, dict):
-        return False
-    permissions = document.get("permissions")
-    if not isinstance(permissions, dict):
-        return False
-    allow = permissions.get("allow")
-    return isinstance(allow, list) and f"mcp__{server}" in allow
+
+    current = document
+    for key in edit.pointer.split("."):
+        if not isinstance(current, dict) or key not in current:
+            return False
+        current = current[key]
+    if edit.mode == "append_unique":
+        return isinstance(current, list) and edit.value in current
+    return current == edit.value

--- a/python/cheese_flow/adapters/native_config.py
+++ b/python/cheese_flow/adapters/native_config.py
@@ -32,3 +32,18 @@ def read_mcp_entry(path: Path, harness: HarnessName, server: str) -> Any:
         return None
     servers = document.get("mcpServers")
     return servers.get(server) if isinstance(servers, dict) else None
+
+
+def has_allowed_mcp_server(path: Path, server: str) -> bool:
+    """Return whether Claude Code may invoke every tool exposed by a server."""
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    if not isinstance(document, dict):
+        return False
+    permissions = document.get("permissions")
+    if not isinstance(permissions, dict):
+        return False
+    allow = permissions.get("allow")
+    return isinstance(allow, list) and f"mcp__{server}" in allow

--- a/python/cheese_flow/adapters/tilth.py
+++ b/python/cheese_flow/adapters/tilth.py
@@ -8,12 +8,15 @@ import platform
 import shlex
 from pathlib import Path
 
-from cheese_flow.adapters.native_config import has_allowed_mcp_server, read_mcp_entry
+from cheese_flow.adapters.native_config import (
+    config_edit_holds,
+    mcp_permission_edit,
+    read_mcp_entry,
+)
 from cheese_flow.models import (
     HARNESS_NAMES,
     CommandRunner,
     ComponentName,
-    ConfigEdit,
     DesiredState,
     HarnessName,
     Phase,
@@ -127,9 +130,6 @@ _CONFIG_PATHS: dict[HarnessName, str] = {
     "cursor": ".cursor/mcp.json",
 }
 
-_CLAUDE_SETTINGS_CONFIG = ".claude/settings.json"
-_PERMISSION_STEP = "tilth:permission:claude-code"
-
 
 class TilthAdapter:
     """Installs Tilth from the nightly GitHub release, then registers its MCP
@@ -169,21 +169,19 @@ class TilthAdapter:
             for harness in HARNESS_NAMES
             if harness in state.harnesses
         )
-        if "claude-code" in state.harnesses:
+        for harness in HARNESS_NAMES:
+            if harness not in state.harnesses:
+                continue
+            edit = mcp_permission_edit(harness, PACKAGE)
             steps.append(
                 PlanStep(
-                    step_id=_PERMISSION_STEP,
+                    step_id=f"tilth:permission:{harness}",
                     component=self.name,
-                    harness="claude-code",
+                    harness=harness,
                     phase=Phase.REGISTER,
-                    config_edit=ConfigEdit(
-                        target=Path.home() / _CLAUDE_SETTINGS_CONFIG,
-                        pointer="permissions.allow",
-                        value=f"mcp__{PACKAGE}",
-                        mode="append_unique",
-                    ),
-                    postcondition=f"~/{_CLAUDE_SETTINGS_CONFIG} allows mcp__{PACKAGE}",
-                    depends_on=("tilth:register:claude-code",),
+                    config_edit=edit,
+                    postcondition=f"{edit.target} configures {edit.pointer} as {edit.value!r}",
+                    depends_on=(f"tilth:register:{harness}",),
                 )
             )
         return tuple(steps)
@@ -193,8 +191,8 @@ class TilthAdapter:
         if step.step_id == INSTALL_STEP:
             binary = _bin_dir() / PACKAGE
             return runner.run((str(binary), "--version")).exit_code == 0
-        if step.step_id == _PERMISSION_STEP:
-            return has_allowed_mcp_server(Path.home() / _CLAUDE_SETTINGS_CONFIG, PACKAGE)
+        if step.step_id.startswith("tilth:permission:"):
+            return step.config_edit is not None and config_edit_holds(step.config_edit)
         if step.harness is None:
             raise ValueError(f"step {step.step_id!r} has no harness")
         entry = read_mcp_entry(Path.home() / _CONFIG_PATHS[step.harness], step.harness, PACKAGE)

--- a/python/cheese_flow/adapters/tilth.py
+++ b/python/cheese_flow/adapters/tilth.py
@@ -8,11 +8,12 @@ import platform
 import shlex
 from pathlib import Path
 
-from cheese_flow.adapters.native_config import read_mcp_entry
+from cheese_flow.adapters.native_config import has_allowed_mcp_server, read_mcp_entry
 from cheese_flow.models import (
     HARNESS_NAMES,
     CommandRunner,
     ComponentName,
+    ConfigEdit,
     DesiredState,
     HarnessName,
     Phase,
@@ -126,6 +127,9 @@ _CONFIG_PATHS: dict[HarnessName, str] = {
     "cursor": ".cursor/mcp.json",
 }
 
+_CLAUDE_SETTINGS_CONFIG = ".claude/settings.json"
+_PERMISSION_STEP = "tilth:permission:claude-code"
+
 
 class TilthAdapter:
     """Installs Tilth from the nightly GitHub release, then registers its MCP
@@ -165,6 +169,23 @@ class TilthAdapter:
             for harness in HARNESS_NAMES
             if harness in state.harnesses
         )
+        if "claude-code" in state.harnesses:
+            steps.append(
+                PlanStep(
+                    step_id=_PERMISSION_STEP,
+                    component=self.name,
+                    harness="claude-code",
+                    phase=Phase.REGISTER,
+                    config_edit=ConfigEdit(
+                        target=Path.home() / _CLAUDE_SETTINGS_CONFIG,
+                        pointer="permissions.allow",
+                        value=f"mcp__{PACKAGE}",
+                        mode="append_unique",
+                    ),
+                    postcondition=f"~/{_CLAUDE_SETTINGS_CONFIG} allows mcp__{PACKAGE}",
+                    depends_on=("tilth:register:claude-code",),
+                )
+            )
         return tuple(steps)
 
     def check_postcondition(self, step: PlanStep, runner: CommandRunner) -> bool:
@@ -172,6 +193,8 @@ class TilthAdapter:
         if step.step_id == INSTALL_STEP:
             binary = _bin_dir() / PACKAGE
             return runner.run((str(binary), "--version")).exit_code == 0
+        if step.step_id == _PERMISSION_STEP:
+            return has_allowed_mcp_server(Path.home() / _CLAUDE_SETTINGS_CONFIG, PACKAGE)
         if step.harness is None:
             raise ValueError(f"step {step.step_id!r} has no harness")
         entry = read_mcp_entry(Path.home() / _CONFIG_PATHS[step.harness], step.harness, PACKAGE)

--- a/python/cheese_flow/install.py
+++ b/python/cheese_flow/install.py
@@ -8,11 +8,14 @@ import signal
 import sys
 import tempfile
 import time
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator, MutableMapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+import tomlkit
+from tomlkit.exceptions import ParseError
 
 from cheese_flow.models import (
     COMPONENT_NAMES,
@@ -120,28 +123,30 @@ def report_status(results: Sequence[StepResult]) -> ReportStatus:
 
 
 def apply_config_edit(edit: ConfigEdit) -> None:
-    """Apply a declarative JSON config mutation without clobbering other settings."""
-    if edit.target.suffix != ".json":
-        raise ValueError(f"{edit.target}: only JSON config edits are supported")
-    document = _read_json_document(edit.target)
-    table = document
+    """Apply a declarative config mutation without clobbering other settings."""
+    target = edit.target.resolve(strict=False) if edit.target.is_symlink() else edit.target
     keys = edit.pointer.split(".")
-    for key in keys[:-1]:
-        nested = table.get(key)
-        if nested is None:
-            nested = {}
-            table[key] = nested
-        elif not isinstance(nested, dict):
-            raise ValueError(f"{edit.target}: {key!r} in {edit.pointer!r} is not a table")
-        table = nested
+    if edit.mode == "toml_set":
+        if edit.target.suffix != ".toml":
+            raise ValueError(f"{edit.target}: toml_set requires a TOML target")
+        document = _read_toml_document(target)
+        table = _table_at(document, keys, edit, toml=True)
+        table[keys[-1]] = edit.value
+        _write_atomically(target, document.as_string())
+        return
+
+    if edit.target.suffix != ".json":
+        raise ValueError(f"{edit.target}: JSON config edits require a JSON target")
+    document = _read_json_document(target)
+    table = _table_at(document, keys, edit, toml=False)
     if edit.mode == "set":
         table[keys[-1]] = edit.value
     else:
         _append_unique(table, keys[-1], edit.value)
-    _write_atomically(edit.target, json.dumps(document, indent=2) + "\n")
+    _write_atomically(target, json.dumps(document, indent=2) + "\n")
 
 
-def _append_unique(table: dict[str, Any], key: str, value: dict[str, Any] | str) -> None:
+def _append_unique(table: MutableMapping[str, Any], key: str, value: dict[str, Any] | str) -> None:
     if not isinstance(value, str):
         raise ValueError("append_unique requires a string value")
     existing = table.get(key, [])
@@ -376,6 +381,36 @@ def _read_json_document(target: Path) -> dict[str, Any]:
     if not isinstance(document, dict):
         raise ValueError(f"{target}: existing config is not a JSON object")
     return document
+
+
+def _read_toml_document(target: Path) -> tomlkit.TOMLDocument:
+    try:
+        raw = target.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return tomlkit.document()
+    try:
+        return tomlkit.parse(raw) if raw.strip() else tomlkit.document()
+    except ParseError as error:
+        raise ValueError(f"{target}: existing config is not valid TOML: {error}") from error
+
+
+def _table_at(
+    document: MutableMapping[str, Any],
+    keys: Sequence[str],
+    edit: ConfigEdit,
+    *,
+    toml: bool,
+) -> MutableMapping[str, Any]:
+    current = document
+    for key in keys[:-1]:
+        nested = current.get(key)
+        if nested is None:
+            nested = tomlkit.table() if toml else {}
+            current[key] = nested
+        elif not isinstance(nested, MutableMapping):
+            raise ValueError(f"{edit.target}: {key!r} in {edit.pointer!r} is not a table")
+        current = nested
+    return current
 
 
 def _write_atomically(target: Path, text: str) -> None:

--- a/python/cheese_flow/install.py
+++ b/python/cheese_flow/install.py
@@ -120,11 +120,7 @@ def report_status(results: Sequence[StepResult]) -> ReportStatus:
 
 
 def apply_config_edit(edit: ConfigEdit) -> None:
-    """Write ``edit.value`` at ``edit.pointer``, preserving the rest of the document.
-
-    Raises rather than writing anything when the target exists but cannot be
-    parsed, so a hand-edited config is never clobbered.
-    """
+    """Apply a declarative JSON config mutation without clobbering other settings."""
     if edit.target.suffix != ".json":
         raise ValueError(f"{edit.target}: only JSON config edits are supported")
     document = _read_json_document(edit.target)
@@ -138,8 +134,21 @@ def apply_config_edit(edit: ConfigEdit) -> None:
         elif not isinstance(nested, dict):
             raise ValueError(f"{edit.target}: {key!r} in {edit.pointer!r} is not a table")
         table = nested
-    table[keys[-1]] = edit.value
+    if edit.mode == "set":
+        table[keys[-1]] = edit.value
+    else:
+        _append_unique(table, keys[-1], edit.value)
     _write_atomically(edit.target, json.dumps(document, indent=2) + "\n")
+
+
+def _append_unique(table: dict[str, Any], key: str, value: dict[str, Any] | str) -> None:
+    if not isinstance(value, str):
+        raise ValueError("append_unique requires a string value")
+    existing = table.get(key, [])
+    if not isinstance(existing, list) or not all(isinstance(item, str) for item in existing):
+        raise ValueError(f"{key!r} must be a list of strings")
+    if value not in existing:
+        table[key] = [*existing, value]
 
 
 @dataclass

--- a/python/cheese_flow/models.py
+++ b/python/cheese_flow/models.py
@@ -289,24 +289,23 @@ class RepositoryCandidate(_Frozen):
 
 
 class ConfigEdit(_Frozen):
-    """A declarative write of ``value`` at ``pointer`` in a config file.
-
-    Some registrations have no native command to run: the harness's only user
-    surface is a config file. Such a step declares the edit instead of argv.
-    """
+    """A declarative JSON config mutation for a harness without a native CLI."""
 
     target: Path
     """Absolute path of the config file to edit."""
 
     pointer: str
-    """Dotted path to the entry inside the document, e.g. ``mcpServers.tilth``."""
+    """Dotted path inside the document, such as permissions.allow."""
 
-    value: dict[str, Any]
-    """The object that must sit at ``pointer``."""
+    value: dict[str, Any] | str
+    """The object to set, or the string to append uniquely."""
+
+    mode: Literal["set", "append_unique"] = "set"
+    """Whether to replace the pointer value or add one rule to its string list."""
 
     @field_serializer("value")
-    def _serialize_value(self, value: dict[str, Any]) -> dict[str, Any]:
-        return _redact_config_value(value)
+    def _serialize_value(self, value: dict[str, Any] | str) -> dict[str, Any] | str:
+        return _redact_config_value(value) if isinstance(value, dict) else value
 
     @field_validator("target")
     @classmethod
@@ -320,6 +319,16 @@ class ConfigEdit(_Frozen):
         if not value.strip():
             raise ValueError("pointer must not be empty")
         return value
+
+    @model_validator(mode="after")
+    def _value_matches_mode(self) -> ConfigEdit:
+        if self.mode == "set" and isinstance(self.value, dict):
+            return self
+        if self.mode == "append_unique" and isinstance(self.value, str):
+            return self
+        raise ValueError(
+            f"config edit mode {self.mode!r} does not accept {type(self.value).__name__}"
+        )
 
 
 class ConfigEditSummary(_Frozen):

--- a/python/cheese_flow/models.py
+++ b/python/cheese_flow/models.py
@@ -289,7 +289,7 @@ class RepositoryCandidate(_Frozen):
 
 
 class ConfigEdit(_Frozen):
-    """A declarative JSON config mutation for a harness without a native CLI."""
+    """A declarative JSON or TOML config mutation for a harness."""
 
     target: Path
     """Absolute path of the config file to edit."""
@@ -298,10 +298,10 @@ class ConfigEdit(_Frozen):
     """Dotted path inside the document, such as permissions.allow."""
 
     value: dict[str, Any] | str
-    """The object to set, or the string to append uniquely."""
+    """The object or string to set, or the string to append uniquely."""
 
-    mode: Literal["set", "append_unique"] = "set"
-    """Whether to replace the pointer value or add one rule to its string list."""
+    mode: Literal["set", "append_unique", "toml_set"] = "set"
+    """Whether to set a JSON/TOML value or append one JSON string rule."""
 
     @field_serializer("value")
     def _serialize_value(self, value: dict[str, Any] | str) -> dict[str, Any] | str:
@@ -324,7 +324,7 @@ class ConfigEdit(_Frozen):
     def _value_matches_mode(self) -> ConfigEdit:
         if self.mode == "set" and isinstance(self.value, dict):
             return self
-        if self.mode == "append_unique" and isinstance(self.value, str):
+        if self.mode in ("append_unique", "toml_set") and isinstance(self.value, str):
             return self
         raise ValueError(
             f"config edit mode {self.mode!r} does not accept {type(self.value).__name__}"

--- a/tests/python/test_adapters.py
+++ b/tests/python/test_adapters.py
@@ -171,6 +171,38 @@ def test_hallouminate_registers_cursor_mcp_entry_declaratively(
     )
 
 
+def test_hallouminate_plans_a_claude_code_mcp_permission_after_the_plugin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    steps = steps_by_id(HallouminateAdapter(FakeRunner(npm_script())).plan_steps(state()))
+
+    permission = steps["hallouminate:permission:claude-code"]
+    assert permission.depends_on == ("hallouminate:plugin:claude-code",)
+    assert permission.config_edit == ConfigEdit(
+        target=tmp_path / ".claude/settings.json",
+        pointer="permissions.allow",
+        value="mcp__hallouminate",
+        mode="append_unique",
+    )
+
+
+def test_hallouminate_permission_postcondition_requires_its_allow_rule(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    adapter = HallouminateAdapter(FakeRunner(npm_script()))
+    permission = steps_by_id(adapter.plan_steps(state()))["hallouminate:permission:claude-code"]
+    settings = tmp_path / ".claude/settings.json"
+    settings.parent.mkdir()
+    settings.write_text(json.dumps({"permissions": {"allow": ["mcp__tilth"]}}))
+
+    assert adapter.check_postcondition(permission, FakeRunner()) is False
+
+    settings.write_text(json.dumps({"permissions": {"allow": ["mcp__hallouminate"]}}))
+    assert adapter.check_postcondition(permission, FakeRunner()) is True
+
+
 def test_hallouminate_omits_the_cursor_mcp_step_when_cursor_is_not_selected() -> None:
     runner = FakeRunner(npm_script())
     steps = HallouminateAdapter(runner).plan_steps(state(harnesses=("claude-code", "codex")))
@@ -1085,7 +1117,7 @@ def test_target_triple_rejects_an_unsupported_platform(monkeypatch: pytest.Monke
         _target_triple()
 
 
-def test_tilth_plans_one_install_step_and_a_register_step_per_harness(
+def test_tilth_plans_registration_and_claude_code_permission(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(platform, "system", lambda: "Darwin")
@@ -1098,6 +1130,7 @@ def test_tilth_plans_one_install_step_and_a_register_step_per_harness(
         "tilth:register:claude-code",
         "tilth:register:codex",
         "tilth:register:cursor",
+        "tilth:permission:claude-code",
     ]
     install = steps[0]
     assert install.phase is Phase.INSTALL
@@ -1105,11 +1138,15 @@ def test_tilth_plans_one_install_step_and_a_register_step_per_harness(
     assert install.depends_on == ()
 
     binary = str(_bin_dir() / "tilth")
-    for register in steps[1:]:
+    for register in steps[1:4]:
         assert register.phase is Phase.REGISTER
         assert register.depends_on == ("tilth:install",)
     assert steps[1].argv == (binary, "install", "claude-code", "--edit")
     assert steps[3].argv == (binary, "install", "cursor", "--edit")
+    assert steps[4].depends_on == ("tilth:register:claude-code",)
+    assert steps[4].config_edit is not None
+    assert steps[4].config_edit.value == "mcp__tilth"
+    assert steps[4].config_edit.mode == "append_unique"
 
 
 def test_tilth_plans_nothing_when_component_not_selected() -> None:
@@ -1349,6 +1386,22 @@ def test_tilth_install_postcondition_checks_the_installed_binary_version() -> No
 
 def tilth_step(harness: str) -> PlanStep:
     return steps_by_id(TilthAdapter(FakeRunner()).plan_steps(state()))[f"tilth:register:{harness}"]
+
+
+def test_tilth_permission_postcondition_requires_its_allow_rule(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    adapter = TilthAdapter(FakeRunner())
+    permission = steps_by_id(adapter.plan_steps(state()))["tilth:permission:claude-code"]
+    settings = tmp_path / ".claude/settings.json"
+    settings.parent.mkdir()
+    settings.write_text(json.dumps({"permissions": {"allow": ["mcp__hallouminate"]}}))
+
+    assert adapter.check_postcondition(permission, FakeRunner()) is False
+
+    settings.write_text(json.dumps({"permissions": {"allow": ["mcp__tilth"]}}))
+    assert adapter.check_postcondition(permission, FakeRunner()) is True
 
 
 EDIT_ENTRY = {"command": "npx", "args": ["tilth", "--mcp", "--edit"], "env": {}}

--- a/tests/python/test_adapters.py
+++ b/tests/python/test_adapters.py
@@ -150,7 +150,10 @@ def test_hallouminate_gives_cursor_no_plugin_steps() -> None:
 
     assert "hallouminate:plugin:cursor" not in steps_by_id(steps)
     assert "hallouminate:marketplace:cursor" not in steps_by_id(steps)
-    assert [s.step_id for s in steps if s.harness == "cursor"] == ["hallouminate:mcp:cursor"]
+    assert [s.step_id for s in steps if s.harness == "cursor"] == [
+        "hallouminate:mcp:cursor",
+        "hallouminate:permission:cursor",
+    ]
 
 
 def test_hallouminate_registers_cursor_mcp_entry_declaratively(
@@ -171,36 +174,95 @@ def test_hallouminate_registers_cursor_mcp_entry_declaratively(
     )
 
 
-def test_hallouminate_plans_a_claude_code_mcp_permission_after_the_plugin(
+def test_hallouminate_plans_native_mcp_permissions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    claude_home = tmp_path / "claude"
+    codex_home = tmp_path / "codex"
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
     steps = steps_by_id(HallouminateAdapter(FakeRunner(npm_script())).plan_steps(state()))
 
-    permission = steps["hallouminate:permission:claude-code"]
-    assert permission.depends_on == ("hallouminate:plugin:claude-code",)
-    assert permission.config_edit == ConfigEdit(
-        target=tmp_path / ".claude/settings.json",
-        pointer="permissions.allow",
-        value="mcp__hallouminate",
-        mode="append_unique",
-    )
+    expected = {
+        "claude-code": (
+            "hallouminate:plugin:claude-code",
+            ConfigEdit(
+                target=claude_home / "settings.json",
+                pointer="permissions.allow",
+                value="mcp__plugin_hallouminate_hallouminate__*",
+                mode="append_unique",
+            ),
+        ),
+        "codex": (
+            "hallouminate:plugin:codex",
+            ConfigEdit(
+                target=codex_home / "config.toml",
+                pointer=(
+                    "plugins.hallouminate.mcp_servers.hallouminate.default_tools_approval_mode"
+                ),
+                value="approve",
+                mode="toml_set",
+            ),
+        ),
+        "cursor": (
+            "hallouminate:mcp:cursor",
+            ConfigEdit(
+                target=tmp_path / ".cursor/cli-config.json",
+                pointer="permissions.allow",
+                value="Mcp(hallouminate:*)",
+                mode="append_unique",
+            ),
+        ),
+    }
+    for harness, (dependency, edit) in expected.items():
+        permission = steps[f"hallouminate:permission:{harness}"]
+        assert permission.depends_on == (dependency,)
+        assert permission.config_edit == edit
+        assert "configures" in permission.postcondition
 
 
-def test_hallouminate_permission_postcondition_requires_its_allow_rule(
+def test_hallouminate_permission_postconditions_require_each_native_rule(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
     adapter = HallouminateAdapter(FakeRunner(npm_script()))
-    permission = steps_by_id(adapter.plan_steps(state()))["hallouminate:permission:claude-code"]
-    settings = tmp_path / ".claude/settings.json"
-    settings.parent.mkdir()
-    settings.write_text(json.dumps({"permissions": {"allow": ["mcp__tilth"]}}))
+    permissions = {
+        harness: steps_by_id(adapter.plan_steps(state()))[f"hallouminate:permission:{harness}"]
+        for harness in ALL_HARNESSES
+    }
 
-    assert adapter.check_postcondition(permission, FakeRunner()) is False
+    assert all(
+        adapter.check_postcondition(permission, FakeRunner()) is False
+        for permission in permissions.values()
+    )
 
-    settings.write_text(json.dumps({"permissions": {"allow": ["mcp__hallouminate"]}}))
-    assert adapter.check_postcondition(permission, FakeRunner()) is True
+    claude = tmp_path / ".claude/settings.json"
+    claude.parent.mkdir()
+    claude.write_text(
+        json.dumps({"permissions": {"allow": ["mcp__plugin_hallouminate_hallouminate__*"]}}),
+        encoding="utf-8",
+    )
+    codex = tmp_path / ".codex/config.toml"
+    codex.parent.mkdir()
+    codex.write_text(
+        "[plugins.hallouminate.mcp_servers.hallouminate]\n"
+        'default_tools_approval_mode = "approve"\n',
+        encoding="utf-8",
+    )
+    cursor = tmp_path / ".cursor/cli-config.json"
+    cursor.parent.mkdir()
+    cursor.write_text(
+        json.dumps({"permissions": {"allow": ["Mcp(hallouminate:*)"]}}),
+        encoding="utf-8",
+    )
+
+    assert all(
+        adapter.check_postcondition(permission, FakeRunner()) is True
+        for permission in permissions.values()
+    )
 
 
 def test_hallouminate_omits_the_cursor_mcp_step_when_cursor_is_not_selected() -> None:
@@ -1117,11 +1179,14 @@ def test_target_triple_rejects_an_unsupported_platform(monkeypatch: pytest.Monke
         _target_triple()
 
 
-def test_tilth_plans_registration_and_claude_code_permission(
-    monkeypatch: pytest.MonkeyPatch,
+def test_tilth_plans_registration_and_native_permissions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(platform, "system", lambda: "Darwin")
     monkeypatch.setattr(platform, "machine", lambda: "arm64")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex"))
     runner = FakeRunner()
     steps = TilthAdapter(runner).plan_steps(state())
 
@@ -1131,6 +1196,8 @@ def test_tilth_plans_registration_and_claude_code_permission(
         "tilth:register:codex",
         "tilth:register:cursor",
         "tilth:permission:claude-code",
+        "tilth:permission:codex",
+        "tilth:permission:cursor",
     ]
     install = steps[0]
     assert install.phase is Phase.INSTALL
@@ -1143,10 +1210,33 @@ def test_tilth_plans_registration_and_claude_code_permission(
         assert register.depends_on == ("tilth:install",)
     assert steps[1].argv == (binary, "install", "claude-code", "--edit")
     assert steps[3].argv == (binary, "install", "cursor", "--edit")
-    assert steps[4].depends_on == ("tilth:register:claude-code",)
-    assert steps[4].config_edit is not None
-    assert steps[4].config_edit.value == "mcp__tilth"
-    assert steps[4].config_edit.mode == "append_unique"
+
+    expected = {
+        "claude-code": ConfigEdit(
+            target=tmp_path / "claude/settings.json",
+            pointer="permissions.allow",
+            value="mcp__tilth__*",
+            mode="append_unique",
+        ),
+        "codex": ConfigEdit(
+            target=tmp_path / "codex/config.toml",
+            pointer="mcp_servers.tilth.default_tools_approval_mode",
+            value="approve",
+            mode="toml_set",
+        ),
+        "cursor": ConfigEdit(
+            target=tmp_path / ".cursor/cli-config.json",
+            pointer="permissions.allow",
+            value="Mcp(tilth:*)",
+            mode="append_unique",
+        ),
+    }
+    planned = steps_by_id(steps)
+    for harness, edit in expected.items():
+        permission = planned[f"tilth:permission:{harness}"]
+        assert permission.depends_on == (f"tilth:register:{harness}",)
+        assert permission.config_edit == edit
+        assert "configures" in permission.postcondition
 
 
 def test_tilth_plans_nothing_when_component_not_selected() -> None:
@@ -1388,19 +1478,20 @@ def tilth_step(harness: str) -> PlanStep:
     return steps_by_id(TilthAdapter(FakeRunner()).plan_steps(state()))[f"tilth:register:{harness}"]
 
 
-def test_tilth_permission_postcondition_requires_its_allow_rule(
+def test_tilth_permission_postcondition_requires_the_canonical_claude_rule(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     adapter = TilthAdapter(FakeRunner())
     permission = steps_by_id(adapter.plan_steps(state()))["tilth:permission:claude-code"]
     settings = tmp_path / ".claude/settings.json"
     settings.parent.mkdir()
-    settings.write_text(json.dumps({"permissions": {"allow": ["mcp__hallouminate"]}}))
+    settings.write_text(json.dumps({"permissions": {"allow": ["mcp__tilth"]}}), encoding="utf-8")
 
     assert adapter.check_postcondition(permission, FakeRunner()) is False
 
-    settings.write_text(json.dumps({"permissions": {"allow": ["mcp__tilth"]}}))
+    settings.write_text(json.dumps({"permissions": {"allow": ["mcp__tilth__*"]}}), encoding="utf-8")
     assert adapter.check_postcondition(permission, FakeRunner()) is True
 
 

--- a/tests/python/test_desired_state.py
+++ b/tests/python/test_desired_state.py
@@ -14,7 +14,7 @@ from cheese_flow.desired_state import (
     save_desired_state,
     state_from_options,
 )
-from cheese_flow.models import DEFAULT_MAX_DEPTH, DesiredState, RepositorySelection
+from cheese_flow.models import DEFAULT_MAX_DEPTH, DesiredState, RepositorySelection, canonicalize
 from pydantic import ValidationError
 
 VALID = """\
@@ -121,7 +121,7 @@ def test_selected_path_equal_to_search_root_is_consistent(tmp_path: Path) -> Non
             'selected = ["/home/me/Dev"]\n',
         )
     )
-    assert state.repositories.selected == (Path("/home/me/Dev"),)
+    assert state.repositories.selected == (canonicalize(Path("/home/me/Dev")),)
 
 
 # --- file and syntax errors ------------------------------------------------
@@ -295,14 +295,16 @@ def test_selected_without_search_roots(tmp_path: Path) -> None:
         'selected = ["/home/me/Dev/project"]\n',
     )
     assert error.reason == (
-        "selected repositories are not under any search root: /home/me/Dev/project"
+        "selected repositories are not under any search root: "
+        + str(canonicalize(Path("/home/me/Dev/project")))
     )
 
 
 def test_sibling_prefix_is_not_under_a_search_root(tmp_path: Path) -> None:
     error = load_error(tmp_path, VALID.replace('"/home/me/Dev/project"', '"/home/me/Development"'))
-    assert (
-        error.reason == "selected repositories are not under any search root: /home/me/Development"
+    assert error.reason == (
+        "selected repositories are not under any search root: "
+        + str(canonicalize(Path("/home/me/Development")))
     )
 
 
@@ -376,7 +378,9 @@ def test_saved_manifest_matches_the_documented_shape(tmp_path: Path) -> None:
     )
     path = tmp_path / "config.toml"
     save_desired_state(state, path)
-    assert path.read_text(encoding="utf-8") == VALID
+    assert path.read_text(encoding="utf-8") == VALID.replace(
+        "/home/me/Dev", str(canonicalize(Path("/home/me/Dev")))
+    )
 
 
 # --- default config path ---------------------------------------------------

--- a/tests/python/test_doctor.py
+++ b/tests/python/test_doctor.py
@@ -166,6 +166,12 @@ def test_doctor_with_real_adapters_runs_only_read_only_commands(
         ),
         encoding="utf-8",
     )
+    claude_settings = tmp_path / ".claude" / "settings.json"
+    claude_settings.parent.mkdir(exist_ok=True)
+    claude_settings.write_text(
+        json.dumps({"permissions": {"allow": ["mcp__hallouminate"]}}),
+        encoding="utf-8",
+    )
     before = cursor_config.read_bytes()
     state = DesiredState(
         harnesses=("claude-code", "cursor"), components=("hallouminate", "easy-cheese")
@@ -188,6 +194,7 @@ def test_doctor_with_real_adapters_runs_only_read_only_commands(
         "hallouminate:marketplace:claude-code",
         "hallouminate:plugin:claude-code",
         "hallouminate:mcp:cursor",
+        "hallouminate:permission:claude-code",
         "hallouminate:config-init",
         "easy-cheese:install:claude-code",
         "easy-cheese:install:cursor",

--- a/tests/python/test_doctor.py
+++ b/tests/python/test_doctor.py
@@ -152,6 +152,7 @@ def test_doctor_with_real_adapters_runs_only_read_only_commands(
 ) -> None:
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
     monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
     install_core_skills(tmp_path)
     cursor_config = tmp_path / ".cursor" / "mcp.json"
     cursor_config.parent.mkdir()
@@ -169,10 +170,15 @@ def test_doctor_with_real_adapters_runs_only_read_only_commands(
     claude_settings = tmp_path / ".claude" / "settings.json"
     claude_settings.parent.mkdir(exist_ok=True)
     claude_settings.write_text(
-        json.dumps({"permissions": {"allow": ["mcp__hallouminate"]}}),
+        json.dumps({"permissions": {"allow": ["mcp__plugin_hallouminate_hallouminate__*"]}}),
         encoding="utf-8",
     )
-    before = cursor_config.read_bytes()
+    cursor_cli_config = tmp_path / ".cursor/cli-config.json"
+    cursor_cli_config.write_text(
+        json.dumps({"permissions": {"allow": ["Mcp(hallouminate:*)"]}}),
+        encoding="utf-8",
+    )
+    before = {path: path.read_bytes() for path in (cursor_config, cursor_cli_config)}
     state = DesiredState(
         harnesses=("claude-code", "cursor"), components=("hallouminate", "easy-cheese")
     )
@@ -188,13 +194,14 @@ def test_doctor_with_real_adapters_runs_only_read_only_commands(
         ("claude", "plugin", "list", "--json"),
         ("hallouminate", "config", "validate"),
     ]
-    assert cursor_config.read_bytes() == before
+    assert {path: path.read_bytes() for path in before} == before
     assert [result.step_id for result in report.results] == [
         "hallouminate:npm-install",
         "hallouminate:marketplace:claude-code",
         "hallouminate:plugin:claude-code",
         "hallouminate:mcp:cursor",
         "hallouminate:permission:claude-code",
+        "hallouminate:permission:cursor",
         "hallouminate:config-init",
         "easy-cheese:install:claude-code",
         "easy-cheese:install:cursor",

--- a/tests/python/test_install.py
+++ b/tests/python/test_install.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import signal
+import tomllib
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
@@ -258,7 +259,7 @@ def test_config_edit_appends_a_unique_permission_without_clobbering_rules(tmp_pa
     edit = ConfigEdit(
         target=target,
         pointer="permissions.allow",
-        value="mcp__tilth",
+        value="mcp__tilth__*",
         mode="append_unique",
     )
 
@@ -266,8 +267,99 @@ def test_config_edit_appends_a_unique_permission_without_clobbering_rules(tmp_pa
     install.apply_config_edit(edit)
 
     assert json.loads(target.read_text(encoding="utf-8")) == {
-        "permissions": {"allow": ["Read", "mcp__other", "mcp__tilth"]},
+        "permissions": {"allow": ["Read", "mcp__other", "mcp__tilth__*"]},
         "keep": True,
+    }
+
+
+def test_config_edit_sets_toml_without_clobbering_comments_or_tables(tmp_path: Path) -> None:
+    target = tmp_path / "config.toml"
+    target.write_text("# keep this comment\n[unrelated]\nvalue = 1\n", encoding="utf-8")
+    edit = ConfigEdit(
+        target=target,
+        pointer="plugins.hallouminate.mcp_servers.hallouminate.default_tools_approval_mode",
+        value="approve",
+        mode="toml_set",
+    )
+
+    install.apply_config_edit(edit)
+    install.apply_config_edit(edit)
+
+    raw = target.read_text(encoding="utf-8")
+    assert raw.count("# keep this comment") == 1
+    assert tomllib.loads(raw) == {
+        "unrelated": {"value": 1},
+        "plugins": {
+            "hallouminate": {
+                "mcp_servers": {"hallouminate": {"default_tools_approval_mode": "approve"}}
+            }
+        },
+    }
+
+
+def test_config_edit_never_clobbers_unparseable_toml(tmp_path: Path) -> None:
+    target = tmp_path / "config.toml"
+    before = b"[broken\n"
+    target.write_bytes(before)
+    edit = ConfigEdit(
+        target=target,
+        pointer="mcp_servers.tilth.default_tools_approval_mode",
+        value="approve",
+        mode="toml_set",
+    )
+
+    with pytest.raises(ValueError, match="not valid TOML"):
+        install.apply_config_edit(edit)
+
+    assert target.read_bytes() == before
+
+
+def test_config_edit_preserves_a_symlink_and_updates_its_referent(tmp_path: Path) -> None:
+    managed = tmp_path / "dotfiles/settings-managed"
+    managed.parent.mkdir()
+    managed.write_text(json.dumps({"permissions": {"allow": ["Read"]}}), encoding="utf-8")
+    target = tmp_path / ".claude/settings.json"
+    target.parent.mkdir()
+    target.symlink_to(managed)
+    edit = ConfigEdit(
+        target=target,
+        pointer="permissions.allow",
+        value="mcp__tilth__*",
+        mode="append_unique",
+    )
+
+    install.apply_config_edit(edit)
+
+    assert target.is_symlink()
+    assert target.resolve() == managed.resolve()
+    assert json.loads(managed.read_text(encoding="utf-8")) == {
+        "permissions": {"allow": ["Read", "mcp__tilth__*"]}
+    }
+
+
+def test_toml_config_edit_preserves_a_symlink_to_an_extensionless_referent(
+    tmp_path: Path,
+) -> None:
+    managed = tmp_path / "dotfiles/codex-managed"
+    managed.parent.mkdir()
+    managed.write_text("[keep]\nvalue = 1\n", encoding="utf-8")
+    target = tmp_path / ".codex/config.toml"
+    target.parent.mkdir()
+    target.symlink_to(managed)
+    edit = ConfigEdit(
+        target=target,
+        pointer="mcp_servers.tilth.default_tools_approval_mode",
+        value="approve",
+        mode="toml_set",
+    )
+
+    install.apply_config_edit(edit)
+
+    assert target.is_symlink()
+    assert target.resolve() == managed.resolve()
+    assert tomllib.loads(managed.read_text(encoding="utf-8")) == {
+        "keep": {"value": 1},
+        "mcp_servers": {"tilth": {"default_tools_approval_mode": "approve"}},
     }
 
 

--- a/tests/python/test_install.py
+++ b/tests/python/test_install.py
@@ -249,6 +249,44 @@ def test_config_edit_sets_the_pointer_and_preserves_surrounding_config(tmp_path:
     }
 
 
+def test_config_edit_appends_a_unique_permission_without_clobbering_rules(tmp_path: Path) -> None:
+    target = tmp_path / "settings.json"
+    target.write_text(
+        json.dumps({"permissions": {"allow": ["Read", "mcp__other"]}, "keep": True}),
+        encoding="utf-8",
+    )
+    edit = ConfigEdit(
+        target=target,
+        pointer="permissions.allow",
+        value="mcp__tilth",
+        mode="append_unique",
+    )
+
+    install.apply_config_edit(edit)
+    install.apply_config_edit(edit)
+
+    assert json.loads(target.read_text(encoding="utf-8")) == {
+        "permissions": {"allow": ["Read", "mcp__other", "mcp__tilth"]},
+        "keep": True,
+    }
+
+
+def test_config_edit_rejects_a_non_list_permission_target(tmp_path: Path) -> None:
+    target = tmp_path / "settings.json"
+    target.write_text(json.dumps({"permissions": {"allow": "Read"}}), encoding="utf-8")
+    edit = ConfigEdit(
+        target=target,
+        pointer="permissions.allow",
+        value="mcp__tilth",
+        mode="append_unique",
+    )
+
+    with pytest.raises(ValueError, match="list of strings"):
+        install.apply_config_edit(edit)
+
+    assert json.loads(target.read_text(encoding="utf-8")) == {"permissions": {"allow": "Read"}}
+
+
 def test_config_edit_creates_a_missing_target_without_touching_other_steps(tmp_path: Path) -> None:
     target = tmp_path / "cursor" / "mcp.json"
     edit = ConfigEdit(target=target, pointer="mcpServers.tilth", value={"command": "npx"})

--- a/tests/python/test_integration.py
+++ b/tests/python/test_integration.py
@@ -157,9 +157,29 @@ class FakeWorld:
             settings.parent.mkdir(parents=True, exist_ok=True)
             document = _read_json(settings)
             document.setdefault("permissions", {}).setdefault("allow", []).extend(
-                ["mcp__hallouminate", "mcp__tilth"]
+                ["mcp__plugin_hallouminate_hallouminate__*", "mcp__tilth__*"]
             )
             settings.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+        if "codex" in harnesses:
+            config = self.home / CODEX_MCP_CONFIG
+            config.write_text(
+                config.read_text(encoding="utf-8")
+                + '\ndefault_tools_approval_mode = "approve"\n'
+                + "\n[plugins.hallouminate.mcp_servers.hallouminate]\n"
+                + 'default_tools_approval_mode = "approve"\n',
+                encoding="utf-8",
+            )
+        if "cursor" in harnesses:
+            config = self.home / ".cursor/cli-config.json"
+            config.parent.mkdir(parents=True, exist_ok=True)
+            config.write_text(
+                json.dumps(
+                    {"permissions": {"allow": ["Mcp(hallouminate:*)", "Mcp(tilth:*)"]}},
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
 
     def install_skills(self, harness: str) -> None:
         """What ``skills add <repo> --skill '*' --agent <harness> --global`` leaves on disk."""
@@ -376,6 +396,8 @@ def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(root / ".config"))
     monkeypatch.setenv("PATH", str(empty_bin))
     monkeypatch.delenv("XDG_BIN_HOME", raising=False)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
     return root
 
 
@@ -528,16 +550,19 @@ def test_dry_run_emits_the_exact_plan_without_executing_package_code(
         "hallouminate:npm-install",
         "hallouminate:marketplace:codex",
         "hallouminate:plugin:codex",
+        "hallouminate:permission:codex",
         "hallouminate:config-init",
         "easy-cheese:install:codex",
         "tilth:install",
         "tilth:register:codex",
+        "tilth:permission:codex",
     ]
     tilth_binary = str(_bin_dir() / "tilth")
     assert [entry["argv"] for entry in document["plan"]["steps"]] == [
         ["npm", "install", "-g", "hallouminate@1.0.0"],
         ["codex", "plugin", "marketplace", "add", MARKETPLACE_SOURCE],
         ["codex", "plugin", "add", PLUGIN_ID],
+        [],
         ["hallouminate", "config", "init", "--force"],
         [
             "npx",
@@ -554,6 +579,7 @@ def test_dry_run_emits_the_exact_plan_without_executing_package_code(
         ],
         ["sh", "-c", _install_script(_target_triple(), _bin_dir())],
         [tilth_binary, "install", "codex", "--edit"],
+        [],
     ]
     # Metadata resolution is the only thing a dry run is allowed to do.
     assert world.argvs() == [
@@ -604,6 +630,7 @@ def test_complete_config_runs_headlessly_and_stdout_is_one_json_document(
         ("hallouminate:plugin:claude-code", "succeeded"),
         ("hallouminate:mcp:cursor", "succeeded"),
         ("hallouminate:permission:claude-code", "succeeded"),
+        ("hallouminate:permission:cursor", "succeeded"),
         ("hallouminate:config-init", "succeeded"),
         (f"hallouminate:init-repo:{key}", "succeeded"),
         (f"hallouminate:index:{key}", "succeeded"),
@@ -616,6 +643,7 @@ def test_complete_config_runs_headlessly_and_stdout_is_one_json_document(
         ("tilth:register:claude-code", "succeeded"),
         ("tilth:register:cursor", "succeeded"),
         ("tilth:permission:claude-code", "succeeded"),
+        ("tilth:permission:cursor", "succeeded"),
     ]
     # Every reported "succeeded" corresponds to a real mutation of the world.
     assert world.installed == {"hallouminate": "1.0.0", "tilth": "nightly"}
@@ -666,7 +694,7 @@ def test_already_satisfied_postconditions_skip_every_mutation(
     assert result.exit_code == 0, result.stderr
     document = json.loads(result.stdout)
     assert {status for _, status in statuses(document)} == {"skipped"}
-    assert len(document["results"]) == 13
+    assert len(document["results"]) == 15
     assert world.argvs() == read_only_probes(home)
     assert snapshot(home) == before
 
@@ -877,6 +905,7 @@ def test_doctor_reports_every_unsatisfied_postcondition_independently(
         ("hallouminate:npm-install", "succeeded"),
         ("hallouminate:marketplace:codex", "failed"),
         ("hallouminate:plugin:codex", "failed"),
+        ("hallouminate:permission:codex", "failed"),
         ("hallouminate:config-init", "failed"),
         ("easy-cheese:install:codex", "failed"),
     ]
@@ -1111,6 +1140,11 @@ def test_cursor_selection_writes_both_mcp_entries_and_preserves_the_rest(
         ),
         encoding="utf-8",
     )
+    cursor_cli_config = home / ".cursor/cli-config.json"
+    cursor_cli_config.write_text(
+        json.dumps({"permissions": {"allow": ["Shell(ls)"]}, "keep": True}),
+        encoding="utf-8",
+    )
     world = wire(monkeypatch, FakeWorld(home))
     manifest = write_manifest(
         tmp_path,
@@ -1124,10 +1158,12 @@ def test_cursor_selection_writes_both_mcp_entries_and_preserves_the_rest(
     assert statuses(document) == [
         ("hallouminate:npm-install", "succeeded"),
         ("hallouminate:mcp:cursor", "succeeded"),
+        ("hallouminate:permission:cursor", "succeeded"),
         ("hallouminate:config-init", "succeeded"),
         ("easy-cheese:install:cursor", "succeeded"),
         ("tilth:install", "succeeded"),
         ("tilth:register:cursor", "succeeded"),
+        ("tilth:permission:cursor", "succeeded"),
     ]
     assert json.loads(cursor_config.read_text(encoding="utf-8")) == {
         "someOtherSetting": {"keep": True},
@@ -1136,6 +1172,10 @@ def test_cursor_selection_writes_both_mcp_entries_and_preserves_the_rest(
             "hallouminate": HALLOUMINATE_CURSOR_ENTRY,
             "tilth": tilth_entry(),
         },
+    }
+    assert json.loads(cursor_cli_config.read_text(encoding="utf-8")) == {
+        "permissions": {"allow": ["Shell(ls)", "Mcp(hallouminate:*)", "Mcp(tilth:*)"]},
+        "keep": True,
     }
     assert not any(argv[:2] == ("cursor", "plugin") for argv in world.argvs())
 
@@ -1168,7 +1208,7 @@ def test_built_package_declares_no_milknado_dependency_or_extra_entry_point() ->
         for requirement in project["dependencies"]
     )
 
-    assert names == ["pydantic", "rich", "typer"]
+    assert names == ["pydantic", "rich", "tomlkit", "typer"]
     assert project["scripts"] == {"cheese": "cheese_flow.cli:app"}
     assert "entry-points" not in project
     assert "optional-dependencies" not in project

--- a/tests/python/test_integration.py
+++ b/tests/python/test_integration.py
@@ -150,6 +150,14 @@ class FakeWorld:
         for harness in harnesses:
             self.install_skills(harness)
             self.write_tilth_entry(harness)
+        if "claude-code" in harnesses:
+            settings = self.home / ".claude/settings.json"
+            settings.parent.mkdir(parents=True, exist_ok=True)
+            document = _read_json(settings)
+            document.setdefault("permissions", {}).setdefault("allow", []).extend(
+                ["mcp__hallouminate", "mcp__tilth"]
+            )
+            settings.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
 
     def install_skills(self, harness: str) -> None:
         """What ``skills add <repo> --skill '*' --agent <harness> --global`` leaves on disk."""
@@ -593,6 +601,7 @@ def test_complete_config_runs_headlessly_and_stdout_is_one_json_document(
         ("hallouminate:marketplace:claude-code", "succeeded"),
         ("hallouminate:plugin:claude-code", "succeeded"),
         ("hallouminate:mcp:cursor", "succeeded"),
+        ("hallouminate:permission:claude-code", "succeeded"),
         ("hallouminate:config-init", "succeeded"),
         (f"hallouminate:init-repo:{key}", "succeeded"),
         (f"hallouminate:index:{key}", "succeeded"),
@@ -604,6 +613,7 @@ def test_complete_config_runs_headlessly_and_stdout_is_one_json_document(
         ("tilth:install", "succeeded"),
         ("tilth:register:claude-code", "succeeded"),
         ("tilth:register:cursor", "succeeded"),
+        ("tilth:permission:claude-code", "succeeded"),
     ]
     # Every reported "succeeded" corresponds to a real mutation of the world.
     assert world.installed == {"hallouminate": "1.0.0", "tilth": "nightly"}
@@ -654,7 +664,7 @@ def test_already_satisfied_postconditions_skip_every_mutation(
     assert result.exit_code == 0, result.stderr
     document = json.loads(result.stdout)
     assert {status for _, status in statuses(document)} == {"skipped"}
-    assert len(document["results"]) == 11
+    assert len(document["results"]) == 13
     assert world.argvs() == read_only_probes(home)
     assert snapshot(home) == before
 
@@ -706,10 +716,12 @@ def test_apply_installs_exactly_the_version_planning_resolved(
         ("hallouminate:npm-install", "succeeded"),
         ("hallouminate:marketplace:claude-code", "succeeded"),
         ("hallouminate:plugin:claude-code", "succeeded"),
+        ("hallouminate:permission:claude-code", "succeeded"),
         ("hallouminate:config-init", "succeeded"),
         ("easy-cheese:install:claude-code", "succeeded"),
         ("tilth:install", "succeeded"),
         ("tilth:register:claude-code", "succeeded"),
+        ("tilth:permission:claude-code", "succeeded"),
     ]
 
 
@@ -763,12 +775,14 @@ def test_failed_step_blocks_adapter_wired_dependents_and_lets_others_run(
         ("hallouminate:npm-install", "succeeded"),
         ("hallouminate:marketplace:claude-code", "succeeded"),
         ("hallouminate:plugin:claude-code", "succeeded"),
+        ("hallouminate:permission:claude-code", "succeeded"),
         ("hallouminate:config-init", "failed"),
         (f"hallouminate:init-repo:{key}", "blocked"),
         (f"hallouminate:index:{key}", "blocked"),
         ("easy-cheese:install:claude-code", "succeeded"),
         ("tilth:install", "succeeded"),
         ("tilth:register:claude-code", "succeeded"),
+        ("tilth:permission:claude-code", "succeeded"),
     ]
     blocked = {entry["step_id"]: entry["remediation"] for entry in document["results"]}
     assert blocked[f"hallouminate:init-repo:{key}"] == (
@@ -808,6 +822,7 @@ def test_interrupt_forwards_the_signal_and_reports_the_remaining_steps(
         ("hallouminate:npm-install", "succeeded"),
         ("hallouminate:marketplace:claude-code", "succeeded"),
         ("hallouminate:plugin:claude-code", "interrupted"),
+        ("hallouminate:permission:claude-code", "interrupted"),
         ("hallouminate:config-init", "interrupted"),
         ("easy-cheese:install:claude-code", "interrupted"),
     ]

--- a/tests/python/test_runner.py
+++ b/tests/python/test_runner.py
@@ -245,6 +245,7 @@ def test_forward_signal_kills_the_grandchildren_too() -> None:
     assert _group_is_gone(pgid), "the backgrounded grandchild outlived the forwarded signal"
 
 
+@pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="requires Linux procfs")
 def test_every_child_is_reaped_leaving_no_zombie_and_no_leaked_descriptors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -35,6 +35,7 @@ source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
     { name = "rich" },
+    { name = "tomlkit" },
     { name = "typer" },
 ]
 
@@ -49,6 +50,7 @@ dev = [
 requires-dist = [
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "rich", specifier = ">=15.0.0" },
+    { name = "tomlkit", specifier = ">=0.15.1" },
     { name = "typer", specifier = "==0.25.1" },
 ]
 
@@ -460,6 +462,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

## Summary
- configure server-wide MCP approvals for Hallouminate and Tilth on every currently supported harness
- emit canonical Claude Code wildcards, formatting-preserving Codex TOML approvals, and Cursor CLI permission rules
- honor Claude/Codex config-root overrides and preserve symlink-managed configuration files
- verify declared rules without overstating effective managed-policy precedence

## Harness behavior
- **Claude Code:** `mcp__plugin_hallouminate_hallouminate__*` and `mcp__tilth__*`
- **Codex:** `default_tools_approval_mode = "approve"` for plugin Hallouminate and direct Tilth MCP servers
- **Cursor:** `Mcp(hallouminate:*)` and `Mcp(tilth:*)` in `~/.cursor/cli-config.json`

OMP and Pi remain outside the supported harness model: OMP has no safe server-wide MCP approval rule, and Pi has no native MCP configuration surface. This avoids placeholder adapters or globally weakening unrelated tool permissions.

## Verification
- `just build-ci` — Ruff format/lint clean; 507 tests passed
- `just smoke claude-code`
- `just smoke codex`
- `just smoke cursor`
- Hallouminate wiki reindexed and the corrected Claude permission entry grounded successfully

## Merge
- merged current `main` and resolved `tests/python/test_desired_state.py` by retaining canonical path behavior