### PR TITLE
docs(wiki-harvest): curate cheese-flow wiki

### DIFF
--- a/.hallouminate/wiki/gotchas/claude-plugin-registration-via-settings.md
+++ b/.hallouminate/wiki/gotchas/claude-plugin-registration-via-settings.md
@@ -1,0 +1,39 @@
+# Claude plugin registration goes through settings.json, never the `claude` CLI
+
+Hallouminate's Claude Code registration is declared as two `ConfigEdit`s against
+`settings.json` (`extraKnownMarketplaces.hallouminate` and
+`enabledPlugins.hallouminate@hallouminate`), not shelled out to `claude plugin
+marketplace add` / `claude plugin install` the way Codex's registration is.[^1]
+
+## Why: the headless target has no `claude` on PATH and a locked-down proxy
+
+The installer must converge on a Claude Cloud setup script, which runs with no
+`claude` executable on PATH and sits behind a GitHub proxy that refuses to clone
+any repository not already attached to the session. A CLI-driven install cannot
+complete there. Declaring the marketplace and plugin entries directly in
+`settings.json` instead defers the actual catalog fetch to Claude Code's own
+session start, which the cloud environment permits — and the same declarative
+edit converges identically on a developer machine, so there is no
+environment-specific branch in the adapter.
+
+This is why `PLUGIN_CLIS` in `python/cheese_flow/adapters/hallouminate.py`
+deliberately omits `"claude-code"`: Codex still goes through its native CLI
+(`codex plugin add`), but Claude Code is handled entirely by
+`_claude_registration_steps`, which writes both edits under `Phase.REGISTER`
+with the plugin edit depending on the marketplace edit.
+
+## Postcondition follows the edit, not a CLI query
+
+Because there is no CLI call to inspect, the postcondition for both steps is
+`config_edit_holds(step.config_edit)` — it reads `settings.json` back and
+checks the declared pointer/value, the same primitive `claude-mcp-permissions`
+describes for MCP permission rules. `_check_marketplace` / `_check_plugin`
+(the `claude plugin ... --json` parsing path) only run for harnesses that still
+register through a CLI.
+
+## Related
+
+- [Claude MCP permissions](./claude-mcp-permissions.md) — same `settings.json` edit/read machinery, applied to permission rules instead of plugin registration.
+- [V1 installer boundary](../architecture/v1-installer-boundary.md) — Hallouminate setup delegates to its own binary/plugin/config surface; this page is the concrete mechanism for the Claude Code leg of that delegation.
+
+[^1]: `python/cheese_flow/adapters/hallouminate.py:26-40` (constants and `PLUGIN_CLIS` comment), `:129-131` (dispatch), `:315-352` (`_claude_registration_steps`), `:278-283` (`_check_marketplace`/`_check_plugin` CLI-only fallback). Introduced by commit `8b56923` ("fix(hallouminate): declare Claude Code plugin registration in settings, not via the claude CLI (#101)").

--- a/.hallouminate/wiki/gotchas/index.md
+++ b/.hallouminate/wiki/gotchas/index.md
@@ -2,6 +2,7 @@
 
 <!-- HALLOUMINATE:INDEX-START -->
 - [claude-mcp-permissions](./claude-mcp-permissions.md) — Claude MCP permissions
+- [claude-plugin-registration-via-settings](./claude-plugin-registration-via-settings.md) — Claude plugin registration goes through settings.json, never the `claude` CLI
 - [gh-skill-provenance](./gh-skill-provenance.md) — gh skill provenance
 - [git-has-no-read-timeout](./git-has-no-read-timeout.md) — Git has no read timeout — the install tree bounds it via GIT_HTTP_LOW_SPEED_*
 - [pydantic-lax-coercion-at-the-manifest-boundary](./pydantic-lax-coercion-at-the-manifest-boundary.md) — Pydantic lax coercion at the manifest boundary

--- a/.hallouminate/wiki/log.md
+++ b/.hallouminate/wiki/log.md
@@ -3,3 +3,4 @@
 ## Log
 
 2026-08-02 · 49c3e71a79cff4ae · merged · gotchas/tilth-installs-from-nightly-release.md · Recorded the absolute-command convergence invariant found and cured by /affinage PR #95.
+2026-08-16 · wiki-harvest · pending · gotchas/claude-plugin-registration-via-settings.md · Recorded why PR #101 moved Claude Code plugin registration from the `claude` CLI to declarative `settings.json` edits (headless Claude Cloud host has no `claude` on PATH and a proxy that refuses unattached repo clones).


### PR DESCRIPTION
## Wiki changes

- **New:** `.hallouminate/wiki/gotchas/claude-plugin-registration-via-settings.md` — records why PR #101 (`8b56923`) moved Claude Code's Hallouminate marketplace/plugin registration from the `claude` CLI to declarative `settings.json` edits (`extraKnownMarketplaces` / `enabledPlugins`): the headless Claude Cloud setup-script host has no `claude` on PATH and sits behind a GitHub proxy that refuses to clone repositories not attached to the session. Verified against `python/cheese_flow/adapters/hallouminate.py` (`PLUGIN_CLIS`, `_claude_registration_steps`, `_check_marketplace`/`_check_plugin`) as it stands on `main`. Links to the existing `claude-mcp-permissions` gotcha (same settings.json edit/read primitive, different pointer) and `architecture/v1-installer-boundary` (Hallouminate delegation).
- **Updated:** `.hallouminate/wiki/gotchas/index.md` — added the new page's index entry.
- **Updated:** `.hallouminate/wiki/log.md` — appended an ingest-log line for this harvest.

No `hallouminate index` was run (no hallouminate MCP available in this environment) — retrieval refresh is pending.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4fuVXehTHMyHM48u9c4oa)_