### PR TITLE
feat: add Copilot instruction review sets

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,67 @@
+# Copilot Instructions
+
+## Engineering Principles
+
+1. **Input Validation** - Trust nothing from external sources. Validate at system boundaries (manifest TOML, harness config files, CLI arguments, downloaded artifacts) — pydantic models for object safety. Internal code trusts internal code.
+2. **Fail Fast and Loud** - Handle errors where they occur. No silent failures, no swallowed exceptions, no empty defaults on error. An installer that half-succeeds silently is worse than one that stops loudly.
+3. **Loose Coupling** - Separate business logic from infrastructure. Core models and planning logic must not shell out, touch the network, or depend on a specific harness; harness- and component-specific behavior lives in `python/cheese_flow/adapters/`.
+4. **YAGNI** - Build only what is needed now. No abstract base classes with one implementation, no config options that are never varied.
+5. **Real-World Models** - Name things after installer concepts: `DesiredState`, `Harness`, `Profile`, `Repository` — not `DataProcessor`, `Manager`, `StrategyHandler`.
+6. **Immutable Patterns** - Minimize state mutation. Prefer pure functions and returning new values over mutating arguments.
+
+## Complexity Budget
+
+- **Functions**: Maximum 40 lines
+- **Files**: Maximum 300 lines
+- **Parameters**: Maximum 4 per function
+- **Nesting**: Maximum 3 levels deep
+
+If a function or file exceeds these limits, decompose it.
+
+## Code Style
+
+- **Classes**: PascalCase
+- **Functions / variables**: snake_case
+- **Constants**: SCREAMING_SNAKE_CASE
+- **Files**: kebab-case (snake_case for Python modules, matching the existing tree)
+- **Commits**: Conventional Commits format (`feat:`, `fix:`, `chore:`, etc.)
+
+## Architecture
+
+Follow the Sliced Bread layout:
+
+- Flat concept modules under `python/cheese_flow/` (`cli`, `install`, `desired_state`, `models`, `repositories`, `runner`, `doctor`, `harness_detection`, `tui`) with component adapters under `python/cheese_flow/adapters/` and profile logic under `python/cheese_flow/profiles/`.
+- Harness- and component-specific behavior belongs in an adapter, never inlined into planning or CLI code.
+- Templates are Eta-rendered `agents/*.md.eta` and `skills/*/SKILL.md`; generated harness config is data, not code.
+- One-directional dependencies only; do not reach into another module's internals.
+
+## No Migration Code
+
+This project is pre-release. Do not add migration backfills, deprecation shims, or compatibility layers.
+
+## What NOT to Do
+
+- Do not add docstrings to private methods or small helpers with clear names.
+- Do not create abstract base classes, factories, or registries unless there are 2+ concrete implementations today.
+- Do not add error handling for conditions that cannot occur in the current system.
+- Do not add backwards-compatibility shims — change the code directly.
+- Do not wrap functions that add no logic — call the original directly.
+- Do not add type annotations to every local variable — annotate function signatures and let inference handle the rest.
+- Never weaken the `bootstrap.sh` uv-installer pin or add a verification bypass (see `bootstrap.instructions.md`).
+
+## Tech Stack
+
+- **Language**: Python 3.11+ (`uv` for all dependency and environment management; package root `python/cheese_flow/`)
+- **Boundary models**: pydantic v2
+- **CLI**: typer + rich
+- **Config**: tomlkit (manifest), PyYAML
+- **Tests**: pytest + pytest-bdd (features under `tests/python/features/`), smoke install via `just smoke`
+- **Lint**: Ruff (E, F, I, UP, B, SIM; line length 100)
+- **Shell**: `bootstrap.sh` curl-pipe entry point and repo hooks
+
+## Build, Test, and Lint Commands
+
+- **The PR gate**: `just build` — autofix format + lint, then pytest. Must pass before any PR; CI runs `just build-ci` (no autofix).
+- Tests: `just test` (passthrough: `just test -k pattern`)
+- Smoke install into a throwaway HOME: `just smoke [harness]`
+- Install deps: `just install`

--- a/.github/instructions/bootstrap.instructions.md
+++ b/.github/instructions/bootstrap.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "bootstrap.sh"
+---
+
+## Bootstrap supply-chain review — strictest tier
+
+`bootstrap.sh` is the `curl … | sh` entry point, and the uv installer it downloads is the only code it runs that is not ours. It is pinned by version **and** SHA-256 and refuses to execute a body that does not match. Review any diff here as a supply-chain change:
+
+1. **Keep the version in the URL.** Astral serves the unversioned `/uv/install.sh` from whatever release is current, so a hash pinned against it breaks for every user on every uv release. Only `/uv/<version>/install.sh` is frozen — flag any change that drops the version from the URL or pins a hash against the unversioned path.
+2. **Never a verification bypass.** Flag any environment variable, flag, or code path that skips hash verification — a bypass knob is exactly the hole the pin exists to close. Tests that need their own installer accepted rewrite the constant in a copy of the script instead.
+3. **Pin refresh is a release action.** `UV_VERSION` and `UV_INSTALLER_SHA256` change together, via the refresh procedure in `AGENTS.md`, as part of cutting a release — flag a version bump without a matching hash, or vice versa.
+4. **Hash mismatch is an incident.** A mismatch against a frozen versioned URL means content changed underneath an immutable release. Flag any handling that retries, warns-and-continues, or auto-refreshes the pin instead of failing hard.
+5. **POSIX only.** The script runs under `sh` on fresh machines — flag bashisms.

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -1,0 +1,30 @@
+---
+applyTo: "**"
+excludeAgent: "coding-agent"
+---
+
+## Code Review Focus
+
+Focus reviews on these categories, in priority order:
+
+1. **Supply chain & security** - Flag hardcoded secrets, command injection (this tool shells out to harness CLIs), path traversal, unpinned or verification-weakened downloads, and any change that loosens the `bootstrap.sh` uv-installer pin (scoped in `bootstrap.instructions.md`). This installer writes into users' home directories — treat every write path and every fetched artifact as hostile until validated.
+2. **Silent failures** - Flag swallowed exceptions, empty `except` blocks, or install/apply steps that report success without verifying their effect. A half-applied profile must surface, not vanish.
+3. **Coupling violations** - Flag harness- or component-specific behavior inlined into planning, models, or CLI code instead of an adapter under `python/cheese_flow/adapters/`.
+4. **Complexity violations** - Flag functions over 40 lines, files over 300 lines, functions with more than 4 parameters, nesting deeper than 3 levels.
+5. **Architectural violations** - Flag cross-module internal reaches, mutable shared state, God modules, and single-use abstractions (factories, registries, ABCs with one implementation).
+
+Test quality rules are scoped to `tests/**` in `tests.instructions.md`; shell rules to `*.sh` in `shell.instructions.md`; the bootstrap supply-chain contract to `bootstrap.instructions.md` — do not duplicate those categories here.
+
+## What NOT to Comment On
+
+- Linting, formatting, and import ordering — handled by Ruff (E, F, I, UP, B, SIM) in `just build` / `just build-ci`
+- Missing docstrings on internal or private functions
+- Style preferences that are consistent with the rest of the codebase
+- Nitpicks with no functional impact
+
+## Review Style
+
+- Only comment when confidence is high
+- If a pattern is used consistently elsewhere in the codebase, do not flag it as wrong
+- Suggest specific fixes, not vague improvements
+- One comment per issue — do not repeat the same feedback on multiple occurrences

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -1,6 +1,6 @@
 ---
 applyTo: "**"
-excludeAgent: "coding-agent"
+excludeAgent: "cloud-agent"
 ---
 
 ## Code Review Focus
@@ -10,10 +10,10 @@ Focus reviews on these categories, in priority order:
 1. **Supply chain & security** - Flag hardcoded secrets, command injection (this tool shells out to harness CLIs), path traversal, unpinned or verification-weakened downloads, and any change that loosens the `bootstrap.sh` uv-installer pin (scoped in `bootstrap.instructions.md`). This installer writes into users' home directories — treat every write path and every fetched artifact as hostile until validated.
 2. **Silent failures** - Flag swallowed exceptions, empty `except` blocks, or install/apply steps that report success without verifying their effect. A half-applied profile must surface, not vanish.
 3. **Coupling violations** - Flag harness- or component-specific behavior inlined into planning, models, or CLI code instead of an adapter under `python/cheese_flow/adapters/`.
-4. **Complexity violations** - Flag functions over 40 lines, files over 300 lines, functions with more than 4 parameters, nesting deeper than 3 levels.
+4. **Complexity violations** - Flag functions over 40 lines, files over 300 lines, functions with more than 4 parameters, nesting deeper than 3 levels. Do not flag a file that is already over budget on `main` unless the diff makes it larger.
 5. **Architectural violations** - Flag cross-module internal reaches, mutable shared state, God modules, and single-use abstractions (factories, registries, ABCs with one implementation).
 
-Test quality rules are scoped to `tests/**` in `tests.instructions.md`; shell rules to `*.sh` in `shell.instructions.md`; the bootstrap supply-chain contract to `bootstrap.instructions.md` — do not duplicate those categories here.
+Test quality rules are scoped to `tests/**` in `tests.instructions.md`; shell rules to `**/*.sh` in `shell.instructions.md`; the bootstrap supply-chain contract to `bootstrap.instructions.md` — do not duplicate those categories here.
 
 ## What NOT to Comment On
 

--- a/.github/instructions/coding-agent.instructions.md
+++ b/.github/instructions/coding-agent.instructions.md
@@ -1,0 +1,25 @@
+---
+applyTo: "**"
+excludeAgent: "code-review"
+---
+
+## Coding Agent Guidelines
+
+When implementing changes:
+
+- Read existing code before modifying it — understand the patterns in use
+- Follow the existing code style of the file you are editing
+- Keep changes minimal and focused on the issue at hand
+- Do not refactor surrounding code unless the issue requires it
+- Do not add docstrings to helper functions or private methods with clear names
+- Do not introduce new dependencies without explicit approval; manage everything through `uv`
+- Write tests for new functionality — match the existing pytest / pytest-bdd patterns in `tests/python/`
+- Prefer editing existing files over creating new ones
+- Run `just build` before opening a PR — it must pass cleanly (autofix + lint + tests); re-run if autofix changed files
+
+## Architecture Rules
+
+- Harness- and component-specific behavior goes in an adapter under `python/cheese_flow/adapters/`, never inlined into planning or CLI code
+- Validate external input (manifest TOML, harness config, CLI args) with pydantic models at the boundary
+- No migration code — this project is pre-release; change the code directly instead of adding backfills, deprecation shims, or compatibility layers
+- Never touch the `bootstrap.sh` uv-installer pin except through the release refresh procedure in `AGENTS.md`, and never add a verification bypass

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "**/*.py"
+---
+- Use type hints on all function signatures and return types; omit obvious local annotations.
+- Use `uv` for dependency management, never pip directly.
+- Use pytest (plus pytest-bdd for Gherkin features), not unittest.
+- Validate untrusted boundary data (manifest TOML, harness config files, CLI input) with pydantic v2 models; internal code passes validated objects, not raw dicts.
+- Raise specific exceptions; never bare `except`, `raise Exception`, or `contextlib.suppress(Exception)`.
+- Route every filesystem path through `pathlib.Path`; this installer targets macOS and Linux home directories — never hardcode a harness's config location outside the detection/adapters layer.
+- Prefer comprehensions and generators for pure transforms; keep a loop when it carries state, side effects, or clearer early exits.
+- Fix the underlying lint issue instead of adding a suppression.

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "**/*.sh"
+---
+- Use `set -euo pipefail` at the top of bash scripts (`bootstrap.sh` is POSIX `sh` — keep it POSIX-compatible; no bashisms there).
+- Quote all variable expansions: `"$var"`, not `$var`.
+- Use `[[ ]]` over `[ ]` in bash scripts; plain `[ ]` in POSIX `sh`.
+- Use functions for any logic that repeats or exceeds 10 lines; `local` for function variables in bash.
+- Fail loudly: check command exit status, and never pipe a download into execution without verifying its hash first.
+- Prefer `printf` over `echo` for portable output.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,23 @@
+---
+applyTo: "tests/**/*.py"
+excludeAgent: "coding-agent"
+---
+
+## pytest / pytest-bdd test review
+
+Unit tests live under `tests/python/` with Gherkin features in `tests/python/features/`, shared fixtures in `tests/python/fixtures/`, and the smoke-install assertion in `tests/smoke/` (driven by `just smoke`, which runs a real bounded `bootstrap.sh` install into a throwaway HOME).
+
+Flag as weak — a test that passes even when the code is broken:
+
+- No assertions, or existence/no-crash-only checks
+- Tautological assertions, and mirror-implementation tests that re-derive the expected value from the same logic as the system under test
+- Mock echo tests — asserting a mock returned what the mock was told to return
+- Assertions behind conditional branches that silently pass when the branch is skipped
+- Happy-path-only coverage — no error or boundary case for the behavior under test
+- `len()`-only collection checks where content matters
+- Mocking the system under test
+- Installer tests that assert a step was *attempted* without asserting the resulting on-disk state
+
+Do not flag: sandboxed throwaway-HOME fixtures and subprocess doubles — they are the sanctioned way to exercise install flows without touching the real home directory; naming/style consistent with existing tests.
+
+A test that needs its own uv installer accepted must rewrite the pin constant in a **copy** of `bootstrap.sh` — never via a bypass knob in the script itself.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,6 +1,6 @@
 ---
-applyTo: "tests/**/*.py"
-excludeAgent: "coding-agent"
+applyTo: "tests/**/*.py,tests/**/*.feature"
+excludeAgent: "cloud-agent"
 ---
 
 ## pytest / pytest-bdd test review


### PR DESCRIPTION
Adds GitHub Copilot instruction review sets, following the layout used in tdbr/poln8r/milknado, adapted to cheese-flow's Python + shell installer stack.

**Semantics-preserving** — documentation/configuration only; no production code changes. Reviewers should verify the rules accurately reflect repo conventions.

## Files

| File | Scope | Purpose |
| --- | --- | --- |
| `.github/copilot-instructions.md` | global | Principles (pydantic at boundaries), complexity budget, architecture, no-migration-code, stack, commands |
| `instructions/code-review.instructions.md` | `**` (review only) | Supply chain & security first — this tool writes into users' home directories |
| `instructions/coding-agent.instructions.md` | `**` (coding agent only) | Implementation guidelines; `just build` gate; pin-touch prohibition |
| `instructions/python.instructions.md` | `**/*.py` | pydantic v2 boundaries, pathlib, no adapter-bypassing harness paths |
| `instructions/shell.instructions.md` | `**/*.sh` | Bash/POSIX rules; `bootstrap.sh` stays POSIX `sh` |
| `instructions/tests.instructions.md` | `tests/**/*.py` | Weak-assertion catalog; sanctions throwaway-HOME fixtures; on-disk-state assertions for installer tests |
| `instructions/bootstrap.instructions.md` | `bootstrap.sh` | Supply-chain contract: versioned-URL + SHA-256 pin, no bypass knobs, pin refresh only at release, hash mismatch = incident |

Grounded in `AGENTS.md` (including the pinned-uv-installer rules), `justfile`, `pyproject.toml`, and the CI workflow.

Quality gate: `just build` — passed (ruff clean, 925 tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
