### PR TITLE
fix(mcp): install milknado + register hallouminate/milknado MCP directly

### DIFF
--- a/python/cheese_flow/adapters/hallouminate.py
+++ b/python/cheese_flow/adapters/hallouminate.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from cheese_flow.adapters.native_config import (
     claude_config_dir,
     config_edit_holds,
+    mcp_entry_holds,
     mcp_permission_edit,
-    read_mcp_entry,
 )
 from cheese_flow.models import (
     HARNESS_NAMES,
@@ -48,12 +48,22 @@ CURSOR_MCP_CONFIG = ".cursor/mcp.json"
 
 CURSOR_MCP_POINTER = f"mcpServers.{PACKAGE}"
 
-CURSOR_MCP_ENTRY: dict[str, object] = {"command": PACKAGE, "args": ["serve"]}
+MCP_ENTRY: dict[str, object] = {"command": PACKAGE, "args": ["serve"]}
 """The entry Hallouminate's own plugin ``.mcp.json`` declares for its server."""
+
+CURSOR_MCP_ENTRY = MCP_ENTRY
+"""Kept for backward-compatible imports; the entry is harness-independent."""
+
+CLAUDE_MCP_CONFIG = ".claude.json"
+"""Claude Code's user-scope MCP surface, relative to the home directory."""
+
+CLAUDE_MCP_POINTER = f"mcpServers.{PACKAGE}"
 
 _INSTALL_STEP = "hallouminate:npm-install"
 _CONFIG_STEP = "hallouminate:config-init"
 _CURSOR_MCP_STEP = "hallouminate:mcp:cursor"
+_CLAUDE_MCP_STEP = "hallouminate:mcp:claude-code"
+_CLAUDE_MCP_PERMISSION_STEP = "hallouminate:permission-mcp:claude-code"
 
 
 def _corpus_name(repository: Path) -> str:
@@ -180,6 +190,26 @@ class HallouminateAdapter:
                     depends_on=(dependency,),
                 )
             )
+
+        if "claude-code" in harnesses:
+            # The direct ``mcpServers`` entry serves tools under ``mcp__hallouminate__*``,
+            # not the plugin's ``mcp__plugin_hallouminate_hallouminate__*`` namespace, so
+            # it needs its own approval to be usable headlessly.
+            mcp_permission = mcp_permission_edit("claude-code", PACKAGE)
+            steps.append(
+                PlanStep(
+                    step_id=_CLAUDE_MCP_PERMISSION_STEP,
+                    component=self.name,
+                    harness="claude-code",
+                    phase=Phase.REGISTER,
+                    config_edit=mcp_permission,
+                    postcondition=(
+                        f"{mcp_permission.target} configures {mcp_permission.pointer} as "
+                        f"{mcp_permission.value!r}"
+                    ),
+                    depends_on=(_CLAUDE_MCP_STEP,),
+                )
+            )
         steps.append(
             PlanStep(
                 step_id=_CONFIG_STEP,
@@ -255,8 +285,10 @@ class HallouminateAdapter:
                 return config_edit_holds(step.config_edit)
             return self._check_plugin(step, runner)
         if step.step_id == _CURSOR_MCP_STEP:
-            return _check_cursor_mcp(step)
-        if step.step_id.startswith("hallouminate:permission:"):
+            return _mcp_step_holds(step, "cursor")
+        if step.step_id == _CLAUDE_MCP_STEP:
+            return _mcp_step_holds(step, "claude-code")
+        if step.step_id.startswith("hallouminate:permission"):
             return step.config_edit is not None and config_edit_holds(step.config_edit)
         if step.step_id == _CONFIG_STEP:
             return runner.run(("hallouminate", "config", "validate")).exit_code == 0
@@ -312,7 +344,7 @@ class HallouminateAdapter:
         return outcome.exit_code == 0 and _has_corpus_result(outcome.stdout)
 
 
-def _claude_registration_steps(component: ComponentName) -> tuple[PlanStep, PlanStep]:
+def _claude_registration_steps(component: ComponentName) -> tuple[PlanStep, ...]:
     """Registration declared in Claude Code's user settings, never through its CLI.
 
     Claude Code reads ``extraKnownMarketplaces`` and ``enabledPlugins`` from
@@ -322,6 +354,13 @@ def _claude_registration_steps(component: ComponentName) -> tuple[PlanStep, Plan
     behind a GitHub proxy that refuses clones of repositories not attached to
     the session. Declaring the entries defers the fetch to session start,
     which the cloud blesses, and works identically on a developer machine.
+
+    The MCP server is the exception: the plugin's own ``.mcp.json`` only
+    launches ``hallouminate serve`` once Claude Code materializes the plugin
+    cache at session start, which proved unreliable in Claude Cloud. Since the
+    binary is already installed globally, a direct ``mcpServers`` entry launches
+    it without waiting on the plugin cache, so the wiki grounding comes up even
+    when materialization does not.
     """
     settings = claude_config_dir() / "settings.json"
     marketplace = ConfigEdit(
@@ -330,6 +369,9 @@ def _claude_registration_steps(component: ComponentName) -> tuple[PlanStep, Plan
         value=CLAUDE_MARKETPLACE_ENTRY,
     )
     plugin = ConfigEdit(target=settings, pointer=f"enabledPlugins.{PLUGIN_ID}", value=True)
+    mcp = ConfigEdit(
+        target=Path.home() / CLAUDE_MCP_CONFIG, pointer=CLAUDE_MCP_POINTER, value=MCP_ENTRY
+    )
     return (
         PlanStep(
             step_id="hallouminate:marketplace:claude-code",
@@ -351,18 +393,25 @@ def _claude_registration_steps(component: ComponentName) -> tuple[PlanStep, Plan
             postcondition=f"{settings} enables {PLUGIN_ID} at {plugin.pointer}",
             depends_on=("hallouminate:marketplace:claude-code",),
         ),
+        PlanStep(
+            step_id=_CLAUDE_MCP_STEP,
+            component=component,
+            harness="claude-code",
+            phase=Phase.REGISTER,
+            config_edit=mcp,
+            postcondition=(
+                f"~/{CLAUDE_MCP_CONFIG} holds {CLAUDE_MCP_POINTER} running `{PACKAGE} serve`"
+            ),
+            depends_on=(_INSTALL_STEP,),
+        ),
     )
 
 
-def _check_cursor_mcp(step: PlanStep) -> bool:
-    """Confirm Cursor MCP config declares the entry the step specifies."""
-    edit = step.config_edit
-    if edit is None or not isinstance(edit.value, dict):
+def _mcp_step_holds(step: PlanStep, harness: HarnessName) -> bool:
+    """Confirm ``harness``'s MCP config declares the direct entry the step specifies."""
+    if step.config_edit is None:
         raise ValueError(f"step {step.step_id!r} has no MCP config entry")
-    entry = read_mcp_entry(edit.target, "cursor", PACKAGE)
-    if not isinstance(entry, dict):
-        return False
-    return entry.get("command") == edit.value["command"] and entry.get("args") == edit.value["args"]
+    return mcp_entry_holds(step.config_edit, harness, PACKAGE)
 
 
 _BULLETS = "-*•❯> \t"

--- a/python/cheese_flow/adapters/milknado.py
+++ b/python/cheese_flow/adapters/milknado.py
@@ -1,20 +1,34 @@
-"""Milknado adapter: Claude Code plugin registration only.
+"""Milknado adapter: pinned MCP-server install plus Claude Code registration.
 
-Milknado's plugin ``.mcp.json`` launches its server with
-``uvx --from git+...@main milknado-mcp``, so cheese-flow installs nothing —
-the first launch self-fetches from the bleeding-edge default branch, which is
-intentional for this cut. Codex and Cursor are deferred entirely: adding them
-later should extract the shared plugin-CLI/cursor helpers from
-hallouminate.py rather than duplicate them here.
+The Milknado plugin's own ``.mcp.json`` launches its server with
+``uvx --from git+...@main milknado-mcp`` — an unpinned, cold source build (~90s
+of downloading and compiling a heavy dependency tree) that must both materialize
+the plugin cache and finish inside the session-start window. In Claude Cloud it
+did neither reliably, so the ``milknado`` MCP tools never came up.
+
+So cheese-flow stops relying on that lazy build. It installs a pinned PyPI wheel
+once with ``uv tool install`` (paid in the install phase, where it can finish and
+persists into the cached container) and registers the resulting ``milknado-mcp``
+binary as a direct user-scope MCP entry — which launches in seconds and does not
+depend on the plugin cache materializing. The plugin is still declared so its
+agents and commands load; the direct entry is the authoritative MCP surface.
+
+Codex and Cursor are deferred entirely: adding them later should extract the
+shared plugin-CLI/cursor helpers from hallouminate.py rather than duplicate them
+here.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from cheese_flow.adapters.native_config import (
     claude_config_dir,
     config_edit_holds,
+    mcp_entry_holds,
     mcp_permission_edit,
 )
+from cheese_flow.adapters.tilth import _bin_dir
 from cheese_flow.models import (
     CommandRunner,
     ComponentName,
@@ -29,25 +43,50 @@ MARKETPLACE_SOURCE = "paulnsorensen/milknado"
 MARKETPLACE_NAME = "milknado"
 PLUGIN_ID = "milknado@milknado"
 CLAUDE_SERVER = "plugin_milknado_milknado"
-"""Matches the live tool namespace ``mcp__plugin_milknado_milknado__*``."""
+"""The plugin-scoped tool namespace ``mcp__plugin_milknado_milknado__*``."""
+
+MCP_VERSION = "0.2.1"
+"""Pinned PyPI wheel for the ``milknado-mcp`` server, decoupled from the plugin cut.
+
+A version pin, not ``@main``: an unpinned spec re-resolves and rebuilds from source
+on every marketplace advance, which is exactly the cold-build cost this avoids.
+"""
+
+MCP_SERVER_BIN = "milknado-mcp"
+"""The console script ``uv tool install`` exposes for the MCP server."""
+
+PROBE_BIN = "milknado"
+"""The companion CLI ``uv tool install`` exposes; ``--help`` proves the install."""
+
+CLAUDE_MCP_CONFIG = ".claude.json"
+"""Claude Code's user-scope MCP surface, relative to the home directory."""
 
 CLAUDE_MARKETPLACE_ENTRY: dict[str, object] = {
     "source": {"source": "github", "repo": MARKETPLACE_SOURCE}
 }
 """The ``extraKnownMarketplaces`` entry Claude Code fetches the catalog from at startup."""
 
+_INSTALL_STEP = "milknado:install"
 _MARKETPLACE_STEP = "milknado:marketplace:claude-code"
 _PLUGIN_STEP = "milknado:plugin:claude-code"
 _PERMISSION_STEP = "milknado:permission:claude-code"
+_MCP_STEP = "milknado:mcp:claude-code"
+_MCP_PERMISSION_STEP = "milknado:permission-mcp:claude-code"
+
+
+def _mcp_entry() -> dict[str, object]:
+    """The direct user-scope MCP entry launching the installed server binary."""
+    return {"command": str(_bin_dir() / MCP_SERVER_BIN), "args": []}
 
 
 class MilknadoAdapter:
-    """Declares Milknado's Claude Code plugin registration in user settings.
+    """Installs the pinned MCP server and declares Claude Code registration.
 
-    Mirrors Hallouminate's ``_claude_registration_steps``: Claude Code reads
-    ``extraKnownMarketplaces`` and ``enabledPlugins`` from user settings at
-    startup and fetches the marketplace itself, so declaring the entries
-    converges on a headless host with no ``claude`` on PATH.
+    Claude Code reads ``extraKnownMarketplaces``/``enabledPlugins`` from user
+    settings at startup and fetches the marketplace itself, so declaring those
+    entries converges on a headless host with no ``claude`` on PATH. The MCP
+    server, in contrast, is installed here and wired as a direct ``mcpServers``
+    entry rather than left to the plugin's lazy ``uvx`` launch.
     """
 
     name: ComponentName = "milknado"
@@ -56,21 +95,33 @@ class MilknadoAdapter:
         self._runner = runner
 
     def plan_steps(self, state: DesiredState) -> tuple[PlanStep, ...]:
-        """Emit Claude Code registration steps only; other harnesses are deferred."""
+        """Emit the pinned install plus Claude Code registration; other harnesses deferred."""
         if self.name not in state.components:
             return ()
         if "claude-code" not in state.harnesses:
             return ()
 
+        probe = _bin_dir() / PROBE_BIN
         settings = claude_config_dir() / "settings.json"
+        mcp_config = Path.home() / CLAUDE_MCP_CONFIG
+
         marketplace = ConfigEdit(
             target=settings,
             pointer=f"extraKnownMarketplaces.{MARKETPLACE_NAME}",
             value=CLAUDE_MARKETPLACE_ENTRY,
         )
         plugin = ConfigEdit(target=settings, pointer=f"enabledPlugins.{PLUGIN_ID}", value=True)
-        permission = mcp_permission_edit("claude-code", PACKAGE, claude_server=CLAUDE_SERVER)
+        plugin_permission = mcp_permission_edit("claude-code", PACKAGE, claude_server=CLAUDE_SERVER)
+        mcp = ConfigEdit(target=mcp_config, pointer=f"mcpServers.{PACKAGE}", value=_mcp_entry())
+        mcp_permission = mcp_permission_edit("claude-code", PACKAGE)
         return (
+            PlanStep(
+                step_id=_INSTALL_STEP,
+                component=self.name,
+                phase=Phase.INSTALL,
+                argv=("uv", "tool", "install", f"{PACKAGE}=={MCP_VERSION}"),
+                postcondition=f"`{probe} --help` exits 0",
+            ),
             PlanStep(
                 step_id=_MARKETPLACE_STEP,
                 component=self.name,
@@ -97,16 +148,51 @@ class MilknadoAdapter:
                 component=self.name,
                 harness="claude-code",
                 phase=Phase.REGISTER,
-                config_edit=permission,
+                config_edit=plugin_permission,
                 postcondition=(
-                    f"{permission.target} configures {permission.pointer} as {permission.value!r}"
+                    f"{plugin_permission.target} configures {plugin_permission.pointer} as "
+                    f"{plugin_permission.value!r}"
                 ),
                 depends_on=(_PLUGIN_STEP,),
+            ),
+            PlanStep(
+                step_id=_MCP_STEP,
+                component=self.name,
+                harness="claude-code",
+                phase=Phase.REGISTER,
+                config_edit=mcp,
+                postcondition=(
+                    f"~/{CLAUDE_MCP_CONFIG} holds {mcp.pointer} running `{MCP_SERVER_BIN}`"
+                ),
+                depends_on=(_INSTALL_STEP,),
+            ),
+            PlanStep(
+                step_id=_MCP_PERMISSION_STEP,
+                component=self.name,
+                harness="claude-code",
+                phase=Phase.REGISTER,
+                config_edit=mcp_permission,
+                postcondition=(
+                    f"{mcp_permission.target} configures {mcp_permission.pointer} as "
+                    f"{mcp_permission.value!r}"
+                ),
+                depends_on=(_MCP_STEP,),
             ),
         )
 
     def check_postcondition(self, step: PlanStep, runner: CommandRunner) -> bool:
-        """Every step's postcondition is the settings file itself."""
-        if step.step_id in (_MARKETPLACE_STEP, _PLUGIN_STEP, _PERMISSION_STEP):
+        """Probe the installed binary, the direct MCP entry, or the settings edits."""
+        if step.step_id == _INSTALL_STEP:
+            return runner.run((str(_bin_dir() / PROBE_BIN), "--help")).exit_code == 0
+        if step.step_id == _MCP_STEP:
+            if step.config_edit is None:
+                raise ValueError(f"{step.step_id!r} has no MCP config entry")
+            return mcp_entry_holds(step.config_edit, "claude-code", PACKAGE)
+        if step.step_id in (
+            _MARKETPLACE_STEP,
+            _PLUGIN_STEP,
+            _PERMISSION_STEP,
+            _MCP_PERMISSION_STEP,
+        ):
             return step.config_edit is not None and config_edit_holds(step.config_edit)
         raise ValueError(f"{step.step_id!r} is not a milknado step")

--- a/python/cheese_flow/adapters/native_config.py
+++ b/python/cheese_flow/adapters/native_config.py
@@ -33,6 +33,21 @@ def read_mcp_entry(path: Path, harness: HarnessName, server: str) -> Any:
     return servers.get(server) if isinstance(servers, dict) else None
 
 
+def mcp_entry_holds(edit: ConfigEdit, harness: HarnessName, server: str) -> bool:
+    """Whether ``harness``'s MCP config declares ``server`` exactly as ``edit`` says.
+
+    A direct ``mcpServers`` entry is verified by its launch command and args, not
+    by the config file merely mentioning the server — a stale entry pointing at a
+    different binary must not satisfy the step that declared this one.
+    """
+    if not isinstance(edit.value, dict):
+        raise ValueError(f"{server} MCP edit carries no entry mapping")
+    entry = read_mcp_entry(edit.target, harness, server)
+    if not isinstance(entry, dict):
+        return False
+    return entry.get("command") == edit.value["command"] and entry.get("args") == edit.value["args"]
+
+
 def claude_config_dir() -> Path:
     """Claude's user config directory, including its documented override."""
     configured = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()

--- a/tests/python/test_adapters.py
+++ b/tests/python/test_adapters.py
@@ -25,6 +25,7 @@ from cheese_flow.adapters import (
 )
 from cheese_flow.adapters.easy_cheese import AGENT_TOKENS, CORE_SKILLS, skills_directory
 from cheese_flow.adapters.hallouminate import _owner_repo
+from cheese_flow.adapters.native_config import mcp_entry_holds
 from cheese_flow.adapters.tilth import (
     RELEASE_URL,
     _bin_dir,
@@ -234,6 +235,75 @@ def test_hallouminate_plans_native_mcp_permissions(
         assert permission.depends_on == (dependency,)
         assert permission.config_edit == edit
         assert "configures" in permission.postcondition
+
+
+def test_hallouminate_registers_the_claude_mcp_entry_directly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+    steps = steps_by_id(HallouminateAdapter(FakeRunner(npm_script())).plan_steps(state()))
+
+    mcp = steps["hallouminate:mcp:claude-code"]
+    assert mcp.argv == ()
+    assert mcp.config_edit == ConfigEdit(
+        target=tmp_path / ".claude.json",
+        pointer="mcpServers.hallouminate",
+        value={"command": "hallouminate", "args": ["serve"]},
+    )
+    assert mcp.depends_on == ("hallouminate:npm-install",)
+
+    permission = steps["hallouminate:permission-mcp:claude-code"]
+    assert permission.config_edit == ConfigEdit(
+        target=tmp_path / "claude" / "settings.json",
+        pointer="permissions.allow",
+        value="mcp__hallouminate__*",
+        mode="append_unique",
+    )
+    assert permission.depends_on == ("hallouminate:mcp:claude-code",)
+
+
+def test_hallouminate_claude_mcp_postcondition_reads_the_config_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    adapter = HallouminateAdapter(FakeRunner(npm_script()))
+    mcp = steps_by_id(adapter.plan_steps(state()))["hallouminate:mcp:claude-code"]
+
+    assert adapter.check_postcondition(mcp, FakeRunner()) is False
+    config = tmp_path / ".claude.json"
+    config.write_text(
+        json.dumps(
+            {"mcpServers": {"hallouminate": {"command": "hallouminate", "args": ["serve"]}}}
+        ),
+        encoding="utf-8",
+    )
+    assert adapter.check_postcondition(mcp, FakeRunner()) is True
+
+
+def test_hallouminate_mcp_step_without_a_config_edit_raises() -> None:
+    adapter = HallouminateAdapter(FakeRunner(npm_script()))
+    step = PlanStep(
+        step_id="hallouminate:mcp:cursor",
+        component="hallouminate",
+        harness="cursor",
+        phase=Phase.REGISTER,
+        argv=("noop",),
+        postcondition="unused",
+    )
+    with pytest.raises(ValueError, match="has no MCP config entry"):
+        adapter.check_postcondition(step, FakeRunner())
+
+
+def test_mcp_entry_holds_requires_a_mapping_value() -> None:
+    edit = ConfigEdit(
+        target=Path("/does/not/matter/.claude.json"),
+        pointer="mcpServers.hallouminate",
+        value=True,
+    )
+    with pytest.raises(ValueError, match="carries no entry mapping"):
+        mcp_entry_holds(edit, "claude-code", "hallouminate")
 
 
 def test_hallouminate_permission_postconditions_require_each_native_rule(
@@ -1669,14 +1739,111 @@ def test_milknado_permission_appends_the_plugin_mcp_wildcard(
     assert permission.depends_on == ("milknado:plugin:claude-code",)
 
 
-def test_milknado_plans_no_install_step() -> None:
+def test_milknado_installs_pinned_wheel_and_registers_direct_mcp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+    monkeypatch.setenv("XDG_BIN_HOME", str(tmp_path / "bin"))
     steps = milknado_steps()
+
     assert set(steps) == {
+        "milknado:install",
         "milknado:marketplace:claude-code",
         "milknado:plugin:claude-code",
         "milknado:permission:claude-code",
+        "milknado:mcp:claude-code",
+        "milknado:permission-mcp:claude-code",
     }
-    assert all(step.argv == () for step in steps.values())
+
+    install = steps["milknado:install"]
+    assert install.phase is Phase.INSTALL
+    assert install.argv == ("uv", "tool", "install", "milknado==0.2.1")
+    assert install.depends_on == ()
+
+    mcp = steps["milknado:mcp:claude-code"]
+    assert mcp.argv == ()
+    assert mcp.config_edit == ConfigEdit(
+        target=tmp_path / ".claude.json",
+        pointer="mcpServers.milknado",
+        value={"command": str(tmp_path / "bin" / "milknado-mcp"), "args": []},
+    )
+    assert mcp.depends_on == ("milknado:install",)
+
+    permission = steps["milknado:permission-mcp:claude-code"]
+    assert permission.config_edit == ConfigEdit(
+        target=tmp_path / "claude" / "settings.json",
+        pointer="permissions.allow",
+        value="mcp__milknado__*",
+        mode="append_unique",
+    )
+    assert permission.depends_on == ("milknado:mcp:claude-code",)
+
+
+def test_milknado_install_postcondition_probes_the_binary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_BIN_HOME", str(tmp_path / "bin"))
+    adapter = MilknadoAdapter(FakeRunner())
+    install = milknado_steps()["milknado:install"]
+    probe = (str(tmp_path / "bin" / "milknado"), "--help")
+
+    assert adapter.check_postcondition(install, FakeRunner()) is False
+    ready = FakeRunner({probe: outcome(probe, exit_code=0)})
+    assert adapter.check_postcondition(install, ready) is True
+    assert ready.argvs() == [probe]
+
+
+def test_milknado_mcp_postcondition_reads_the_claude_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_BIN_HOME", str(tmp_path / "bin"))
+    adapter = MilknadoAdapter(FakeRunner())
+    mcp = milknado_steps()["milknado:mcp:claude-code"]
+    server = str(tmp_path / "bin" / "milknado-mcp")
+
+    assert adapter.check_postcondition(mcp, FakeRunner()) is False
+
+    config = tmp_path / ".claude.json"
+    config.write_text(
+        json.dumps({"mcpServers": {"milknado": {"command": server, "args": []}}}),
+        encoding="utf-8",
+    )
+    assert adapter.check_postcondition(mcp, FakeRunner()) is True
+
+    config.write_text(
+        json.dumps({"mcpServers": {"milknado": {"command": "/other/milknado-mcp", "args": []}}}),
+        encoding="utf-8",
+    )
+    assert adapter.check_postcondition(mcp, FakeRunner()) is False
+
+
+def test_milknado_mcp_postcondition_requires_a_config_edit() -> None:
+    adapter = MilknadoAdapter(FakeRunner())
+    step = PlanStep(
+        step_id="milknado:mcp:claude-code",
+        component="milknado",
+        harness="claude-code",
+        phase=Phase.REGISTER,
+        argv=("noop",),
+        postcondition="unused",
+    )
+    with pytest.raises(ValueError, match="has no MCP config entry"):
+        adapter.check_postcondition(step, FakeRunner())
+
+
+def test_milknado_rejects_an_unknown_step() -> None:
+    adapter = MilknadoAdapter(FakeRunner())
+    step = PlanStep(
+        step_id="milknado:unknown",
+        component="milknado",
+        phase=Phase.REGISTER,
+        argv=("noop",),
+        postcondition="unused",
+    )
+    with pytest.raises(ValueError, match="not a milknado step"):
+        adapter.check_postcondition(step, FakeRunner())
 
 
 def test_milknado_plans_nothing_when_not_selected() -> None:

--- a/tests/python/test_doctor.py
+++ b/tests/python/test_doctor.py
@@ -157,12 +157,24 @@ def test_doctor_with_real_adapters_runs_only_read_only_commands(
         ),
         encoding="utf-8",
     )
+    claude_mcp = tmp_path / ".claude.json"
+    claude_mcp.write_text(
+        json.dumps(
+            {"mcpServers": {"hallouminate": {"command": "hallouminate", "args": ["serve"]}}}
+        ),
+        encoding="utf-8",
+    )
     claude_settings = tmp_path / ".claude" / "settings.json"
     claude_settings.parent.mkdir(exist_ok=True)
     claude_settings.write_text(
         json.dumps(
             {
-                "permissions": {"allow": ["mcp__plugin_hallouminate_hallouminate__*"]},
+                "permissions": {
+                    "allow": [
+                        "mcp__plugin_hallouminate_hallouminate__*",
+                        "mcp__hallouminate__*",
+                    ]
+                },
                 "extraKnownMarketplaces": {
                     "hallouminate": {
                         "source": {"source": "github", "repo": "paulnsorensen/hallouminate"}
@@ -197,9 +209,11 @@ def test_doctor_with_real_adapters_runs_only_read_only_commands(
         "hallouminate:npm-install",
         "hallouminate:marketplace:claude-code",
         "hallouminate:plugin:claude-code",
+        "hallouminate:mcp:claude-code",
         "hallouminate:mcp:cursor",
         "hallouminate:permission:claude-code",
         "hallouminate:permission:cursor",
+        "hallouminate:permission-mcp:claude-code",
         "hallouminate:config-init",
         "easy-cheese:install:claude-code",
         "easy-cheese:install:cursor",

--- a/tests/python/test_integration.py
+++ b/tests/python/test_integration.py
@@ -152,13 +152,23 @@ class FakeWorld:
             settings.parent.mkdir(parents=True, exist_ok=True)
             document = _read_json(settings)
             document.setdefault("permissions", {}).setdefault("allow", []).extend(
-                ["mcp__plugin_hallouminate_hallouminate__*", "mcp__tilth__*"]
+                [
+                    "mcp__plugin_hallouminate_hallouminate__*",
+                    "mcp__hallouminate__*",
+                    "mcp__tilth__*",
+                ]
             )
             document["extraKnownMarketplaces"] = {
                 MARKETPLACE_NAME: {"source": {"source": "github", "repo": MARKETPLACE_SOURCE}}
             }
             document["enabledPlugins"] = {PLUGIN_ID: True}
             settings.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+            # The direct user-scope MCP entry Claude Code launches without the
+            # plugin cache, alongside the tilth entry already written above.
+            mcp = self.home / CLAUDE_MCP_CONFIG
+            mcp_document = _read_json(mcp)
+            mcp_document.setdefault("mcpServers", {})["hallouminate"] = HALLOUMINATE_CURSOR_ENTRY
+            mcp.write_text(json.dumps(mcp_document, indent=2) + "\n", encoding="utf-8")
         if "codex" in harnesses:
             config = self.home / CODEX_MCP_CONFIG
             config.write_text(
@@ -607,9 +617,11 @@ def test_complete_config_runs_headlessly_and_stdout_is_one_json_document(
         ("hallouminate:npm-install", "succeeded"),
         ("hallouminate:marketplace:claude-code", "succeeded"),
         ("hallouminate:plugin:claude-code", "succeeded"),
+        ("hallouminate:mcp:claude-code", "succeeded"),
         ("hallouminate:mcp:cursor", "succeeded"),
         ("hallouminate:permission:claude-code", "succeeded"),
         ("hallouminate:permission:cursor", "succeeded"),
+        ("hallouminate:permission-mcp:claude-code", "succeeded"),
         ("hallouminate:config-init", "succeeded"),
         (f"hallouminate:init-repo:{key}", "succeeded"),
         (f"hallouminate:index:{key}", "succeeded"),
@@ -673,7 +685,7 @@ def test_already_satisfied_postconditions_skip_every_mutation(
     assert result.exit_code == 0, result.stderr
     document = json.loads(result.stdout)
     assert {status for _, status in statuses(document)} == {"skipped"}
-    assert len(document["results"]) == 15
+    assert len(document["results"]) == 17
     assert world.argvs() == read_only_probes(home)
     assert snapshot(home) == before
 
@@ -725,7 +737,9 @@ def test_apply_installs_exactly_the_version_planning_resolved(
         ("hallouminate:npm-install", "succeeded"),
         ("hallouminate:marketplace:claude-code", "succeeded"),
         ("hallouminate:plugin:claude-code", "succeeded"),
+        ("hallouminate:mcp:claude-code", "succeeded"),
         ("hallouminate:permission:claude-code", "succeeded"),
+        ("hallouminate:permission-mcp:claude-code", "succeeded"),
         ("hallouminate:config-init", "succeeded"),
         ("easy-cheese:install:claude-code", "succeeded"),
         ("tilth:install", "succeeded"),
@@ -784,7 +798,9 @@ def test_failed_step_blocks_adapter_wired_dependents_and_lets_others_run(
         ("hallouminate:npm-install", "succeeded"),
         ("hallouminate:marketplace:claude-code", "succeeded"),
         ("hallouminate:plugin:claude-code", "succeeded"),
+        ("hallouminate:mcp:claude-code", "succeeded"),
         ("hallouminate:permission:claude-code", "succeeded"),
+        ("hallouminate:permission-mcp:claude-code", "succeeded"),
         ("hallouminate:config-init", "failed"),
         (f"hallouminate:init-repo:{key}", "blocked"),
         (f"hallouminate:index:{key}", "blocked"),


### PR DESCRIPTION
## Problem

In a Claude Cloud (`milknado` env) session, **none of the milknado, tilth, or hallouminate MCP servers came up**. Root cause for the two plugin-provided ones:

- Claude Code must **materialize the plugin cache** at session start to read a plugin's `.mcp.json` and launch its server. On the provisioned box `~/.claude/plugins/cache/` was empty despite install records — materialization silently didn't happen, so neither `milknado` nor `hallouminate serve` ever launched.
- **milknado compounded it**: its plugin launches `uvx --from git+…@main milknado-mcp` — a cold, unpinned source build (~90s: numpy/pandas/ortools/tree-sitter) that must *also* finish inside the session-start window. Measured cold ~90s vs warm ~3.8s.

`settings.json` registration itself was correct — the failure is entirely in the lazy, plugin-cache-dependent MCP launch. Notably hallouminate's binary was already installed globally, so its MCP was one small change away from working.

## Fix

Stop depending on plugin-cache materialization for MCP; register each server as a direct user-scope `mcpServers` entry pointing at an installed binary (mirroring the pattern the Cursor path already uses).

**milknado** (`adapters/milknado.py`) — was registration-only:
- New install step: `uv tool install milknado==0.2.1` (pinned PyPI wheel; paid once in the install phase, persists into the cached container). A **version pin, not `@main`**, so a marketplace advance no longer forces a source rebuild.
- Direct `mcpServers.milknado` entry in `~/.claude.json` → `milknado-mcp` binary. Launches in seconds, no plugin-cache dependency.
- Its own `mcp__milknado__*` permission + a real liveness postcondition (`milknado --help` exit 0). Plugin still declared for its agents/commands.

**hallouminate** (`adapters/hallouminate.py`) — binary already installs via global npm:
- Add a direct `mcpServers.hallouminate` entry (`hallouminate serve`) in `~/.claude.json` + `mcp__hallouminate__*` permission, so wiki grounding comes up even when the plugin cache doesn't materialize.

**Verification** (`adapters/native_config.py`):
- New shared `mcp_entry_holds()` helper verifies a direct entry by its launch command/args (not just that the file mentions the server). Used for the new claude-code postconditions and the refactored cursor check.

## Design note

Both plugin registrations are kept (they carry agents/commands/skills); the direct entry is the authoritative MCP surface. If a plugin's own MCP ever *does* materialize, its tools land under a different namespace (`mcp__plugin_*`), so there's no hard collision — strictly better than the current total failure. Companion changes land separately: pinning milknado's plugin `.mcp.json` off `@main`, and the routine-env provisioning for tilth.

## Tests

Updated adapter/doctor/integration tests for the new steps; added coverage for the install probe, direct-entry postconditions, and guard branches. `just build-ci` (ruff format --check + ruff check + pytest) passes. Two unrelated failures (`test_writability_reflects_filesystem_permission`, `test_launch_cli_redacts_build_environment_diagnostics`) are **pre-existing** on this branch's base — they fail only when the suite runs as root / with a colliding random secret, not on CI's non-root runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5vDuCJHw6hwkLXUppEWEh)_