### PR TITLE
fix(profiles): harden source and apply boundaries

### DIFF
--- a/python/cheese_flow/profiles/parse.py
+++ b/python/cheese_flow/profiles/parse.py
@@ -11,7 +11,15 @@ from types import MappingProxyType
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, ValidationError, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    ValidationError,
+    field_serializer,
+    field_validator,
+)
 
 from .errors import ProfileSourceError
 from .models import CompileTarget
@@ -31,6 +39,7 @@ _PATH_FIELDS = ("body_path", "path", "script")
 _ENV_REF_RE = re.compile(r"\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))")
 _COMPILE_HARNESSES = {"claude", "codex", "copilot", "crush", "cursor", "opencode"}
 _DRIVABLE_HARNESSES = {"claude", "codex", "copilot"}
+_NATIVE_PLUGIN_HARNESSES = {"claude", "copilot"}
 _STRING_ITEM_FIELDS = (
     "args",
     "disabled_tools",
@@ -82,6 +91,8 @@ _PLUGIN_KEYS = frozenset(
     {
         "name",
         "path",
+        "git",
+        "branch",
         "harnesses",
         "native",
         "claude_native",
@@ -114,6 +125,14 @@ def _freeze(value: Any) -> Any:
         return tuple(_freeze(item) for item in value)
     if isinstance(value, set):
         return frozenset(_freeze(item) for item in value)
+    return value
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_json_value(item) for item in value]
     return value
 
 
@@ -168,6 +187,21 @@ class ResolvedProfile(BaseModel):
     def template_environment(self) -> Mapping[str, str]:
         """Caller/source values available only to renderer templates."""
         return self._template_environment
+
+    @field_serializer(
+        "mcps",
+        "agents",
+        "skills",
+        "commands",
+        "hooks",
+        "settings",
+        "enabled_plugins",
+        "env",
+        "marketplaces",
+        "native_plugins",
+    )
+    def _serialize_frozen_values(self, value: Any) -> Any:
+        return _json_value(value)
 
     @field_validator("source_id")
     @classmethod
@@ -529,7 +563,7 @@ def _plugin_native_harnesses(body: Mapping[str, Any], *, name: str, where: str) 
     native_value = body.get("native", False)
     if isinstance(native_value, bool):
         native = (
-            ((_DRIVABLE_HARNESSES & requested) if requested else set(_DRIVABLE_HARNESSES))
+            ((_NATIVE_PLUGIN_HARNESSES & requested) if requested else set(_NATIVE_PLUGIN_HARNESSES))
             if native_value
             else set()
         )
@@ -857,21 +891,43 @@ def _plugin_items(
             raise ProfileSourceError(
                 f"plugins registry {path} entry {name!r} has conflicting item name {body['name']!r}"
             )
+        for key in ("path", "git", "branch"):
+            if key in body and (not isinstance(body[key], str) or not body[key]):
+                raise ProfileSourceError(
+                    f"plugins registry {path} entry {name!r} field {key!r} "
+                    "must be a non-empty string"
+                )
         local_path = body.get("path")
-        if not isinstance(local_path, str) or not local_path:
-            raise ProfileSourceError(
-                f"plugins registry {path} entry {name!r} requires an explicit local path"
+        git_source = body.get("git")
+        if local_path is not None:
+            marketplace_root = resolve_declared_path(
+                source_root, local_path, kind=f"plugin {name!r} path"
             )
-        marketplace_root = resolve_declared_path(
-            source_root, local_path, kind=f"plugin {name!r} path"
-        )
+            plugin_boundary = source_root
+        elif git_source is not None:
+            home = environment.get("HOME")
+            if not isinstance(home, str) or not home:
+                raise ProfileSourceError(
+                    f"git plugin {name!r} requires HOME in the supplied environment"
+                )
+            home_path = Path(home)
+            if not home_path.is_absolute():
+                raise ProfileSourceError(f"git plugin {name!r} requires an absolute HOME path")
+            marketplace_root = (home_path / ".cache" / "cheese-flow" / "plugins" / name).resolve(
+                strict=False
+            )
+            plugin_boundary = marketplace_root
+        else:
+            raise ProfileSourceError(
+                f"plugins registry {path} entry {name!r} requires a local path or git source"
+            )
         if not marketplace_root.is_dir():
             raise ProfileSourceError(f"plugin {name!r} path is not a directory: {marketplace_root}")
         native = _plugin_native_harnesses(
             body, name=name, where=f"plugins registry {path} entry {name!r}"
         )
         marketplace_json = resolve_within(
-            source_root,
+            plugin_boundary,
             marketplace_root / ".claude-plugin" / "marketplace.json",
             kind=f"plugin {name!r} marketplace",
         )
@@ -898,7 +954,7 @@ def _plugin_items(
             payload_base = _resolve_plugin_relative(
                 marketplace_root,
                 metadata["pluginRoot"],
-                source_root=source_root,
+                source_root=plugin_boundary,
                 kind="metadata.pluginRoot",
                 plugin=name,
             )
@@ -921,7 +977,7 @@ def _plugin_items(
             payload_root = _resolve_plugin_relative(
                 payload_base,
                 entry.get("source", ""),
-                source_root=source_root,
+                source_root=plugin_boundary,
                 kind="source",
                 plugin=name,
             )
@@ -930,7 +986,9 @@ def _plugin_items(
                     f"plugin {name!r} payload is not a directory: {payload_root}"
                 )
             mcp_path = resolve_within(
-                source_root, payload_root / ".mcp.json", kind=f"plugin {name!r} MCP manifest"
+                plugin_boundary,
+                payload_root / ".mcp.json",
+                kind=f"plugin {name!r} MCP manifest",
             )
             if mcp_path.is_file():
                 try:
@@ -985,13 +1043,13 @@ def _plugin_items(
                     out["mcps"].append(item)
                     servers.append(server_name)
             out["skills"].extend(
-                _plugin_skills(name, payload_root, source_root, requested, native, str(path))
+                _plugin_skills(name, payload_root, plugin_boundary, requested, native, str(path))
             )
             out["agents"].extend(
-                _plugin_agents(name, payload_root, source_root, requested, native, str(path))
+                _plugin_agents(name, payload_root, plugin_boundary, requested, native, str(path))
             )
             out["hooks"].extend(
-                _plugin_hooks(name, payload_root, source_root, requested, native, str(path))
+                _plugin_hooks(name, payload_root, plugin_boundary, requested, native, str(path))
             )
         if not matched:
             raise ProfileSourceError(

--- a/python/cheese_flow/profiles/renderers/claude.py
+++ b/python/cheese_flow/profiles/renderers/claude.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 import shutil
 import stat
-from collections.abc import Mapping, MutableSequence, MutableSet, Sequence
+from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -32,6 +32,8 @@ from ..rendering.permissions import (
     validate_permission_rules,
 )
 from ..rendering.template import mcp_entry_for_harness
+
+ClaimRegistry = MutableMapping[str, tuple[bytes, int]]
 
 _MCP_DEFAULT = ("claude", "codex", "opencode")
 _ITEM_DEFAULT = ("claude", "codex", "copilot", "crush", "cursor", "opencode")
@@ -77,7 +79,7 @@ def _write_json(
     value: Mapping[str, Any],
     *,
     target: Path,
-    claims: MutableSet[str],
+    claims: ClaimRegistry,
 ) -> None:
     payload = json.dumps(value, indent=2, ensure_ascii=False) + "\n"
     claim_destination(claims, target, path)
@@ -89,7 +91,7 @@ def _write_local_settings(
     profile: ResolvedProfile,
     target: Path,
     out: MutableSequence[str],
-    claims: MutableSet[str],
+    claims: ClaimRegistry,
 ) -> None:
     """Project explicit Claude marketplace and enabled-plugin declarations."""
 
@@ -156,12 +158,12 @@ def _copy_skill(
     item: Mapping[str, Any],
     out: MutableSequence[str],
     server_plugins: Mapping[str, str],
-    claims: MutableSet[str],
+    claims: ClaimRegistry,
 ) -> None:
-    name = _safe_name(item.get("name"), kind="skill")
     relative = item.get("path") or ""
     if not relative:
         return
+    name = _safe_name(item.get("name"), kind="skill")
     source = _source_path(item, relative, label="skill path")
     if not source.is_dir():
         return
@@ -188,7 +190,7 @@ def _write_commands(
     plugin_dir: Path,
     target: Path,
     out: MutableSequence[str],
-    claims: MutableSet[str],
+    claims: ClaimRegistry,
 ) -> None:
     for item in profile.commands:
         if item.get("_from_native_plugin") or not _selected(item, _ITEM_DEFAULT):
@@ -222,7 +224,7 @@ def _write_hooks(
     plugin_dir: Path,
     target: Path,
     out: MutableSequence[str],
-    claims: MutableSet[str],
+    claims: ClaimRegistry,
 ) -> dict[str, list[dict[str, Any]]]:
     entries: dict[str, list[dict[str, Any]]] = {}
     for item in profile.hooks:
@@ -241,12 +243,12 @@ def _write_hooks(
                 raise FileNotFoundError(f"Claude hook script not found: {source}")
             basename = _safe_name(Path(script).name, kind="hook script")
             destination = plugin_dir / "hooks" / basename
-            claim_destination(claims, target, destination)
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(source, destination)
-            destination.chmod(
-                destination.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-            )
+            content = source.read_bytes()
+            mode = stat.S_IMODE(source.stat().st_mode) | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+            if claim_destination(claims, target, destination, content=content, mode=mode):
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_bytes(content)
+                destination.chmod(mode)
             _track_path(out, target, destination)
             copy_hook_shared_assets(item, plugin_dir, target, out, claims=claims)
             command_value = f"${{CLAUDE_PLUGIN_ROOT}}/hooks/{basename}"
@@ -294,7 +296,7 @@ class ClaudeRenderer:
         )
         plugin_dir.mkdir(parents=True, exist_ok=True)
         out: list[str] = []
-        claims: set[str] = set()
+        claims: dict[str, tuple[bytes, int]] = {}
         _write_local_settings(profile, target, out, claims)
 
         server_plugins = native_mcp_server_plugins(profile.native_plugins, "claude")

--- a/python/cheese_flow/profiles/renderers/cursor.py
+++ b/python/cheese_flow/profiles/renderers/cursor.py
@@ -127,8 +127,11 @@ class CursorRenderer:
         for item in _items(profile, "skills"):
             if not _selected(item, _DEFAULT_SKILLS):
                 continue
+            relative_path = item.get("path") or ""
+            if not relative_path:
+                continue
             name = _component(item.get("name"), label="skill name")
-            source_rel = _relative_path(item.get("path"), label="skill path")
+            source_rel = _relative_path(relative_path, label="skill path")
             source_root = _source_root(item)
             source = source_root.joinpath(*source_rel.parts)
             if not source.is_dir():

--- a/tests/python/test_profiles_apply_preflight.py
+++ b/tests/python/test_profiles_apply_preflight.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 import socket
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
+import cheese_flow.profiles.compile as compile_module
 import pytest
 from cheese_flow.profiles.apply import apply_profile
 from cheese_flow.profiles.errors import ProfileApplyError
@@ -19,6 +21,7 @@ from cheese_flow.profiles.generation import (
 from cheese_flow.profiles.models import (
     CompiledFile,
     CompiledProfileManifest,
+    CompileRequest,
     CompileTarget,
     DriftRecord,
     ProfileApplyState,
@@ -509,3 +512,96 @@ def test_apply_rejects_special_existing_lock_before_open(tmp_path: Path, special
         if listener is not None:
             listener.close()
         lock_path.unlink(missing_ok=True)
+
+
+def test_public_apply_works_after_source_and_baseline_removal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_root = tmp_path / "source"
+    profile_dir = source_root / "profiles" / "live"
+    profile_dir.mkdir(parents=True)
+    baseline_root = tmp_path / "baseline"
+    baseline_root.mkdir()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+    output_root = tmp_path / "compiled"
+    (profile_dir / "profile.yaml").write_text(
+        "name: live\ncompile_targets:\n  home:\n    target_root: $HOME\n    harnesses: [claude]\n",
+        encoding="utf-8",
+    )
+
+    class _Renderer:
+        def render(self, profile, target: Path, *, logical_root: Path):
+            del profile, logical_root
+            destination = target / ".generated" / "profile.json"
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(b'{"compiled":true}\n')
+            return (PurePosixPath(".generated/profile.json"),)
+
+    monkeypatch.setattr(compile_module, "renderer", lambda harness: _Renderer())
+    manifest = compile_module.compile_profile(
+        CompileRequest(
+            profile_name="live",
+            source_root=source_root,
+            baseline_root=baseline_root,
+            output_root=output_root,
+        ),
+        environment={"HOME": str(target_root)},
+    )
+    manifest_path = output_root / "manifest.json"
+    assert manifest.generation
+
+    shutil.rmtree(source_root)
+    shutil.rmtree(baseline_root)
+    assert not source_root.exists()
+    assert not baseline_root.exists()
+    state_path = tmp_path / "state" / "apply-state.json"
+
+    report = apply_profile(manifest_path, state_path=state_path)
+
+    destination = target_root / ".generated" / "profile.json"
+    assert report.copied == (destination,)
+    assert destination.read_bytes() == b'{"compiled":true}\n'
+    assert state_path.is_file()
+    assert not Path(f"{state_path}.journal").exists()
+
+
+def test_public_apply_rejects_a_later_invalid_fragment_before_mutation(tmp_path: Path) -> None:
+    manifest_path, target_root, _, manifest = _published(
+        tmp_path,
+        files=(
+            ("home", "claude", "first.json", b"first"),
+            ("home", "claude", "second.json", b"second"),
+        ),
+    )
+    second_fragment = manifest_path.parent / manifest.files[1].fragment_path
+    second_fragment.write_bytes(b"tampered")
+    first_destination = target_root / "first.json"
+    first_destination.write_bytes(b"existing")
+    stale_destination = target_root / "stale.json"
+    stale_destination.write_bytes(b"stale")
+    state_path = tmp_path / "state" / "apply-state.json"
+    state_path.parent.mkdir()
+    state_payload = {
+        "schema_version": 1,
+        "managed_files": [str(first_destination), str(stale_destination)],
+    }
+    state_path.write_text(json.dumps(state_payload, separators=(",", ":")) + "\n", encoding="utf-8")
+    lock_path = Path(f"{state_path}.lock")
+    lock_path.write_bytes(b"")
+    lock_path.chmod(0o600)
+    lock_mode = lock_path.stat().st_mode
+    state_bytes = state_path.read_bytes()
+    lock_bytes = lock_path.read_bytes()
+    journal_path = Path(f"{state_path}.journal")
+
+    with pytest.raises(ProfileApplyError, match="hash mismatch"):
+        apply_profile(manifest_path, state_path=state_path)
+
+    assert first_destination.read_bytes() == b"existing"
+    assert stale_destination.read_bytes() == b"stale"
+    assert not (target_root / "second.json").exists()
+    assert state_path.read_bytes() == state_bytes
+    assert lock_path.read_bytes() == lock_bytes
+    assert lock_path.stat().st_mode == lock_mode
+    assert not journal_path.exists()

--- a/tests/python/test_profiles_cli.py
+++ b/tests/python/test_profiles_cli.py
@@ -15,6 +15,17 @@ from typer.testing import CliRunner
 runner = CliRunner()
 
 
+def _assert_secret_absent(result: Any, secret: str) -> None:
+    for text in (
+        result.output,
+        result.stdout,
+        result.stderr,
+        str(result.exception),
+        repr(result.exception),
+    ):
+        assert secret not in text
+
+
 class _Document(BaseModel):
     value: str
 
@@ -156,6 +167,45 @@ def test_launch_exec_seam_receives_only_a_validated_launch_spec(
     assert request_seen["environment"]["PROFILE_TEST"] == "present"
 
 
+def test_launch_wrapper_arguments_parse_without_separator(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    request_seen: dict[str, Any] = {}
+    spec = LaunchSpec(
+        executable="codex",
+        argv=("codex", "--resume"),
+        environment={"PROFILE_TEST": "present"},
+    )
+
+    def fake_build(request: Any, *, environment: dict[str, str]) -> tuple[LaunchSpec, None]:
+        request_seen["request"] = request
+        request_seen["environment"] = environment
+        return spec, None
+
+    executed: list[LaunchSpec] = []
+    monkeypatch.setattr(cli, "_build_launch_with_workspace", fake_build)
+    monkeypatch.setattr(cli, "_exec_launch", executed.append)
+
+    source_root = tmp_path / "source"
+    result = runner.invoke(
+        cli.app,
+        [
+            "launch",
+            "codex",
+            "demo",
+            "--resume",
+            "--source-root",
+            str(source_root),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert executed == [spec]
+    assert request_seen["request"].source_root == source_root
+    assert request_seen["request"].harness == "codex"
+    assert request_seen["request"].arguments == ("--resume",)
+
+
 def test_launch_exec_rejects_unvalidated_values() -> None:
     with pytest.raises(ProfileLaunchError, match="validated LaunchSpec"):
         cli._exec_launch(object())  # type: ignore[arg-type]
@@ -245,7 +295,34 @@ def test_launch_reports_exec_and_cleanup_failures_without_environment_values(
     assert result.exit_code == 1
     assert "could not exec harness 'claude'" in result.output
     assert "workspace cleanup failed" in result.output
-    assert secret not in result.output
+    assert "cleanup failed for <redacted>" in result.output
+    _assert_secret_absent(result, secret)
+
+
+def test_launch_cli_redacts_build_environment_diagnostics(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    secret = "profile-launch-secret-unique-9f3d"
+
+    def fail_build(request: Any, *, environment: dict[str, str]) -> tuple[LaunchSpec, None]:
+        raise ProfileLaunchError(f"launch build received {environment['PROFILE_LAUNCH_SECRET']}")
+
+    monkeypatch.setattr(cli, "_build_launch_with_workspace", fail_build)
+    result = runner.invoke(
+        cli.app,
+        [
+            "launch",
+            "codex",
+            "demo",
+            "--source-root",
+            str(tmp_path),
+        ],
+        env={"PROFILE_LAUNCH_SECRET": secret},
+    )
+
+    assert result.exit_code == 1
+    assert "launch build received <redacted>" in result.output
+    _assert_secret_absent(result, secret)
 
 
 def test_permissions_builds_the_closed_request(

--- a/tests/python/test_profiles_cli.py
+++ b/tests/python/test_profiles_cli.py
@@ -305,7 +305,7 @@ def test_launch_cli_redacts_build_environment_diagnostics(
     secret = "profile-launch-secret-unique-9f3d"
 
     def fail_build(request: Any, *, environment: dict[str, str]) -> tuple[LaunchSpec, None]:
-        raise ProfileLaunchError(f"launch build received {environment['PROFILE_LAUNCH_SECRET']}")
+        raise ProfileLaunchError(f"diagnostic-prefix-56aa {environment['PROFILE_LAUNCH_SECRET']}")
 
     monkeypatch.setattr(cli, "_build_launch_with_workspace", fail_build)
     result = runner.invoke(
@@ -321,7 +321,7 @@ def test_launch_cli_redacts_build_environment_diagnostics(
     )
 
     assert result.exit_code == 1
-    assert "launch build received <redacted>" in result.output
+    assert "diagnostic-prefix-56aa <redacted>" in result.output
     _assert_secret_absent(result, secret)
 
 

--- a/tests/python/test_profiles_compile.py
+++ b/tests/python/test_profiles_compile.py
@@ -6,6 +6,8 @@ import importlib
 import json
 import os
 import stat
+import subprocess
+import sys
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -859,3 +861,222 @@ compile_targets:
             request,
             environment={"HOME": str(live_root), "TOKEN": "secret"},
         )
+
+
+def test_compile_uses_only_explicit_source_root_when_ambient_channels_are_poisoned(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_root = tmp_path / "explicit-source"
+    baseline_root = tmp_path / "baseline"
+    output_root = tmp_path / "compiled"
+    explicit_target = tmp_path / "explicit-target"
+    baseline_root.mkdir()
+
+    def write_profile(root: Path, description: str, target: Path) -> None:
+        profile_dir = root / "profiles" / "live"
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "profile.yaml").write_text(
+            (
+                f"name: live\ndescription: {description}\ncompile_targets:\n"
+                f"  home:\n    target_root: {target}\n    harnesses: [claude]\n"
+            ),
+            encoding="utf-8",
+        )
+
+    write_profile(source_root, "explicit", explicit_target)
+    ambient_roots = {
+        "DOTFILES_DIR": tmp_path / "dotfiles-decoy",
+        "HOME": tmp_path / "home-decoy",
+        "XDG_CONFIG_HOME": tmp_path / "xdg-config-decoy",
+        "XDG_CACHE_HOME": tmp_path / "xdg-cache-decoy",
+        "XDG_DATA_HOME": tmp_path / "xdg-data-decoy",
+        "XDG_STATE_HOME": tmp_path / "xdg-state-decoy",
+    }
+    decoy_targets: list[Path] = []
+    for variable, root in ambient_roots.items():
+        decoy_target = tmp_path / f"{variable.lower()}-target"
+        decoy_targets.append(decoy_target)
+        write_profile(root, f"{variable.lower()} decoy", decoy_target)
+        monkeypatch.setenv(variable, str(root))
+
+    cwd = tmp_path / "cwd-decoy"
+    cwd.mkdir()
+    cwd_target = tmp_path / "cwd-target"
+    write_profile(cwd, "cwd decoy", cwd_target)
+    (cwd / ".env").write_text("DOTFILES_DIR=/wrong/source\n", encoding="utf-8")
+    for directory in (".cache", ".vault"):
+        write_profile(cwd / directory, f"{directory} decoy", tmp_path / f"{directory[1:]}-target")
+    monkeypatch.chdir(cwd)
+
+    class _DescriptionRenderer(_Renderer):
+        def render(self, profile, target: Path, *, logical_root: Path):
+            self.payload = f"{profile.description}\n"
+            return super().render(profile, target, logical_root=logical_root)
+
+    monkeypatch.setattr(compile_module, "renderer", lambda harness: _DescriptionRenderer())
+    request = CompileRequest(
+        profile_name="live",
+        source_root=source_root,
+        baseline_root=baseline_root,
+        output_root=output_root,
+    )
+
+    manifest = compile_module.compile_profile(
+        request,
+        environment={"HOME": str(ambient_roots["HOME"])},
+    )
+
+    assert manifest.compile_targets[0].resolved_root == explicit_target.resolve()
+    fragment = output_root / manifest.files[0].fragment_path
+    assert fragment.read_bytes() == b"explicit\n"
+    assert all(not any(target.rglob("*")) for target in (*decoy_targets, cwd_target))
+
+
+def test_compile_changes_only_output_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    shared_parent = tmp_path / "shared"
+    source_root = shared_parent / "source"
+    baseline_root = shared_parent / "baseline"
+    live_root = shared_parent / "live"
+    output_root = shared_parent / "compiled"
+    shared_parent.mkdir()
+    (source_root / "profiles" / "live").mkdir(parents=True)
+    (source_root / "source-only.txt").write_text("source must stay unchanged\n", encoding="utf-8")
+    (source_root / "profiles" / "live" / "profile.yaml").write_text(
+        (
+            "name: live\ncompile_targets:\n"
+            f"  home:\n    target_root: {live_root}\n    harnesses: [claude]\n"
+        ),
+        encoding="utf-8",
+    )
+    baseline_root.mkdir()
+    (baseline_root / "baseline-only.txt").write_text(
+        "baseline must stay unchanged\n", encoding="utf-8"
+    )
+    live_root.mkdir()
+    (live_root / "user-owned.txt").write_text("live must stay unchanged\n", encoding="utf-8")
+    (shared_parent / "sibling.txt").write_text("sibling must stay unchanged\n", encoding="utf-8")
+    monkeypatch.setattr(compile_module, "renderer", lambda harness: _Renderer())
+
+    def snapshot(root: Path, *, excluded: Path | None = None) -> tuple[tuple[object, ...], ...]:
+        entries: list[tuple[object, ...]] = []
+        for path in sorted(root.rglob("*"), key=lambda item: item.as_posix()):
+            if excluded is not None and (path == excluded or excluded in path.parents):
+                continue
+            relative = path.relative_to(root).as_posix()
+            mode = stat.S_IMODE(path.lstat().st_mode)
+            if path.is_symlink():
+                entries.append((relative, "symlink", mode, os.readlink(path)))
+            elif path.is_dir():
+                entries.append((relative, "directory", mode, None))
+            elif path.is_file():
+                entries.append((relative, "file", mode, path.read_bytes()))
+            else:
+                entries.append((relative, "special", mode, None))
+        return tuple(entries)
+
+    before = {
+        "source": snapshot(source_root),
+        "baseline": snapshot(baseline_root),
+        "live": snapshot(live_root),
+        "shared": snapshot(shared_parent, excluded=output_root),
+    }
+    request = CompileRequest(
+        profile_name="live",
+        source_root=source_root,
+        baseline_root=baseline_root,
+        output_root=output_root,
+    )
+
+    manifest = compile_module.compile_profile(request, environment={})
+
+    after = {
+        "source": snapshot(source_root),
+        "baseline": snapshot(baseline_root),
+        "live": snapshot(live_root),
+        "shared": snapshot(shared_parent, excluded=output_root),
+    }
+    assert after == before
+    assert (output_root / "manifest.json").is_file()
+    assert manifest.files
+    assert all(output_root in path.parents for path in output_root.rglob("*"))
+
+
+def test_compile_is_byte_deterministic_across_hash_seeds(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    profile_dir = source_root / "profiles" / "live"
+    profile_dir.mkdir(parents=True)
+    baseline_root = tmp_path / "baseline"
+    baseline_root.mkdir()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+    (profile_dir / "profile.yaml").write_text(
+        (
+            "name: live\ncompile_targets:\n"
+            "  home:\n    target_root: $HOME/home\n    harnesses: [claude]\n"
+            "  project:\n    target_root: $HOME/project\n    harnesses: [codex]\n"
+        ),
+        encoding="utf-8",
+    )
+    output_roots = (tmp_path / "compiled-a", tmp_path / "compiled-b")
+    child = """
+from pathlib import Path, PurePosixPath
+import sys
+
+import cheese_flow.profiles.compile as compile_module
+from cheese_flow.profiles.models import CompileRequest
+
+
+class Renderer:
+    def render(self, profile, target: Path, *, logical_root: Path):
+        del profile, logical_root
+        files = (
+            (PurePosixPath(".generated/profile.json"), b'{"compiled":true}\\n'),
+            (PurePosixPath(".generated/profile.json.bak"), b'{"backup":true}\\n'),
+        )
+        for relative, payload in files:
+            destination = target.joinpath(*relative.parts)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(payload)
+        return tuple(relative for relative, _ in files)
+
+
+source_root, baseline_root, target_root, output_root = map(Path, sys.argv[1:])
+compile_module.renderer = lambda harness: Renderer()
+compile_module.compile_profile(
+    CompileRequest(
+        profile_name="live",
+        source_root=source_root,
+        baseline_root=baseline_root,
+        output_root=output_root,
+    ),
+    environment={"HOME": str(target_root)},
+)
+"""
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "python")
+    for seed, output_root in zip(("1", "2"), output_roots, strict=True):
+        child_environment = environment.copy()
+        child_environment["PYTHONHASHSEED"] = seed
+        subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                child,
+                str(source_root),
+                str(baseline_root),
+                str(target_root),
+                str(output_root),
+            ],
+            check=True,
+            cwd=tmp_path,
+            env=child_environment,
+        )
+
+    def output_bytes(root: Path) -> tuple[tuple[str, bytes], ...]:
+        return tuple(
+            (path.relative_to(root).as_posix(), path.read_bytes())
+            for path in sorted(root.rglob("*"), key=lambda item: item.as_posix())
+            if path.is_file()
+        )
+
+    assert output_bytes(output_roots[0]) == output_bytes(output_roots[1])

--- a/tests/python/test_profiles_launch.py
+++ b/tests/python/test_profiles_launch.py
@@ -53,6 +53,9 @@ def test_non_isolated_launch_builds_argv_and_secret_safe_environment_snapshot(
         "executable": "copilot",
         "argv": ("copilot", "--version"),
     }
+    serialized = spec.model_dump_json()
+    assert "caller-secret" not in serialized
+    assert "profile-secret" not in serialized
     with pytest.raises(TypeError):
         spec.environment["TOKEN"] = "changed"  # type: ignore[index]
 

--- a/tests/python/test_profiles_manifest_generation.py
+++ b/tests/python/test_profiles_manifest_generation.py
@@ -257,3 +257,65 @@ def test_interrupted_generation_publication_cleans_staging_and_retries(
         == ()
     )
     publish_generation(output_root, manifest, {"home/claude/settings.json": payload})
+
+
+@pytest.mark.parametrize("failure_seam", ("generation_replace", "manifest_replace"))
+def test_late_publication_failures_preserve_prior_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure_seam: str
+) -> None:
+    prior_descriptor, prior_payload = _descriptor(payload=b'{"generation":"prior"}\n')
+    prior_manifest = bind_generation(prior_descriptor)
+    output_root = tmp_path / "compiled"
+    manifest_path = publish_generation(
+        output_root,
+        prior_manifest,
+        {"home/claude/settings.json": prior_payload},
+    )
+    prior_manifest_bytes = manifest_path.read_bytes()
+    prior_generation_root = output_root / "generations" / prior_manifest.generation
+
+    def snapshot(root: Path) -> tuple[tuple[str, int, bytes], ...]:
+        return tuple(
+            (
+                path.relative_to(root).as_posix(),
+                stat.S_IMODE(path.stat().st_mode),
+                path.read_bytes(),
+            )
+            for path in sorted(root.rglob("*"), key=lambda item: item.as_posix())
+            if path.is_file()
+        )
+
+    prior_generation_snapshot = snapshot(prior_generation_root)
+    next_descriptor, next_payload = _descriptor(payload=b'{"generation":"next"}\n')
+    next_manifest = bind_generation(next_descriptor)
+    next_generation_root = output_root / "generations" / next_manifest.generation
+    original_replace = generation_module.os.replace
+
+    def fail_replace(source: str | Path, destination: str | Path) -> None:
+        if failure_seam == "generation_replace" and Path(destination) == next_generation_root:
+            raise OSError("generation publication interrupted")
+        if failure_seam == "manifest_replace" and Path(destination) == manifest_path:
+            raise OSError("manifest publication interrupted")
+        original_replace(source, destination)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(generation_module.os, "replace", fail_replace)
+        with pytest.raises(OSError, match="publication interrupted"):
+            publish_generation(
+                output_root,
+                next_manifest,
+                {"home/claude/settings.json": next_payload},
+            )
+
+    assert manifest_path.read_bytes() == prior_manifest_bytes
+    assert load_manifest(manifest_path) == prior_manifest
+    assert load_manifest(prior_generation_root / "manifest.json") == prior_manifest
+    assert snapshot(prior_generation_root) == prior_generation_snapshot
+    assert (
+        tuple(
+            path
+            for path in (output_root / "generations").iterdir()
+            if path.name.startswith(f".{next_manifest.generation}.")
+        )
+        == ()
+    )

--- a/tests/python/test_profiles_renderer_claude.py
+++ b/tests/python/test_profiles_renderer_claude.py
@@ -208,6 +208,55 @@ def test_claude_projects_explicit_local_marketplaces_and_plugins(tmp_path: Path)
     }
 
 
+def test_claude_ignores_external_source_records_without_local_paths(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    _write_source(source)
+    profile = _profile(source).model_copy(
+        update={"skills": ({"source": "owner/repository", "_source_dir": str(source)},)}
+    )
+    target = tmp_path / "target"
+
+    written = ClaudeRenderer().render(profile, target, logical_root=tmp_path / "logical")
+
+    assert not any(path.parts[:2] == (".claude", "skills") for path in written)
+    assert not (target / ".claude" / "skills").exists()
+
+
+def test_claude_reuses_identical_hook_script_across_events(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    _write_source(source)
+    profile = _profile(source).model_copy(
+        update={
+            "hooks": tuple(
+                {
+                    "event": event,
+                    "script": "hooks/a.sh",
+                    "harnesses": ["claude"],
+                    "_source_dir": str(source),
+                }
+                for event in ("PreToolUse", "PostToolUse")
+            )
+        }
+    )
+    target = tmp_path / "target"
+
+    written = ClaudeRenderer().render(profile, target, logical_root=tmp_path / "logical")
+    hook_path = PurePosixPath(".claude/plugins/local/demo/hooks/a.sh")
+    manifest = json.loads(
+        (target / ".claude" / "plugins" / "local" / "demo" / "plugin.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert written.count(hook_path) == 1
+    assert set(manifest["hooks"]) == {"PreToolUse", "PostToolUse"}
+    assert {entries[0]["hooks"][0]["command"] for entries in manifest["hooks"].values()} == {
+        "${CLAUDE_PLUGIN_ROOT}/hooks/a.sh"
+    }
+
+
 def test_claude_rejects_scalar_item_harnesses(tmp_path: Path) -> None:
     source = tmp_path / "source"
     source.mkdir()

--- a/tests/python/test_profiles_renderer_cursor.py
+++ b/tests/python/test_profiles_renderer_cursor.py
@@ -153,6 +153,29 @@ def test_cursor_launch_spec_is_a_plain_explicit_exec_projection() -> None:
     assert dict(spec.environment) == {"TOKEN": "secret"}
 
 
+def test_cursor_ignores_external_source_records_without_local_paths(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    _write_source(source)
+    profile = _profile(source).model_copy(
+        update={
+            "skills": (
+                {
+                    "source": "owner/repository",
+                    "harnesses": ["cursor"],
+                    "_source_dir": str(source),
+                },
+            )
+        }
+    )
+    target = tmp_path / "target"
+
+    written = CursorRenderer().render(profile, target, logical_root=tmp_path / "logical")
+
+    assert not any(path.parts[:2] == (".agents", "skills") for path in written)
+    assert not (target / ".agents" / "skills").exists()
+
+
 def test_cursor_rejects_scalar_item_harnesses(tmp_path: Path) -> None:
     source = tmp_path / "source"
     source.mkdir()

--- a/tests/python/test_profiles_source.py
+++ b/tests/python/test_profiles_source.py
@@ -83,7 +83,14 @@ def _plugin_fixture(
     )
     registry = source_root / "plugins" / "registry.yaml"
     registry.write_text(
-        "plugins:\n  demo:\n    path: plugins/marketplace\n    native: [claude]\n",
+        (
+            "plugins:\n"
+            "  demo:\n"
+            "    git: https://example.com/demo.git\n"
+            "    branch: main\n"
+            "    path: plugins/marketplace\n"
+            "    native: [claude]\n"
+        ),
         encoding="utf-8",
     )
     return registry
@@ -545,6 +552,45 @@ def test_declared_plugins_decompose_native_and_non_native_primitives(tmp_path: P
     }
 
 
+def test_git_plugins_use_prepared_cheese_flow_cache(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    registry = _plugin_fixture(source_root)
+    home = tmp_path / "home"
+    cached_plugin = home / ".cache" / "cheese-flow" / "plugins" / "demo"
+    cached_plugin.parent.mkdir(parents=True)
+    (source_root / "plugins" / "marketplace").rename(cached_plugin)
+    registry.write_text(
+        (
+            "plugins:\n"
+            "  demo:\n"
+            "    git: https://example.com/demo.git\n"
+            "    branch: main\n"
+            "    native: true\n"
+        ),
+        encoding="utf-8",
+    )
+    _profile(
+        source_root,
+        "live",
+        "name: live\nregistries:\n  plugins: plugins/registry.yaml\n",
+    )
+
+    profile = load_profile(
+        source_root,
+        "live",
+        environment={"HOME": str(home), "TOKEN": "caller-secret"},
+    )
+
+    assert profile.native_plugins[0]["marketplace_root"] == str(cached_plugin.resolve())
+    assert profile.native_plugins[0]["claude_native"] is True
+    assert profile.native_plugins[0]["codex_native"] is False
+    assert profile.native_plugins[0]["copilot_native"] is True
+    assert [item["name"] for item in profile.skills] == ["demo-skill"]
+    assert profile.model_dump(mode="json")["native_plugins"][0]["marketplace_root"] == str(
+        cached_plugin.resolve()
+    )
+
+
 def test_plugin_payload_traversal_is_rejected(tmp_path: Path) -> None:
     source_root = tmp_path / "source"
     _plugin_fixture(source_root, source="../outside")
@@ -580,3 +626,39 @@ def test_plugin_primitives_collide_with_explicit_items(tmp_path: Path) -> None:
 
     with pytest.raises(ProfileSourceError, match="duplicate mcps item name 'shared'"):
         load_profile(source_root, "live", environment={"TOKEN": "caller-secret"})
+
+
+def test_source_apis_ignore_legacy_ambient_discovery_channels(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_root = tmp_path / "explicit-source"
+    _profile(source_root, "live", "name: live\ndescription: explicit\n")
+
+    ambient_roots = {
+        "DOTFILES_DIR": tmp_path / "dotfiles-decoy",
+        "HOME": tmp_path / "home-decoy",
+        "XDG_CONFIG_HOME": tmp_path / "xdg-config-decoy",
+        "XDG_CACHE_HOME": tmp_path / "xdg-cache-decoy",
+        "XDG_DATA_HOME": tmp_path / "xdg-data-decoy",
+        "XDG_STATE_HOME": tmp_path / "xdg-state-decoy",
+    }
+    for root in ambient_roots.values():
+        _profile(root, "live", "name: live\ndescription: ambient decoy\n")
+
+    cwd = tmp_path / "cwd-decoy"
+    cwd.mkdir()
+    _profile(cwd, "live", "name: live\ndescription: cwd decoy\n")
+    (cwd / ".env").write_text("DOTFILES_DIR=/wrong/source\n", encoding="utf-8")
+    for directory in (".cache", ".vault"):
+        _profile(cwd / directory, "live", "name: live\ndescription: hidden decoy\n")
+    monkeypatch.chdir(cwd)
+    for variable, root in ambient_roots.items():
+        monkeypatch.setenv(variable, str(root))
+
+    summaries = list_profiles(source_root)
+    assert [(summary.name, summary.description, summary.source_id) for summary in summaries] == [
+        ("live", "explicit", "profiles/live")
+    ]
+
+    profile = load_profile(source_root, "live", environment={})
+    assert profile.description == "explicit"


### PR DESCRIPTION
## Purpose

Harden the profile engine shipped in #98 at its source, rendering, launch, and apply boundaries.

## Behaviour

- confines git-backed plugin resolution to the prepared cache and rejects source escape
- preserves recursive immutable values in generated manifests
- skips unavailable external skill paths for Claude and Cursor
- reuses identical Claude hook assets without duplicate publication
- preflights apply mutations and preserves launch argv/environment semantics

## Verification

- `rtk just build` — Ruff clean; 925 tests passed
- focused profile suite — 418 tests passed
- fresh-root compile/apply/reapply/reduced-apply/launch smoke — passed; deterministic generation, stale-owned deletion, sentinel preservation, and `codex-cli 0.145.0` launch observed

## Durable artifacts

- `{target: .cheese/cook/agent-profile-extraction.md, backend: transient report, verified: true}`
- `{target: .cheese/press/agent-profile-extraction.md, backend: transient report, verified: true}`

## Risks

- Launch intentionally uses process replacement and performs no post-exit overlay cleanup (AC18).
- Dotfiles must pin the exact squash-merge SHA from this PR before its migration PR is opened.
