### PR TITLE
feat(milknado): add optional Claude Code plugin component

### DIFF
--- a/.hallouminate/wiki/architecture/v1-installer-boundary.md
+++ b/.hallouminate/wiki/architecture/v1-installer-boundary.md
@@ -31,6 +31,18 @@ Tilth is optional in v1 and unselected by default. The TUI may recommend it, but
 
 Milknado is post-v1 because its runtime is not ready for this installer contract. V1 removes the existing Milknado dependency, commands, demo, and cheese-flow MCP path rather than retaining unused integration code.[^4]
 
+
+
+**Update (2026-08-16) — partially reintroduced as an optional component.** The deferral above is superseded for the registration surface: milknado now ships as an optional component (`adapters/milknado.py`, added to `COMPONENT_NAMES`, not `REQUIRED_COMPONENTS`). It contributes **no install step** — the plugin's `.mcp.json` self-fetches the server via `uvx --from git+https://github.com/paulnsorensen/milknado@main milknado-mcp` at session start — so cheese-flow only declares three Claude Code registration edits in `~/.claude/settings.json`, mirroring `hallouminate._claude_registration_steps`:
+
+- `extraKnownMarketplaces.milknado` → `{source: {github, paulnsorensen/milknado}}`
+- `enabledPlugins."milknado@milknado"` → `true`
+- `permissions.allow` ← `mcp__plugin_milknado_milknado__*`
+
+Driver: the Claude Cloud routine already installs hallouminate + easy-cheese via `bootstrap.sh --harness claude-code --json`; adding milknado to `COMPONENT_NAMES` makes that unchanged headless line register it too.
+
+Scope of this cut (deliberate): **Claude Code only** — `plan_steps` returns `()` for a state without `claude-code`. Bleeding-edge `@main` git source (not a PyPI pin), so the MCP server does a GitHub clone at session start; walk back to a released tag / PyPI `.mcp.json` (`uvx --from milknado==<version>`) if the cloud GitHub proxy refuses that runtime clone. Codex/Cursor registration deferred; adding them should extract the shared plugin-CLI/cursor helpers out of `hallouminate.py` rather than duplicate them. The v1 removal guards still hold — no milknado CLI command, dependency, entry-point, or unified-MCP module was reintroduced.
+
 ## Multi-repository safety model
 
 1. Never scan the whole home directory automatically.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > _"The cheese must flow."_
 
-A composition installer for the cheese ecosystem: it installs and verifies `hallouminate`, `easy-cheese`, and `tilth` across Claude Code, Codex, and Cursor, driven by a single declarative TOML manifest. Aged in Python, served on Sliced Bread. 🧀
+A composition installer for the cheese ecosystem: it installs and verifies `hallouminate`, `easy-cheese`, `tilth`, and `milknado` across Claude Code, Codex, and Cursor, driven by a single declarative TOML manifest. Aged in Python, served on Sliced Bread. 🧀
 
 ## Why Cheese? Two reasons:
 
@@ -19,7 +19,7 @@ A composition installer for the cheese ecosystem: it installs and verifies `hall
 ## Repository layout
 
 - `python/cheese_flow/` — the `cheese` CLI, profile engine, desired-state manifest handling, install planner, doctor, and the interactive wizard TUI
-- `python/cheese_flow/adapters/` — one adapter per component (`hallouminate`, `easy-cheese`, `tilth`)
+- `python/cheese_flow/adapters/` — one adapter per component (`hallouminate`, `easy-cheese`, `tilth`, `milknado`)
 - `tests/python/` — pytest suite
 - `agents/`, `skills/`, `commands/` — this repo's own agent-authoring assets (prompts, skills, slash commands), used to develop cheese-flow itself
 - `references/` — long-form architectural references (Sliced Bread, etc.)
@@ -157,7 +157,7 @@ selected = ["/home/you/Dev/some-repo"]
 ```
 
 - **Harnesses:** `claude-code`, `codex`, `cursor`
-- **Components:** `hallouminate`, `easy-cheese`, `tilth` — `hallouminate` and `easy-cheese` are required in every manifest; `tilth` is optional
+- **Components:** `hallouminate`, `easy-cheese`, `tilth`, `milknado` — `hallouminate` and `easy-cheese` are required in every manifest; `tilth` and `milknado` are optional. `milknado` currently registers only on Claude Code.
 - **Repositories:** `search_roots` are where repository discovery looks, `max_depth` bounds how deep it searches, and `selected` must each sit under one of the search roots
 
 ## Quality gates

--- a/python/cheese_flow/adapters/__init__.py
+++ b/python/cheese_flow/adapters/__init__.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from cheese_flow.adapters.easy_cheese import EasyCheeseAdapter
 from cheese_flow.adapters.hallouminate import HallouminateAdapter
+from cheese_flow.adapters.milknado import MilknadoAdapter
 from cheese_flow.adapters.tilth import TilthAdapter
 from cheese_flow.models import CommandRunner, ComponentAdapters
 
 __all__ = [
     "EasyCheeseAdapter",
     "HallouminateAdapter",
+    "MilknadoAdapter",
     "TilthAdapter",
     "default_component_adapters",
 ]
@@ -17,5 +19,10 @@ __all__ = [
 
 def default_component_adapters(runner: CommandRunner) -> ComponentAdapters:
     """Build the adapter for every supported component, keyed by component name."""
-    adapters = (HallouminateAdapter(runner), EasyCheeseAdapter(runner), TilthAdapter(runner))
+    adapters = (
+        HallouminateAdapter(runner),
+        EasyCheeseAdapter(runner),
+        TilthAdapter(runner),
+        MilknadoAdapter(runner),
+    )
     return {adapter.name: adapter for adapter in adapters}

--- a/python/cheese_flow/adapters/milknado.py
+++ b/python/cheese_flow/adapters/milknado.py
@@ -1,0 +1,112 @@
+"""Milknado adapter: Claude Code plugin registration only.
+
+Milknado's plugin ``.mcp.json`` launches its server with
+``uvx --from git+...@main milknado-mcp``, so cheese-flow installs nothing —
+the first launch self-fetches from the bleeding-edge default branch, which is
+intentional for this cut. Codex and Cursor are deferred entirely: adding them
+later should extract the shared plugin-CLI/cursor helpers from
+hallouminate.py rather than duplicate them here.
+"""
+
+from __future__ import annotations
+
+from cheese_flow.adapters.native_config import (
+    claude_config_dir,
+    config_edit_holds,
+    mcp_permission_edit,
+)
+from cheese_flow.models import (
+    CommandRunner,
+    ComponentName,
+    ConfigEdit,
+    DesiredState,
+    Phase,
+    PlanStep,
+)
+
+PACKAGE = "milknado"
+MARKETPLACE_SOURCE = "paulnsorensen/milknado"
+MARKETPLACE_NAME = "milknado"
+PLUGIN_ID = "milknado@milknado"
+CLAUDE_SERVER = "plugin_milknado_milknado"
+"""Matches the live tool namespace ``mcp__plugin_milknado_milknado__*``."""
+
+CLAUDE_MARKETPLACE_ENTRY: dict[str, object] = {
+    "source": {"source": "github", "repo": MARKETPLACE_SOURCE}
+}
+"""The ``extraKnownMarketplaces`` entry Claude Code fetches the catalog from at startup."""
+
+_MARKETPLACE_STEP = "milknado:marketplace:claude-code"
+_PLUGIN_STEP = "milknado:plugin:claude-code"
+_PERMISSION_STEP = "milknado:permission:claude-code"
+
+
+class MilknadoAdapter:
+    """Declares Milknado's Claude Code plugin registration in user settings.
+
+    Mirrors Hallouminate's ``_claude_registration_steps``: Claude Code reads
+    ``extraKnownMarketplaces`` and ``enabledPlugins`` from user settings at
+    startup and fetches the marketplace itself, so declaring the entries
+    converges on a headless host with no ``claude`` on PATH.
+    """
+
+    name: ComponentName = "milknado"
+
+    def __init__(self, runner: CommandRunner) -> None:
+        self._runner = runner
+
+    def plan_steps(self, state: DesiredState) -> tuple[PlanStep, ...]:
+        """Emit Claude Code registration steps only; other harnesses are deferred."""
+        if self.name not in state.components:
+            return ()
+        if "claude-code" not in state.harnesses:
+            return ()
+
+        settings = claude_config_dir() / "settings.json"
+        marketplace = ConfigEdit(
+            target=settings,
+            pointer=f"extraKnownMarketplaces.{MARKETPLACE_NAME}",
+            value=CLAUDE_MARKETPLACE_ENTRY,
+        )
+        plugin = ConfigEdit(target=settings, pointer=f"enabledPlugins.{PLUGIN_ID}", value=True)
+        permission = mcp_permission_edit("claude-code", PACKAGE, claude_server=CLAUDE_SERVER)
+        return (
+            PlanStep(
+                step_id=_MARKETPLACE_STEP,
+                component=self.name,
+                harness="claude-code",
+                phase=Phase.REGISTER,
+                config_edit=marketplace,
+                postcondition=(
+                    f"{settings} declares the {MARKETPLACE_SOURCE} marketplace at "
+                    f"{marketplace.pointer}"
+                ),
+                depends_on=(),
+            ),
+            PlanStep(
+                step_id=_PLUGIN_STEP,
+                component=self.name,
+                harness="claude-code",
+                phase=Phase.REGISTER,
+                config_edit=plugin,
+                postcondition=f"{settings} enables {PLUGIN_ID} at {plugin.pointer}",
+                depends_on=(_MARKETPLACE_STEP,),
+            ),
+            PlanStep(
+                step_id=_PERMISSION_STEP,
+                component=self.name,
+                harness="claude-code",
+                phase=Phase.REGISTER,
+                config_edit=permission,
+                postcondition=(
+                    f"{permission.target} configures {permission.pointer} as {permission.value!r}"
+                ),
+                depends_on=(_PLUGIN_STEP,),
+            ),
+        )
+
+    def check_postcondition(self, step: PlanStep, runner: CommandRunner) -> bool:
+        """Every step's postcondition is the settings file itself."""
+        if step.step_id in (_MARKETPLACE_STEP, _PLUGIN_STEP, _PERMISSION_STEP):
+            return step.config_edit is not None and config_edit_holds(step.config_edit)
+        raise ValueError(f"{step.step_id!r} is not a milknado step")

--- a/python/cheese_flow/models.py
+++ b/python/cheese_flow/models.py
@@ -29,10 +29,10 @@ HarnessName = Literal["claude-code", "codex", "cursor"]
 
 HARNESS_NAMES: tuple[HarnessName, ...] = ("claude-code", "codex", "cursor")
 
-ComponentName = Literal["hallouminate", "easy-cheese", "tilth"]
+ComponentName = Literal["hallouminate", "easy-cheese", "tilth", "milknado"]
 """Cheese ecosystem components cheese-flow can install."""
 
-COMPONENT_NAMES: tuple[ComponentName, ...] = ("hallouminate", "easy-cheese", "tilth")
+COMPONENT_NAMES: tuple[ComponentName, ...] = ("hallouminate", "easy-cheese", "tilth", "milknado")
 
 REQUIRED_COMPONENTS: tuple[ComponentName, ...] = ("hallouminate", "easy-cheese")
 """Components every valid desired state must select. Tilth is optional."""

--- a/tests/python/test_adapters.py
+++ b/tests/python/test_adapters.py
@@ -18,6 +18,7 @@ import pytest
 from cheese_flow.adapters import (
     EasyCheeseAdapter,
     HallouminateAdapter,
+    MilknadoAdapter,
     TilthAdapter,
     default_component_adapters,
     easy_cheese,
@@ -1614,6 +1615,112 @@ def test_step_result_reports_a_config_edit_step_with_an_empty_argv() -> None:
 
 
 # --------------------------------------------------------------------------
+# Milknado
+# --------------------------------------------------------------------------
+
+
+def milknado_steps(
+    *,
+    components: tuple[str, ...] = ("hallouminate", "easy-cheese", "milknado"),
+    harnesses: tuple[str, ...] = ("claude-code",),
+) -> dict[str, PlanStep]:
+    adapter = MilknadoAdapter(FakeRunner())
+    return steps_by_id(adapter.plan_steps(state(components=components, harnesses=harnesses)))
+
+
+def test_milknado_declares_claude_registration_in_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+    steps = milknado_steps()
+
+    marketplace = steps["milknado:marketplace:claude-code"]
+    assert marketplace.argv == ()
+    assert marketplace.config_edit == ConfigEdit(
+        target=tmp_path / "claude" / "settings.json",
+        pointer="extraKnownMarketplaces.milknado",
+        value={"source": {"source": "github", "repo": "paulnsorensen/milknado"}},
+    )
+    assert marketplace.depends_on == ()
+
+    plugin = steps["milknado:plugin:claude-code"]
+    assert plugin.argv == ()
+    assert plugin.config_edit == ConfigEdit(
+        target=tmp_path / "claude" / "settings.json",
+        pointer="enabledPlugins.milknado@milknado",
+        value=True,
+    )
+    assert plugin.depends_on == ("milknado:marketplace:claude-code",)
+
+
+def test_milknado_permission_appends_the_plugin_mcp_wildcard(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    steps = milknado_steps()
+
+    permission = steps["milknado:permission:claude-code"]
+    assert permission.config_edit == ConfigEdit(
+        target=tmp_path / "settings.json",
+        pointer="permissions.allow",
+        value="mcp__plugin_milknado_milknado__*",
+        mode="append_unique",
+    )
+    assert permission.depends_on == ("milknado:plugin:claude-code",)
+
+
+def test_milknado_plans_no_install_step() -> None:
+    steps = milknado_steps()
+    assert set(steps) == {
+        "milknado:marketplace:claude-code",
+        "milknado:plugin:claude-code",
+        "milknado:permission:claude-code",
+    }
+    assert all(step.argv == () for step in steps.values())
+
+
+def test_milknado_plans_nothing_when_not_selected() -> None:
+    assert milknado_steps(components=("hallouminate", "easy-cheese")) == {}
+
+
+def test_milknado_plans_nothing_without_claude_code() -> None:
+    assert milknado_steps(harnesses=("codex", "cursor")) == {}
+
+
+def test_milknado_claude_registration_postconditions_read_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    adapter = MilknadoAdapter(FakeRunner())
+    steps = milknado_steps()
+    marketplace = steps["milknado:marketplace:claude-code"]
+    plugin = steps["milknado:plugin:claude-code"]
+    permission = steps["milknado:permission:claude-code"]
+
+    probe = FakeRunner()
+    assert adapter.check_postcondition(marketplace, probe) is False
+    assert adapter.check_postcondition(plugin, probe) is False
+    assert adapter.check_postcondition(permission, probe) is False
+
+    (tmp_path / "settings.json").write_text(
+        json.dumps(
+            {
+                "extraKnownMarketplaces": {
+                    "milknado": {"source": {"source": "github", "repo": "paulnsorensen/milknado"}}
+                },
+                "enabledPlugins": {"milknado@milknado": True},
+                "permissions": {"allow": ["mcp__plugin_milknado_milknado__*"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert adapter.check_postcondition(marketplace, probe) is True
+    assert adapter.check_postcondition(plugin, probe) is True
+    assert adapter.check_postcondition(permission, probe) is True
+    assert probe.argvs() == []
+
+
+# --------------------------------------------------------------------------
 # Cross-adapter invariants
 # --------------------------------------------------------------------------
 
@@ -1627,7 +1734,7 @@ def all_planned_steps() -> tuple[PlanStep, ...]:
 
 def test_default_component_adapters_cover_every_component() -> None:
     adapters = default_component_adapters(FakeRunner(npm_script()))
-    assert set(adapters) == {"hallouminate", "easy-cheese", "tilth"}
+    assert set(adapters) == {"hallouminate", "easy-cheese", "tilth", "milknado"}
     assert all(name == adapter.name for name, adapter in adapters.items())
 
 

--- a/tests/python/test_desired_state.py
+++ b/tests/python/test_desired_state.py
@@ -161,7 +161,7 @@ def test_unknown_harness_name(tmp_path: Path) -> None:
 def test_unknown_component_name(tmp_path: Path) -> None:
     error = load_error(tmp_path, VALID.replace('"easy-cheese"', '"brie"', 1))
     assert error.reason == (
-        "unknown component names: brie (supported: hallouminate, easy-cheese, tilth)"
+        "unknown component names: brie (supported: hallouminate, easy-cheese, tilth, milknado)"
     )
 
 


### PR DESCRIPTION
Registers **milknado** through the same installer as hallouminate and easy-cheese, so the Claude Cloud routine picks it up with its **existing** line unchanged.

## Why
The routine runs `bootstrap.sh … --harness claude-code --json`. Headless with no `--component` installs all of `COMPONENT_NAMES` (`cli.py`), so adding `milknado` to that tuple registers it too — no routine edit needed.

## What
New `adapters/milknado.py` mirrors hallouminate’s headless claude-registration path **minus the install step**. milknado’s plugin `.mcp.json` self-fetches the server via `uvx --from git+…@main milknado-mcp`, so cheese-flow installs no package and only declares three `~/.claude/settings.json` edits at install time:

- `extraKnownMarketplaces.milknado` → github `paulnsorensen/milknado`
- `enabledPlugins."milknado@milknado"` → `true`
- `permissions.allow` ← `mcp__plugin_milknado_milknado__*`

Claude Code fetches the marketplace, enables the plugin, and launches the MCP server itself at session start.

## Scope / decisions
- **Optional** component (`COMPONENT_NAMES`, not `REQUIRED_COMPONENTS`) — same treatment as tilth; existing manifests stay valid.
- **Claude Code only** for this cut — `plan_steps` returns `()` without `claude-code`. Codex/Cursor deferred (documented; should extract hallouminate’s shared plugin-CLI/cursor helpers rather than duplicate).
- **Bleeding-edge `@main`** git source, not a PyPI pin. The MCP server does a GitHub clone at session start; if the cloud GitHub proxy refuses that runtime clone, switch the marketplace entry to a released ref (`uvx --from milknado==<version>`). One knob: `CLAUDE_MARKETPLACE_ENTRY`.
- The v1 milknado-removal guards still hold — **no** CLI command, dependency, entry-point, or unified-MCP module reintroduced.

## Tests
`just build` green (930 passed, lint/format clean). Adds 6 milknado adapter tests mirroring the hallouminate registration suite; updates the adapter-set and unknown-component-message assertions. Wiki ADR `v1-installer-boundary.md` updated to record the reversal of the deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)