### PR TITLE
fix(hallouminate): declare Claude Code plugin registration in settings, not via the claude CLI

### DIFF
--- a/python/cheese_flow/adapters/hallouminate.py
+++ b/python/cheese_flow/adapters/hallouminate.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from cheese_flow.adapters.native_config import (
+    claude_config_dir,
     config_edit_holds,
     mcp_permission_edit,
     read_mcp_entry,
@@ -23,13 +24,22 @@ from cheese_flow.models import (
 
 PACKAGE = "hallouminate"
 MARKETPLACE_SOURCE = "paulnsorensen/hallouminate"
+MARKETPLACE_NAME = "hallouminate"
 PLUGIN_ID = "hallouminate@hallouminate"
 
+CLAUDE_MARKETPLACE_ENTRY: dict[str, object] = {
+    "source": {"source": "github", "repo": MARKETPLACE_SOURCE}
+}
+"""The ``extraKnownMarketplaces`` entry Claude Code fetches the catalog from at startup."""
+
 # Harness-native plugin CLIs, keyed by harness: (executable, install verb).
-# Cursor is absent on purpose — it receives MCP and CLI integration, never
-# Hallouminate plugin workflows.
+# Claude Code is absent on purpose — its registration is declared in user
+# settings (see _claude_registration_steps), because the headless host this
+# installer must converge on, a Claude Cloud setup script, has no `claude` on
+# PATH and sits behind a GitHub proxy that refuses clones of repositories not
+# attached to the session. Cursor is absent because it receives MCP and CLI
+# integration, never Hallouminate plugin workflows.
 PLUGIN_CLIS: dict[HarnessName, tuple[str, str]] = {
-    "claude-code": ("claude", "install"),
     "codex": ("codex", "add"),
 }
 
@@ -114,6 +124,9 @@ class HallouminateAdapter:
                         depends_on=(_INSTALL_STEP,),
                     )
                 )
+                continue
+            if harness == "claude-code":
+                steps.extend(_claude_registration_steps(self.name))
                 continue
             if harness not in PLUGIN_CLIS:
                 continue
@@ -234,8 +247,12 @@ class HallouminateAdapter:
         if step.step_id == _INSTALL_STEP:
             return self._check_version(runner)
         if step.step_id.startswith("hallouminate:marketplace:"):
+            if step.config_edit is not None:
+                return config_edit_holds(step.config_edit)
             return self._check_marketplace(step, runner)
         if step.step_id.startswith("hallouminate:plugin:"):
+            if step.config_edit is not None:
+                return config_edit_holds(step.config_edit)
             return self._check_plugin(step, runner)
         if step.step_id == _CURSOR_MCP_STEP:
             return _check_cursor_mcp(step)
@@ -295,6 +312,48 @@ class HallouminateAdapter:
         return outcome.exit_code == 0 and _has_corpus_result(outcome.stdout)
 
 
+def _claude_registration_steps(component: ComponentName) -> tuple[PlanStep, PlanStep]:
+    """Registration declared in Claude Code's user settings, never through its CLI.
+
+    Claude Code reads ``extraKnownMarketplaces`` and ``enabledPlugins`` from
+    user settings at startup and fetches the marketplace itself. Shelling out
+    to ``claude plugin`` cannot converge on the headless host this installer
+    exists for: a Claude Cloud setup script runs with no ``claude`` on PATH,
+    behind a GitHub proxy that refuses clones of repositories not attached to
+    the session. Declaring the entries defers the fetch to session start,
+    which the cloud blesses, and works identically on a developer machine.
+    """
+    settings = claude_config_dir() / "settings.json"
+    marketplace = ConfigEdit(
+        target=settings,
+        pointer=f"extraKnownMarketplaces.{MARKETPLACE_NAME}",
+        value=CLAUDE_MARKETPLACE_ENTRY,
+    )
+    plugin = ConfigEdit(target=settings, pointer=f"enabledPlugins.{PLUGIN_ID}", value=True)
+    return (
+        PlanStep(
+            step_id="hallouminate:marketplace:claude-code",
+            component=component,
+            harness="claude-code",
+            phase=Phase.REGISTER,
+            config_edit=marketplace,
+            postcondition=(
+                f"{settings} declares the {MARKETPLACE_SOURCE} marketplace at {marketplace.pointer}"
+            ),
+            depends_on=(_INSTALL_STEP,),
+        ),
+        PlanStep(
+            step_id="hallouminate:plugin:claude-code",
+            component=component,
+            harness="claude-code",
+            phase=Phase.REGISTER,
+            config_edit=plugin,
+            postcondition=f"{settings} enables {PLUGIN_ID} at {plugin.pointer}",
+            depends_on=("hallouminate:marketplace:claude-code",),
+        ),
+    )
+
+
 def _check_cursor_mcp(step: PlanStep) -> bool:
     """Confirm Cursor MCP config declares the entry the step specifies."""
     edit = step.config_edit
@@ -317,20 +376,20 @@ def _owner_repo(raw: str) -> str:
 
 
 def _marketplace_sources(stdout: str) -> set[str]:
-    """Remote ``owner/repo`` identities from ``plugin marketplace list --json``.
+    """Remote ``owner/repo`` identities from ``codex plugin marketplace list --json``.
 
     Marketplace names collide: a directory-sourced ``hallouminate`` marketplace
     is already registered on developer machines, and it does not satisfy a step
     that added ``paulnsorensen/hallouminate``. Only entries the CLI reports as
     remotely sourced contribute, so a local root can never normalize into a
-    false match. Codex answers ``{"marketplaces": [...]}`` with a nested
-    ``marketplaceSource``; Claude answers a flat list keyed ``source``/``repo``.
+    false match. Codex answers ``{'marketplaces': [...]}`` with a nested
+    ``marketplaceSource``.
     """
     try:
         document = json.loads(stdout)
     except json.JSONDecodeError:
         return set()
-    entries = document.get("marketplaces") if isinstance(document, dict) else document
+    entries = document.get("marketplaces") if isinstance(document, dict) else None
     if not isinstance(entries, list):
         return set()
     sources: set[str] = set()
@@ -338,37 +397,26 @@ def _marketplace_sources(stdout: str) -> set[str]:
         if not isinstance(entry, dict):
             continue
         nested = entry.get("marketplaceSource")
-        if isinstance(nested, dict):
-            if nested.get("sourceType") == "git":
-                sources.add(_owner_repo(str(nested.get("source", ""))))
-        elif entry.get("source") == "github":
-            sources.add(_owner_repo(str(entry.get("repo", ""))))
+        if isinstance(nested, dict) and nested.get("sourceType") == "git":
+            sources.add(_owner_repo(str(nested.get("source", ""))))
     return sources - {""}
 
 
 def _installed_plugin_ids(stdout: str) -> set[str]:
-    """Installed plugin ids from a ``plugin list --json`` document.
+    """Installed plugin ids from a ``codex plugin list --json`` document.
 
-    Codex answers ``{"installed": [...], "available": [...]}`` with entries
-    keyed ``pluginId``; Claude answers a flat list keyed ``id``. Codex lists
-    plugins its marketplaces merely offer, so ``installed: false`` entries are
-    excluded — that distinction is the whole point of the check.
-
-    Claude reports OTHER projects' project-scoped plugins in this global
-    listing, so a flat entry must additionally be ``scope: "user"``. Its
-    ``enabled`` flag is deliberately ignored: claude reports ``enabled: false``
-    for active plugins too, so reading it would reject correct installs.
+    Codex answers ``{'installed': [...], 'available': [...]}`` with entries
+    keyed ``pluginId``, and lists plugins its marketplaces merely offer, so
+    ``installed: false`` entries are excluded — that distinction is the whole
+    point of the check.
     """
     try:
         document = json.loads(stdout)
     except json.JSONDecodeError:
         return set()
-    if isinstance(document, dict):
-        return _codex_plugin_ids(document.get("installed"))
-    return _claude_plugin_ids(document)
-
-
-def _codex_plugin_ids(entries: object) -> set[str]:
+    if not isinstance(document, dict):
+        return set()
+    entries = document.get("installed")
     if not isinstance(entries, list):
         return set()
     ids: set[str] = set()
@@ -376,19 +424,6 @@ def _codex_plugin_ids(entries: object) -> set[str]:
         if not isinstance(entry, dict) or entry.get("installed") is False:
             continue
         identifier = entry.get("pluginId")
-        if isinstance(identifier, str) and identifier:
-            ids.add(identifier)
-    return ids
-
-
-def _claude_plugin_ids(entries: object) -> set[str]:
-    if not isinstance(entries, list):
-        return set()
-    ids: set[str] = set()
-    for entry in entries:
-        if not isinstance(entry, dict) or entry.get("scope") != "user":
-            continue
-        identifier = entry.get("id")
         if isinstance(identifier, str) and identifier:
             ids.add(identifier)
     return ids

--- a/python/cheese_flow/install.py
+++ b/python/cheese_flow/install.py
@@ -146,7 +146,9 @@ def apply_config_edit(edit: ConfigEdit) -> None:
     _write_atomically(target, json.dumps(document, indent=2) + "\n")
 
 
-def _append_unique(table: MutableMapping[str, Any], key: str, value: dict[str, Any] | str) -> None:
+def _append_unique(
+    table: MutableMapping[str, Any], key: str, value: dict[str, Any] | str | bool
+) -> None:
     if not isinstance(value, str):
         raise ValueError("append_unique requires a string value")
     existing = table.get(key, [])

--- a/python/cheese_flow/models.py
+++ b/python/cheese_flow/models.py
@@ -297,14 +297,14 @@ class ConfigEdit(_Frozen):
     pointer: str
     """Dotted path inside the document, such as permissions.allow."""
 
-    value: dict[str, Any] | str
-    """The object or string to set, or the string to append uniquely."""
+    value: dict[str, Any] | str | bool
+    """The object, flag, or string to set, or the string to append uniquely."""
 
     mode: Literal["set", "append_unique", "toml_set"] = "set"
     """Whether to set a JSON/TOML value or append one JSON string rule."""
 
     @field_serializer("value")
-    def _serialize_value(self, value: dict[str, Any] | str) -> dict[str, Any] | str:
+    def _serialize_value(self, value: dict[str, Any] | str | bool) -> dict[str, Any] | str | bool:
         return _redact_config_value(value) if isinstance(value, dict) else value
 
     @field_validator("target")
@@ -322,7 +322,7 @@ class ConfigEdit(_Frozen):
 
     @model_validator(mode="after")
     def _value_matches_mode(self) -> ConfigEdit:
-        if self.mode == "set" and isinstance(self.value, dict):
+        if self.mode == "set" and isinstance(self.value, dict | bool):
             return self
         if self.mode in ("append_unique", "toml_set") and isinstance(self.value, str):
             return self

--- a/tests/python/test_adapters.py
+++ b/tests/python/test_adapters.py
@@ -112,23 +112,36 @@ def test_hallouminate_plans_versioned_global_npm_install() -> None:
     assert install.depends_on == ()
 
 
-def test_hallouminate_plugin_argv_per_native_harness() -> None:
+def test_hallouminate_declares_claude_registration_in_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No `claude` argv anywhere: the Claude Cloud setup shell has no CLI on
+    # PATH, so registration is declared in user settings and Claude Code
+    # fetches the marketplace itself at session start.
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
     runner = FakeRunner(npm_script())
     steps = steps_by_id(HallouminateAdapter(runner).plan_steps(state()))
 
-    assert steps["hallouminate:marketplace:claude-code"].argv == (
-        "claude",
-        "plugin",
-        "marketplace",
-        "add",
-        "paulnsorensen/hallouminate",
+    marketplace = steps["hallouminate:marketplace:claude-code"]
+    assert marketplace.argv == ()
+    assert marketplace.config_edit == ConfigEdit(
+        target=tmp_path / "claude" / "settings.json",
+        pointer="extraKnownMarketplaces.hallouminate",
+        value={"source": {"source": "github", "repo": "paulnsorensen/hallouminate"}},
     )
-    assert steps["hallouminate:plugin:claude-code"].argv == (
-        "claude",
-        "plugin",
-        "install",
-        "hallouminate@hallouminate",
+    plugin = steps["hallouminate:plugin:claude-code"]
+    assert plugin.argv == ()
+    assert plugin.config_edit == ConfigEdit(
+        target=tmp_path / "claude" / "settings.json",
+        pointer="enabledPlugins.hallouminate@hallouminate",
+        value=True,
     )
+
+
+def test_hallouminate_plugin_argv_for_codex() -> None:
+    runner = FakeRunner(npm_script())
+    steps = steps_by_id(HallouminateAdapter(runner).plan_steps(state()))
+
     assert steps["hallouminate:marketplace:codex"].argv == (
         "codex",
         "plugin",
@@ -296,6 +309,10 @@ def test_hallouminate_registration_depends_on_install_and_plugin_on_marketplace(
 
     assert steps["hallouminate:marketplace:codex"].depends_on == ("hallouminate:npm-install",)
     assert steps["hallouminate:plugin:codex"].depends_on == ("hallouminate:marketplace:codex",)
+    assert steps["hallouminate:marketplace:claude-code"].depends_on == ("hallouminate:npm-install",)
+    assert steps["hallouminate:plugin:claude-code"].depends_on == (
+        "hallouminate:marketplace:claude-code",
+    )
 
 
 def test_hallouminate_emits_independent_steps_per_selected_repository() -> None:
@@ -440,32 +457,6 @@ CODEX_MARKETPLACE_JSON_LOCAL = json.dumps(
         ]
     }
 )
-CLAUDE_MARKETPLACE_JSON = json.dumps(
-    [
-        {
-            "name": "hallouminate",
-            "source": "github",
-            "repo": "paulnsorensen/hallouminate",
-            "installLocation": "/home/paul/.claude/plugins/marketplaces/hallouminate",
-        }
-    ]
-)
-CLAUDE_MARKETPLACE_JSON_DIRECTORY = json.dumps(
-    [
-        {
-            "name": "hallouminate",
-            "source": "directory",
-            "path": "/home/paul/.cache/ap/plugins/hallouminate",
-            "installLocation": "/home/paul/.cache/ap/plugins/hallouminate",
-        },
-        {
-            "name": "claude-plugins-official",
-            "source": "github",
-            "repo": "anthropics/claude-plugins-official",
-            "installLocation": "/home/paul/.claude/plugins/marketplaces/official",
-        },
-    ]
-)
 
 
 def test_hallouminate_marketplace_postcondition_reads_the_native_listing() -> None:
@@ -484,14 +475,37 @@ def test_hallouminate_marketplace_postcondition_reads_the_native_listing() -> No
     assert adapter.check_postcondition(step, garbage) is False
 
 
-def test_hallouminate_marketplace_postcondition_reads_the_claude_listing() -> None:
+def test_hallouminate_claude_registration_postconditions_read_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No child process on either probe: the Claude Cloud setup shell has no
+    # `claude` CLI, so the postcondition is the settings file itself.
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
     adapter = HallouminateAdapter(FakeRunner(npm_script()))
-    step = hallouminate_steps(FakeRunner(npm_script()))["hallouminate:marketplace:claude-code"]
+    steps = hallouminate_steps(FakeRunner(npm_script()))
+    marketplace = steps["hallouminate:marketplace:claude-code"]
+    plugin = steps["hallouminate:plugin:claude-code"]
 
-    list_argv = ("claude", "plugin", "marketplace", "list", "--json")
-    ok = FakeRunner({list_argv: outcome(list_argv, stdout=CLAUDE_MARKETPLACE_JSON)})
-    assert adapter.check_postcondition(step, ok) is True
-    assert ok.argvs() == [list_argv]
+    probe = FakeRunner()
+    assert adapter.check_postcondition(marketplace, probe) is False
+    assert adapter.check_postcondition(plugin, probe) is False
+
+    (tmp_path / "settings.json").write_text(
+        json.dumps(
+            {
+                "extraKnownMarketplaces": {
+                    "hallouminate": {
+                        "source": {"source": "github", "repo": "paulnsorensen/hallouminate"}
+                    }
+                },
+                "enabledPlugins": {"hallouminate@hallouminate": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert adapter.check_postcondition(marketplace, probe) is True
+    assert adapter.check_postcondition(plugin, probe) is True
+    assert probe.argvs() == []
 
 
 def test_hallouminate_marketplace_postcondition_rejects_a_same_named_local_marketplace() -> None:
@@ -504,13 +518,6 @@ def test_hallouminate_marketplace_postcondition_rejects_a_same_named_local_marke
     codex_argv = ("codex", "plugin", "marketplace", "list", "--json")
     codex = FakeRunner({codex_argv: outcome(codex_argv, stdout=CODEX_MARKETPLACE_JSON_LOCAL)})
     assert adapter.check_postcondition(steps["hallouminate:marketplace:codex"], codex) is False
-
-    claude_argv = ("claude", "plugin", "marketplace", "list", "--json")
-    claude = FakeRunner(
-        {claude_argv: outcome(claude_argv, stdout=CLAUDE_MARKETPLACE_JSON_DIRECTORY)}
-    )
-    step = steps["hallouminate:marketplace:claude-code"]
-    assert adapter.check_postcondition(step, claude) is False
 
 
 def test_hallouminate_marketplace_postcondition_names_the_json_listing() -> None:
@@ -528,32 +535,6 @@ def test_owner_repo_normalizes_scp_https_and_git_suffix_forms() -> None:
     assert _owner_repo("https://github.com/owner/repo") == "owner/repo"
 
 
-# Verbatim `claude plugin list --json` rows. Every plugin on a real machine
-# reports `enabled: false`, so the check reads `scope` and never `enabled`.
-CLAUDE_PLUGIN_LIST_JSON = json.dumps(
-    [
-        {
-            "id": "hallouminate@hallouminate",
-            "version": "0.3.2",
-            "scope": "user",
-            "enabled": False,
-            "installPath": "/home/paul/.claude/plugins/cache/hallouminate/hallouminate/0.3.2",
-        }
-    ]
-)
-# `claude plugin list` reports OTHER projects' project-scoped plugins globally.
-CLAUDE_PLUGIN_LIST_JSON_FOREIGN_PROJECT = json.dumps(
-    [
-        {
-            "id": "hallouminate@hallouminate",
-            "version": "ad8a4253ce7d",
-            "scope": "project",
-            "enabled": False,
-            "installPath": "/home/paul/.claude/plugins/cache/hallouminate/hallouminate/ad8a",
-            "projectPath": "/home/paul/Dev/easy-cheese/.worktrees/dogfood",
-        }
-    ]
-)
 CODEX_PLUGIN_LIST_JSON = json.dumps(
     {
         "installed": [
@@ -587,49 +568,6 @@ CODEX_PLUGIN_LIST_PLAIN = (
     "agent-sdk-dev@claude-code-plugins  not installed\n"
     "hallouminate@hallouminate          not installed\n"
 )
-
-
-def test_hallouminate_plugin_postcondition_requires_the_plugin_id() -> None:
-    adapter = HallouminateAdapter(FakeRunner(npm_script()))
-    step = hallouminate_steps(FakeRunner(npm_script()))["hallouminate:plugin:claude-code"]
-
-    # `claude plugin list --json` returns a flat list keyed `id`.
-    list_argv = ("claude", "plugin", "list", "--json")
-    ok = FakeRunner({list_argv: outcome(list_argv, stdout=CLAUDE_PLUGIN_LIST_JSON)})
-    assert adapter.check_postcondition(step, ok) is True
-    assert ok.argvs() == [list_argv]
-
-    # `claude plugin list` exits 0 with nothing installed.
-    empty = FakeRunner({list_argv: outcome(list_argv, stdout="[]")})
-    assert adapter.check_postcondition(step, empty) is False
-
-    garbage = FakeRunner({list_argv: outcome(list_argv, stdout="not json")})
-    assert adapter.check_postcondition(step, garbage) is False
-
-
-def test_hallouminate_plugin_postcondition_rejects_another_projects_plugin() -> None:
-    # H-A1: `claude plugin list` reports project-scoped plugins belonging to
-    # unrelated checkouts. A user-scope registration is not satisfied by one.
-    adapter = HallouminateAdapter(FakeRunner(npm_script()))
-    step = hallouminate_steps(FakeRunner(npm_script()))["hallouminate:plugin:claude-code"]
-
-    list_argv = ("claude", "plugin", "list", "--json")
-    foreign = FakeRunner(
-        {list_argv: outcome(list_argv, stdout=CLAUDE_PLUGIN_LIST_JSON_FOREIGN_PROJECT)}
-    )
-    assert adapter.check_postcondition(step, foreign) is False
-
-
-def test_hallouminate_plugin_postcondition_ignores_the_enabled_flag() -> None:
-    # Every plugin claude reports carries `enabled: false`, including active
-    # ones, so the flag must never veto an otherwise user-scoped registration.
-    adapter = HallouminateAdapter(FakeRunner(npm_script()))
-    step = hallouminate_steps(FakeRunner(npm_script()))["hallouminate:plugin:claude-code"]
-
-    list_argv = ("claude", "plugin", "list", "--json")
-    document = json.dumps([{"id": "hallouminate@hallouminate", "scope": "user", "enabled": False}])
-    runner = FakeRunner({list_argv: outcome(list_argv, stdout=document)})
-    assert adapter.check_postcondition(step, runner) is True
 
 
 def test_hallouminate_plugin_postcondition_reads_the_codex_installed_section() -> None:

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -975,7 +975,7 @@ def test_default_runner_bounds_a_stalled_git_clone_for_every_child(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """bootstrap.sh only bounds the uvx clone it execs; every child the runner
-    itself spawns (``npx skills add``, ``claude plugin marketplace add``, and
+    itself spawns (``npx skills add``, ``codex plugin marketplace add``, and
     the checkout / uvx entry points bootstrap.sh cannot reach) must inherit the
     same stall guard."""
     monkeypatch.delenv("GIT_HTTP_LOW_SPEED_LIMIT", raising=False)

--- a/tests/python/test_doctor.py
+++ b/tests/python/test_doctor.py
@@ -116,21 +116,11 @@ def _readonly_script(version: str) -> dict[tuple[str, ...], CommandOutcome]:
     def ok(argv: tuple[str, ...], stdout: str) -> CommandOutcome:
         return CommandOutcome(argv=argv, exit_code=0, stdout=stdout, stderr="", elapsed_ms=1)
 
-    marketplaces = json.dumps(
-        [{"name": "hallouminate", "source": "github", "repo": "paulnsorensen/hallouminate"}]
-    )
     return {
         ("npm", "view", "hallouminate@latest", "version"): ok(
             ("npm", "view", "hallouminate@latest", "version"), version
         ),
         ("hallouminate", "--version"): ok(("hallouminate", "--version"), f"hallouminate {version}"),
-        ("claude", "plugin", "marketplace", "list", "--json"): ok(
-            ("claude", "plugin", "marketplace", "list", "--json"), marketplaces
-        ),
-        ("claude", "plugin", "list", "--json"): ok(
-            ("claude", "plugin", "list", "--json"),
-            json.dumps([{"id": "hallouminate@hallouminate", "scope": "user", "enabled": True}]),
-        ),
         ("hallouminate", "config", "validate"): ok(("hallouminate", "config", "validate"), "ok"),
     }
 
@@ -170,7 +160,17 @@ def test_doctor_with_real_adapters_runs_only_read_only_commands(
     claude_settings = tmp_path / ".claude" / "settings.json"
     claude_settings.parent.mkdir(exist_ok=True)
     claude_settings.write_text(
-        json.dumps({"permissions": {"allow": ["mcp__plugin_hallouminate_hallouminate__*"]}}),
+        json.dumps(
+            {
+                "permissions": {"allow": ["mcp__plugin_hallouminate_hallouminate__*"]},
+                "extraKnownMarketplaces": {
+                    "hallouminate": {
+                        "source": {"source": "github", "repo": "paulnsorensen/hallouminate"}
+                    }
+                },
+                "enabledPlugins": {"hallouminate@hallouminate": True},
+            }
+        ),
         encoding="utf-8",
     )
     cursor_cli_config = tmp_path / ".cursor/cli-config.json"
@@ -190,8 +190,6 @@ def test_doctor_with_real_adapters_runs_only_read_only_commands(
     assert runner.argvs() == [
         ("npm", "view", "hallouminate@latest", "version"),
         ("hallouminate", "--version"),
-        ("claude", "plugin", "marketplace", "list", "--json"),
-        ("claude", "plugin", "list", "--json"),
         ("hallouminate", "config", "validate"),
     ]
     assert {path: path.read_bytes() for path in before} == before

--- a/tests/python/test_integration.py
+++ b/tests/python/test_integration.py
@@ -53,11 +53,6 @@ PLUGIN_ID = "hallouminate@hallouminate"
 DECOY_MARKETPLACE = MARKETPLACE_NAME
 DECOY_MARKETPLACE_ROOT = "/home/paul/Dev/paulnsorensen/hallouminate"
 
-# A plugin another project installed at project scope. Claude reports foreign
-# project-scoped plugins in its global listing, so the same id is present
-# without this user ever having installed it.
-FOREIGN_PROJECT_PLUGIN = PLUGIN_ID
-
 # What `skills add <repo> --skill '*' --global` puts on disk. Spelled out
 # rather than imported: dropping one of these must fail the postcondition, not
 # follow it.
@@ -159,6 +154,10 @@ class FakeWorld:
             document.setdefault("permissions", {}).setdefault("allow", []).extend(
                 ["mcp__plugin_hallouminate_hallouminate__*", "mcp__tilth__*"]
             )
+            document["extraKnownMarketplaces"] = {
+                MARKETPLACE_NAME: {"source": {"source": "github", "repo": MARKETPLACE_SOURCE}}
+            }
+            document["enabledPlugins"] = {PLUGIN_ID: True}
             settings.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
         if "codex" in harnesses:
             config = self.home / CODEX_MCP_CONFIG
@@ -232,12 +231,12 @@ class FakeWorld:
             self.marketplaces.add(MARKETPLACE_SOURCE)
             return _ok(key)
         if key[1:] == ("plugin", "marketplace", "list", "--json"):
-            return _ok(key, self._marketplace_listing(key[0]))
+            return _ok(key, self._marketplace_listing())
         if len(key) == 4 and key[1] == "plugin" and key[2] in ("install", "add"):
             self.plugins.add(key[3])
             return _ok(key)
         if key[1:] == ("plugin", "list", "--json"):
-            return _ok(key, self._plugin_listing(key[0]))
+            return _ok(key, self._plugin_listing())
         if key[:3] == ("hallouminate", "config", "init"):
             if "hallouminate-config" in self._refuse:
                 return _fail(key, "config init refused")
@@ -284,70 +283,50 @@ class FakeWorld:
             return _ok(key)
         raise AssertionError(f"the fake world was asked to run an unmodelled command: {key}")
 
-    def _marketplace_listing(self, executable: str) -> str:
-        """What `<exe> plugin marketplace list --json` prints.
+    def _marketplace_listing(self) -> str:
+        """What `codex plugin marketplace list --json` prints.
 
         Codex answers ``{"marketplaces": [...]}`` with a nested
-        ``marketplaceSource``; Claude answers a flat list keyed
-        ``source``/``repo``. Both always carry the same-named local decoy, which
-        only the remote/local distinction keeps from satisfying the step.
+        ``marketplaceSource``, and always carries the same-named local decoy,
+        which only the remote/local distinction keeps from satisfying the step.
         """
-        added = sorted(self.marketplaces)
-        if executable == "codex":
-            entries: list[dict[str, object]] = [
-                {
-                    "name": DECOY_MARKETPLACE,
-                    "marketplaceSource": {
-                        "sourceType": "local",
-                        "source": DECOY_MARKETPLACE_ROOT,
-                    },
-                }
-            ]
-            entries += [
-                {
-                    "name": MARKETPLACE_NAME,
-                    "marketplaceSource": {
-                        "sourceType": "git",
-                        "source": f"https://github.com/{source}.git",
-                    },
-                }
-                for source in added
-            ]
-            return json.dumps({"marketplaces": entries})
-        flat: list[dict[str, object]] = [
-            {"name": DECOY_MARKETPLACE, "source": "directory", "path": DECOY_MARKETPLACE_ROOT}
+        entries: list[dict[str, object]] = [
+            {
+                "name": DECOY_MARKETPLACE,
+                "marketplaceSource": {
+                    "sourceType": "local",
+                    "source": DECOY_MARKETPLACE_ROOT,
+                },
+            }
         ]
-        flat += [{"name": MARKETPLACE_NAME, "source": "github", "repo": source} for source in added]
-        return json.dumps(flat)
+        entries += [
+            {
+                "name": MARKETPLACE_NAME,
+                "marketplaceSource": {
+                    "sourceType": "git",
+                    "source": f"https://github.com/{source}.git",
+                },
+            }
+            for source in sorted(self.marketplaces)
+        ]
+        return json.dumps({"marketplaces": entries})
 
-    def _plugin_listing(self, executable: str) -> str:
-        """What `<exe> plugin list --json` prints.
+    def _plugin_listing(self) -> str:
+        """What `codex plugin list --json` prints.
 
         Codex lists what its marketplaces merely offer alongside what is
         installed, so an offered-but-uninstalled plugin appears with
         ``installed`` false — the exact row that must not satisfy the
-        postcondition. Claude lists only installed plugins, but reports OTHER
-        projects' project-scoped ones in the same global listing, so the same
-        id is always present at ``scope: "project"``. Claude also reports
-        ``enabled: false`` for plugins that are in fact active, so the fake
-        never ties that flag to installation.
+        postcondition.
         """
-        if executable == "codex":
-            offered = sorted({PLUGIN_ID} - self.plugins) if self.marketplaces else []
-            document = {
-                "installed": [
-                    {"pluginId": plugin, "installed": True} for plugin in sorted(self.plugins)
-                ],
-                "available": [{"pluginId": plugin, "installed": False} for plugin in offered],
-            }
-            return json.dumps(document)
-        entries: list[dict[str, object]] = [
-            {"id": FOREIGN_PROJECT_PLUGIN, "scope": "project", "enabled": True}
-        ]
-        entries += [
-            {"id": plugin, "scope": "user", "enabled": False} for plugin in sorted(self.plugins)
-        ]
-        return json.dumps(entries)
+        offered = sorted({PLUGIN_ID} - self.plugins) if self.marketplaces else []
+        document = {
+            "installed": [
+                {"pluginId": plugin, "installed": True} for plugin in sorted(self.plugins)
+            ],
+            "available": [{"pluginId": plugin, "installed": False} for plugin in offered],
+        }
+        return json.dumps(document)
 
     def _validate(self, key: tuple[str, ...], cwd: Path | None) -> CommandOutcome:
         if cwd is None:
@@ -661,13 +640,13 @@ def read_only_probes(home: Path) -> list[tuple[str, ...]]:
 
     easy-cheese contributes none: its postcondition reads the installed files
     directly, so a converged host needs no child process to prove the pack is
-    there — and a host with no GitHub CLI reaches the same verdict.
+    there — and a host with no GitHub CLI reaches the same verdict. Claude
+    Code registration contributes none either: it is declared in settings, so
+    a host with no `claude` CLI reaches the same verdict too.
     """
     return [
         ("npm", "view", "hallouminate@latest", "version"),
         ("hallouminate", "--version"),
-        ("claude", "plugin", "marketplace", "list", "--json"),
-        ("claude", "plugin", "list", "--json"),
         ("codex", "plugin", "marketplace", "list", "--json"),
         ("codex", "plugin", "list", "--json"),
         ("hallouminate", "config", "validate"),
@@ -832,13 +811,11 @@ def test_interrupt_forwards_the_signal_and_reports_the_remaining_steps(
 ) -> None:
     world = wire(
         monkeypatch,
-        FakeWorld(
-            home, interrupt_on=("claude", "plugin", "marketplace", "add", MARKETPLACE_SOURCE)
-        ),
+        FakeWorld(home, interrupt_on=("codex", "plugin", "marketplace", "add", MARKETPLACE_SOURCE)),
     )
     manifest = write_manifest(
         tmp_path,
-        manifest_text(harnesses=["claude-code"], components=["hallouminate", "easy-cheese"]),
+        manifest_text(harnesses=["codex"], components=["hallouminate", "easy-cheese"]),
     )
     before = signal.getsignal(signal.SIGINT)
 
@@ -850,13 +827,13 @@ def test_interrupt_forwards_the_signal_and_reports_the_remaining_steps(
     assert world.forwarded == [signal.SIGINT]
     assert statuses(document) == [
         ("hallouminate:npm-install", "succeeded"),
-        ("hallouminate:marketplace:claude-code", "succeeded"),
-        ("hallouminate:plugin:claude-code", "interrupted"),
-        ("hallouminate:permission:claude-code", "interrupted"),
+        ("hallouminate:marketplace:codex", "succeeded"),
+        ("hallouminate:plugin:codex", "interrupted"),
+        ("hallouminate:permission:codex", "interrupted"),
         ("hallouminate:config-init", "interrupted"),
-        ("easy-cheese:install:claude-code", "interrupted"),
+        ("easy-cheese:install:codex", "interrupted"),
     ]
-    assert ("claude", "plugin", "install", PLUGIN_ID) not in world.argvs()
+    assert ("codex", "plugin", "add", PLUGIN_ID) not in world.argvs()
     assert signal.getsignal(signal.SIGINT) is before
 
 
@@ -933,6 +910,33 @@ class GhlessWorld(FakeWorld):
                 elapsed_ms=1,
             )
         return super()._dispatch(key, cwd)
+
+
+def test_install_converges_claude_code_without_the_claude_cli(
+    tmp_path: Path, home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cloud regression: a Claude Cloud setup script runs with no `claude`
+    on PATH, so registration never shells out to it — it is declared in user
+    settings instead, and every step still converges."""
+    world = wire(monkeypatch, FakeWorld(home))
+    manifest = write_manifest(
+        tmp_path,
+        manifest_text(
+            harnesses=["claude-code"], components=["hallouminate", "easy-cheese", "tilth"]
+        ),
+    )
+
+    result = cli_runner.invoke(app, ["install", "--config", str(manifest)])
+
+    assert result.exit_code == 0, result.stderr
+    document = json.loads(result.stdout)
+    assert document["status"] == "succeeded"
+    assert not any(argv[0] == "claude" for argv in world.argvs())
+    settings = json.loads((home / ".claude/settings.json").read_text(encoding="utf-8"))
+    assert settings["extraKnownMarketplaces"][MARKETPLACE_NAME] == {
+        "source": {"source": "github", "repo": MARKETPLACE_SOURCE}
+    }
+    assert settings["enabledPlugins"] == {PLUGIN_ID: True}
 
 
 def test_install_converges_every_easy_cheese_step_with_gh_absent(


### PR DESCRIPTION
## Problem

A Claude Cloud environment setup script runs `cheese install` (via `bootstrap.sh`) before Claude Code launches, as root, with no `claude` binary on PATH — and behind a GitHub proxy that refuses clones of repositories not attached to the session. The hallouminate registration steps shelled out to `claude plugin marketplace add` / `claude plugin install`, so every cloud install failed:

- `hallouminate:marketplace:claude-code` — **failed** (exit 127, `could not run claude`)
- `hallouminate:plugin:claude-code`, `hallouminate:permission:claude-code` — **blocked**
- every other component converged, and the run exited 1

Reproduced locally by removing `claude` from PATH; the report tail matches the cloud failure byte-for-byte.

## Fix

**Semantics-altering.** Claude Code registration is now two declarative config edits into user settings instead of CLI invocations:

- `extraKnownMarketplaces.hallouminate` → `{"source": {"source": "github", "repo": "paulnsorensen/hallouminate"}}`
- `enabledPlugins."hallouminate@hallouminate"` → `true`

Claude Code reads these at session start and fetches the marketplace itself (schema per code.claude.com/docs/en/plugin-marketplaces). Postconditions read the settings file, so a host with no `claude` CLI verifies identically — the same pattern the permission step and the tilth adapter already use.

Supporting changes:

- `ConfigEdit.value` accepts `bool` in `set` mode (for the `enabledPlugins` flag).
- Codex keeps its CLI path; the claude-flavored branches of the marketplace/plugin listing parsers became unreachable and were removed.

## What the reviewer should verify

- The settings keys and shapes match what Claude Code actually reads (`extraKnownMarketplaces`, `enabledPlugins`) — a typo here fails silently at session start, not at install time.
- The claude-code plan keeps the same step ids and dependency order, so JSON report consumers see the same shape.
- The removed claude listing parsers have no remaining callers.
- Known residual: whether Claude Code's session-start fetch of an unattached repo passes the cloud GitHub proxy is unverified empirically; the docs bless the settings-declared path.

## Verification

- `just build` / `just build-ci`: 924 tests pass, ruff clean.
- New regression test: a claude-code install converges without ever spawning `claude` and leaves both settings entries on disk.
- End-to-end: `cheese install --harness claude-code --json` with `claude` absent from PATH and an isolated HOME exits 0 with all nine steps green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
