### PR TITLE
refactor(cli): migrate the cheese CLI from typer to cyclopts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ description = "Composition installer for the cheese ecosystem on Claude Code, Co
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+  "cyclopts==4.23.0",
   "pydantic==2.13.4",
   "PyYAML>=6.0",
   "rich>=15.0.0",
   "tomlkit>=0.15.1",
-  "typer==0.25.1",
 ]
 
 [project.scripts]

--- a/python/cheese_flow/cli.py
+++ b/python/cheese_flow/cli.py
@@ -1,4 +1,4 @@
-"""Typer CLI entry point for cheese-flow.
+"""Cyclopts CLI entry point for cheese-flow.
 
 ``cheese install`` runs the wizard, or installs headlessly from a manifest
 (``--config``) or from options (``--harness``/``--component``/``--repo``).
@@ -16,10 +16,11 @@ import sys
 import tempfile
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
+from importlib.metadata import version
 from pathlib import Path
 from typing import Annotated
 
-import typer
+from cyclopts import App, Group, Parameter
 from rich.console import Console
 
 from cheese_flow.adapters import default_component_adapters
@@ -54,65 +55,81 @@ _FAILURE_EXIT_CODE = 1
 # uvx clone it execs directly, which this runner cannot reach.
 _GIT_LOW_SPEED_DEFAULTS = {"GIT_HTTP_LOW_SPEED_LIMIT": "1000", "GIT_HTTP_LOW_SPEED_TIME": "30"}
 
-app = typer.Typer(
+app = App(
     name="cheese",
+    version=version("cheese-flow"),
     help="Install and verify the cheese ecosystem across Claude Code, Codex, and Cursor.",
-    no_args_is_help=True,
-    add_completion=False,
 )
 
-app.add_typer(profile_app, name="profile")
+app.command(profile_app)
+
+_STATE_SOURCE = Group("State source (choose the wizard, a manifest, or options)")
+_BEHAVIOR = Group("Behavior")
 
 
-@app.command()
+@app.command
 def install(
+    *,
     config: Annotated[
         Path | None,
-        typer.Option(
-            "--config",
+        Parameter(
+            group=_STATE_SOURCE,
             help="Apply this manifest headlessly instead of running the wizard.",
         ),
     ] = None,
     harness: Annotated[
         list[str] | None,
-        typer.Option(
-            "--harness",
+        Parameter(
+            group=_STATE_SOURCE,
+            negative="",
             help="Harnesses to manage, comma- or space-separated. Repeatable. Runs headlessly.",
         ),
     ] = None,
     component: Annotated[
         list[str] | None,
-        typer.Option(
-            "--component",
+        Parameter(
+            group=_STATE_SOURCE,
+            negative="",
             help="Components to install, comma- or space-separated. Defaults to all of them.",
         ),
     ] = None,
     repo: Annotated[
         list[str] | None,
-        typer.Option(
-            "--repo",
+        Parameter(
+            group=_STATE_SOURCE,
+            negative="",
             help="Repositories to index, comma- or space-separated. Relative paths are resolved.",
         ),
     ] = None,
     write_config: Annotated[
         bool,
-        typer.Option(
-            "--write-config",
+        Parameter(
+            group=_BEHAVIOR,
+            negative="",
             help="Persist the resolved manifest. Options are ephemeral without it.",
         ),
     ] = False,
     dry_run: Annotated[
         bool,
-        typer.Option("--dry-run", help="Emit the plan without changing managed state."),
+        Parameter(
+            group=_BEHAVIOR,
+            negative="",
+            help="Emit the plan without changing managed state.",
+        ),
     ] = False,
     json_output: Annotated[
         bool,
-        typer.Option("--json", help="Write one JSON document to stdout."),
+        Parameter(
+            name="--json",
+            group=_BEHAVIOR,
+            negative="",
+            help="Write one JSON document to stdout.",
+        ),
     ] = False,
     timeout: Annotated[
         float,
-        typer.Option(
-            "--timeout",
+        Parameter(
+            group=_BEHAVIOR,
             help="Seconds a single command may run before it is killed.",
         ),
     ] = DEFAULT_TIMEOUT_SECONDS,
@@ -156,18 +173,16 @@ def install(
     _emit(console, report, headless=headless)
 
 
-@app.command()
+@app.command
 def doctor(
+    *,
     config: Annotated[
         Path | None,
-        typer.Option("--config", help="Manifest to verify. Defaults to the standard path."),
+        Parameter(help="Manifest to verify. Defaults to the standard path."),
     ] = None,
     timeout: Annotated[
         float,
-        typer.Option(
-            "--timeout",
-            help="Seconds a single command may run before it is killed.",
-        ),
+        Parameter(help="Seconds a single command may run before it is killed."),
     ] = DEFAULT_TIMEOUT_SECONDS,
 ) -> None:
     """Verify declared managed state without changing it."""
@@ -194,7 +209,7 @@ def _resolution_failure_reported(console: Console) -> Iterator[None]:
         yield
     except RuntimeError as error:
         console.print(f"Planning failed: {error}")
-        raise typer.Exit(_FAILURE_EXIT_CODE) from error
+        raise SystemExit(_FAILURE_EXIT_CODE) from error
 
 
 def _console() -> Console:
@@ -236,12 +251,12 @@ def _reject_conflicting_options(
             "Invalid options: --config and --harness/--component/--repo "
             "name two sources of desired state."
         )
-        raise typer.Exit(_MANIFEST_EXIT_CODE)
+        raise SystemExit(_MANIFEST_EXIT_CODE)
     if write_config and dry_run:
         console.print(
             "Invalid options: --dry-run persists nothing, so --write-config cannot apply."
         )
-        raise typer.Exit(_MANIFEST_EXIT_CODE)
+        raise SystemExit(_MANIFEST_EXIT_CODE)
 
 
 def _option_state(
@@ -259,7 +274,7 @@ def _option_state(
         )
     except OptionError as error:
         console.print(f"Invalid options: {error}")
-        raise typer.Exit(_MANIFEST_EXIT_CODE) from error
+        raise SystemExit(_MANIFEST_EXIT_CODE) from error
 
 
 def _headless_state(console: Console, config: Path | None) -> DesiredState:
@@ -269,7 +284,7 @@ def _headless_state(console: Console, config: Path | None) -> DesiredState:
         return load_desired_state(path)
     except ManifestError as error:
         console.print(f"Invalid manifest: {error}")
-        raise typer.Exit(_MANIFEST_EXIT_CODE) from error
+        raise SystemExit(_MANIFEST_EXIT_CODE) from error
 
 
 def _has_terminal() -> bool:
@@ -289,11 +304,11 @@ def _interactive_state(console: Console, *, dry_run: bool) -> DesiredState:
             "No terminal available for the wizard. Pass --harness/--component "
             "to install headlessly, or --config <manifest> to apply a saved one."
         )
-        raise typer.Exit(_FAILURE_EXIT_CODE)
+        raise SystemExit(_FAILURE_EXIT_CODE)
     state = run_wizard(_prefill(console))
     if state is None:
         console.print("Cancelled: no manifest was written and nothing was installed.")
-        raise typer.Exit(_FAILURE_EXIT_CODE)
+        raise SystemExit(_FAILURE_EXIT_CODE)
     if dry_run:
         console.print("Dry run: the accepted state will not be persisted.")
     return state
@@ -319,7 +334,7 @@ def _emit(console: Console, report: ApplyReport | DoctorReport, *, headless: boo
     else:
         _render(console, report)
     if report.status is not ReportStatus.SUCCEEDED:
-        raise typer.Exit(_FAILURE_EXIT_CODE)
+        raise SystemExit(_FAILURE_EXIT_CODE)
 
 
 def _render(console: Console, report: ApplyReport | DoctorReport) -> None:

--- a/python/cheese_flow/profiles/cli.py
+++ b/python/cheese_flow/profiles/cli.py
@@ -1,14 +1,15 @@
-"""Typer commands for the explicit cheese profile engine seams."""
+"""Cyclopts commands for the explicit cheese profile engine seams."""
 
 from __future__ import annotations
 
 import json
 import os
+import sys
 from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Annotated
 
-import typer
+from cyclopts import App, Parameter
 from pydantic import BaseModel, ValidationError
 
 from .apply import apply_profile
@@ -20,11 +21,9 @@ from .models import CompileRequest, LaunchRequest, LaunchSpec, ProjectPermission
 from .project_permissions import render_project_permissions
 from .source import list_profiles, load_profile
 
-app = typer.Typer(
+app = App(
     name="profile",
     help="Inspect, compile, apply, launch, and render agent profiles.",
-    no_args_is_help=True,
-    add_completion=False,
 )
 
 _FAILURE_EXIT_CODE = 1
@@ -40,22 +39,23 @@ def _json_document(value: BaseModel | object) -> str:
 
 
 def _emit(value: BaseModel | object) -> None:
-    typer.echo(_json_document(value))
+    print(_json_document(value))
 
 
 def _handle(operation: Callable[[], object]) -> object:
     try:
         return operation()
     except (ProfileError, ValidationError) as error:
-        typer.echo(str(error), err=True)
-        raise typer.Exit(_FAILURE_EXIT_CODE) from None
+        print(str(error), file=sys.stderr)
+        raise SystemExit(_FAILURE_EXIT_CODE) from None
 
 
-@app.command("list")
+@app.command(name="list")
 def list_command(
+    *,
     source_root: Annotated[
         Path,
-        typer.Option("--source-root", help="Explicit profile source root containing profiles/."),
+        Parameter(help="Explicit profile source root containing profiles/."),
     ],
 ) -> None:
     """List profiles beneath the explicit source root."""
@@ -63,12 +63,13 @@ def list_command(
     _emit([summary.model_dump(mode="json") for summary in summaries])
 
 
-@app.command("describe")
+@app.command(name="describe")
 def describe_command(
-    name: Annotated[str, typer.Argument(help="Profile name to resolve.")],
+    name: Annotated[str, Parameter(help="Profile name to resolve.")],
+    *,
     source_root: Annotated[
         Path,
-        typer.Option("--source-root", help="Explicit profile source root containing profiles/."),
+        Parameter(help="Explicit profile source root containing profiles/."),
     ],
 ) -> None:
     """Show one fully resolved profile."""
@@ -76,19 +77,16 @@ def describe_command(
     _emit(profile)
 
 
-@app.command("compile")
+@app.command(name="compile")
 def compile_command(
-    name: Annotated[str, typer.Argument(help="Profile name to compile.")],
+    name: Annotated[str, Parameter(help="Profile name to compile.")],
+    *,
     source_root: Annotated[
         Path,
-        typer.Option("--source-root", help="Explicit profile source root containing profiles/."),
+        Parameter(help="Explicit profile source root containing profiles/."),
     ],
-    baseline: Annotated[
-        Path, typer.Option("--baseline", help="Baseline tree used for drift and change capture.")
-    ],
-    output: Annotated[
-        Path, typer.Option("--output", help="Directory receiving the immutable publication.")
-    ],
+    baseline: Annotated[Path, Parameter(help="Baseline tree used for drift and change capture.")],
+    output: Annotated[Path, Parameter(help="Directory receiving the immutable publication.")],
 ) -> None:
     """Compile a profile into an immutable manifest publication."""
     manifest = _handle(
@@ -105,12 +103,13 @@ def compile_command(
     _emit(manifest)
 
 
-@app.command("apply")
+@app.command(name="apply")
 def apply_command(
-    manifest: Annotated[Path, typer.Argument(help="Published manifest.json to apply.")],
+    manifest: Annotated[Path, Parameter(help="Published manifest.json to apply.")],
+    *,
     state: Annotated[
         Path | None,
-        typer.Option("--state", help="Optional profile apply state path."),
+        Parameter(help="Optional profile apply state path."),
     ] = None,
 ) -> None:
     """Apply one immutable profile manifest and reconcile prior ownership."""
@@ -168,17 +167,20 @@ def _cleanup_workspace(
     return None
 
 
-@app.command(
-    "launch",
-    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
-)
+@app.command(name="launch")
 def launch_command(
-    context: typer.Context,
-    harness: Annotated[str, typer.Argument(help="Harness to launch.")],
-    name: Annotated[str, typer.Argument(help="Profile name to resolve.")],
+    harness: Annotated[str, Parameter(help="Harness to launch.")],
+    name: Annotated[str, Parameter(help="Profile name to resolve.")],
+    *arguments: Annotated[
+        str,
+        Parameter(
+            allow_leading_hyphen=True,
+            help="Extra arguments forwarded verbatim to the launched harness.",
+        ),
+    ],
     source_root: Annotated[
         Path,
-        typer.Option("--source-root", help="Explicit profile source root containing profiles/."),
+        Parameter(help="Explicit profile source root containing profiles/."),
     ],
 ) -> None:
     """Resolve policy, then exec the harness with the complete LaunchSpec."""
@@ -189,7 +191,7 @@ def launch_command(
             profile_name=name,
             source_root=source_root,
             harness=harness,
-            arguments=tuple(context.args),
+            arguments=tuple(arguments),
         )
         spec: LaunchSpec | None = None
         workspace: Path | None = None
@@ -221,21 +223,27 @@ def launch_command(
     _handle(execute)
 
 
-@app.command("permissions")
+@app.command(name="permissions")
 def permissions_command(
+    *,
     project_root: Annotated[
         Path,
-        typer.Option(
-            "--project-root", help="Explicit project root containing the permission fragment."
-        ),
+        Parameter(help="Explicit project root containing the permission fragment."),
     ],
     local: Annotated[
         bool,
-        typer.Option("--local", help="Write Claude's gitignored personal settings and skip Codex."),
+        Parameter(
+            negative="",
+            help="Write Claude's gitignored personal settings and skip Codex.",
+        ),
     ] = False,
     harnesses: Annotated[
         list[str] | None,
-        typer.Option("--harness", help="Harness to render; repeat for claude and codex."),
+        Parameter(
+            name="--harness",
+            negative="",
+            help="Harness to render; repeat for claude and codex.",
+        ),
     ] = None,
 ) -> None:
     """Render project permissions from the fixed project-local fragment."""

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -5,21 +5,10 @@ the normal `import` machinery, so we load them by path with importlib.
 """
 
 import importlib.util
-import os
 from pathlib import Path
 from types import ModuleType
 
 import pytest
-
-# Force Typer's plain (Click) help formatter for the whole test session. Typer
-# reads ``TYPER_USE_RICH`` exactly once, at ``typer.core`` import time, so it
-# must be set before any test module imports typer — conftest runs first, before
-# collection, which is the only place that guarantees it. With Rich enabled,
-# headless CI runners render help panels with no body text (only borders), so
-# option names like ``--project-root`` never reach ``result.stdout`` and the CLI
-# help assertions in ``test_cli.py`` fail. Plain help renders deterministically
-# regardless of terminal.
-os.environ["TYPER_USE_RICH"] = "0"
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = REPO_ROOT / "skills" / "merge-resolve" / "scripts"

--- a/tests/python/cyclopts_testing.py
+++ b/tests/python/cyclopts_testing.py
@@ -1,0 +1,74 @@
+"""A ``CliRunner`` for cyclopts apps, shaped like Typer's ``CliRunner``.
+
+Cyclopts ships no test runner: an app is invoked by calling it with a token
+list, and its default ``result_action`` turns every outcome — success, parse
+error, ``--help`` — into a ``SystemExit``. This wrapper drives that call, pins a
+wide non-tty console so Rich renders option names without wrapping, isolates
+``os.environ``/``stdin`` per invocation, and captures stdout and stderr into a
+result object exposing the same ``exit_code``/``stdout``/``stderr``/``output``/
+``exception`` surface the migrated tests already assert against.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import sys
+from dataclasses import dataclass
+from unittest import mock
+
+from cyclopts import App
+
+
+@dataclass(frozen=True)
+class Result:
+    """The outcome of one CLI invocation."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+    exception: BaseException | None
+
+    @property
+    def output(self) -> str:
+        """Combined stream, matching Typer's ``result.output``."""
+        return self.stdout + self.stderr
+
+
+class CliRunner:
+    """Invoke a cyclopts ``App`` and collect its streams and exit code."""
+
+    def invoke(
+        self,
+        app: App,
+        args: list[str],
+        *,
+        input: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> Result:
+        out, err = io.StringIO(), io.StringIO()
+        # COLUMNS pins Rich's width so help panels never wrap an option name off
+        # the line the substring assertions read; a live os.environ reference is
+        # what Rich consults per render, so patch.dict reaches it.
+        overlay = {"COLUMNS": "200", **(env or {})}
+        exception: BaseException | None = None
+        exit_code = 0
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(contextlib.redirect_stdout(out))
+            stack.enter_context(contextlib.redirect_stderr(err))
+            stack.enter_context(mock.patch.dict(os.environ, overlay))
+            if input is not None:
+                stack.enter_context(mock.patch.object(sys, "stdin", io.StringIO(input)))
+            try:
+                app(args)
+            except SystemExit as exit_signal:
+                exception = exit_signal
+                code = exit_signal.code
+                exit_code = 0 if code is None else code if isinstance(code, int) else 1
+            except BaseException as error:  # noqa: BLE001 — mirror CliRunner: capture, don't raise
+                exception = error
+                exit_code = 1
+        return Result(
+            exit_code=exit_code, stdout=out.getvalue(), stderr=err.getvalue(), exception=exception
+        )

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the Typer ``cheese`` CLI surface (``cheese_flow.cli``).
+"""Tests for the cyclopts ``cheese`` CLI surface (``cheese_flow.cli``).
 
 The v1 top-level surface is ``install``, ``doctor``, and the nested ``profile``
 engine. These tests own routing, headless output discipline, and persistence
@@ -14,7 +14,6 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
-import typer
 from cheese_flow import cli
 from cheese_flow.cli import app
 from cheese_flow.desired_state import load_desired_state
@@ -33,12 +32,11 @@ from cheese_flow.models import (
     StepStatus,
 )
 from cheese_flow.runner import DEFAULT_TIMEOUT_SECONDS
-from typer.testing import CliRunner
+from cyclopts_testing import CliRunner
 
-# Help-text assertions below rely on Typer's plain (Click) help formatter, which
-# renders option names deterministically regardless of terminal width. The
-# session conftest sets ``TYPER_USE_RICH=0`` before typer is imported; with Rich
-# enabled, headless CI panels render with no body text and these assertions fail.
+# Help-text assertions below read option names out of cyclopts' Rich help. The
+# runner pins a wide, non-tty console (COLUMNS=200) so an option name never wraps
+# off the line an ``in`` assertion scans.
 runner = CliRunner()
 
 REMOVED_COMMANDS = (
@@ -207,8 +205,7 @@ def test_root_help_lists_install_doctor_and_profile() -> None:
 def test_root_help_omits_the_purged_v0_commands() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
-    command = typer.main.get_command(app)
-    exposed = command.commands  # type: ignore[attr-defined]
+    exposed = [name for name in app if not name.startswith("-")]
     for name in REMOVED_COMMANDS:
         assert name not in exposed, f"purged command still exposed: {name!r}"
 

--- a/tests/python/test_integration.py
+++ b/tests/python/test_integration.py
@@ -25,7 +25,6 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
-import typer
 from cheese_flow import cli
 from cheese_flow.adapters import default_component_adapters
 from cheese_flow.adapters.tilth import RELEASE_URL, _bin_dir, _install_script, _target_triple
@@ -34,8 +33,8 @@ from cheese_flow.desired_state import load_desired_state, save_desired_state
 from cheese_flow.install import apply_install_plan, build_install_plan
 from cheese_flow.models import CommandOutcome, DesiredState, StepStatus
 from cheese_flow.tui import run_wizard
+from cyclopts_testing import CliRunner
 from pytest_bdd import given, scenarios, then, when
-from typer.testing import CliRunner
 
 cli_runner = CliRunner()
 scenarios("features/easy_cheese.feature")
@@ -1212,7 +1211,7 @@ def test_built_package_declares_no_milknado_dependency_or_extra_entry_point() ->
         for requirement in project["dependencies"]
     )
 
-    assert names == ["PyYAML", "pydantic", "rich", "tomlkit", "typer"]
+    assert names == ["PyYAML", "cyclopts", "pydantic", "rich", "tomlkit"]
     assert project["scripts"] == {"cheese": "cheese_flow.cli:app"}
     assert "entry-points" not in project
     assert "optional-dependencies" not in project
@@ -1223,9 +1222,9 @@ def test_importable_surface_holds_no_compiler_milknado_or_unified_mcp_module() -
 
 
 def test_cli_exposes_exactly_install_doctor_and_profile() -> None:
-    command = typer.main.get_command(app)
+    exposed = [name for name in app if not name.startswith("-")]
 
-    assert sorted(command.commands) == ["doctor", "install", "profile"]  # type: ignore[attr-defined]
+    assert sorted(exposed) == ["doctor", "install", "profile"]
 
 
 # ─── Round trip: wizard → save → load → plan → apply ─────────────────────────

--- a/tests/python/test_profiles_cli.py
+++ b/tests/python/test_profiles_cli.py
@@ -9,8 +9,8 @@ from cheese_flow.profiles import cli
 from cheese_flow.profiles.errors import ProfileLaunchError
 from cheese_flow.profiles.models import LaunchSpec
 from cheese_flow.profiles.source import ProfileSummary
+from cyclopts_testing import CliRunner
 from pydantic import BaseModel
-from typer.testing import CliRunner
 
 runner = CliRunner()
 

--- a/uv.lock
+++ b/uv.lock
@@ -11,15 +11,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "annotated-doc"
-version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -29,15 +20,24 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "cheese-flow"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "cyclopts" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "tomlkit" },
-    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -49,11 +49,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cyclopts", specifier = "==4.23.0" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=15.0.0" },
     { name = "tomlkit", specifier = ">=0.15.1" },
-    { name = "typer", specifier = "==0.25.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -64,24 +64,36 @@ dev = [
 ]
 
 [[package]]
-name = "click"
-version = "8.3.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cyclopts"
+version = "4.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/62/1b160d5e8c20174392a3a5e3e7e6542e02e6f6922b35ba0962829a6b5c90/cyclopts-4.23.0.tar.gz", hash = "sha256:2f764bbd90f1888073971c09576f90e594f80353588e10aa615b7d59bc009821", size = 195257, upload-time = "2026-08-17T19:44:21.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/1f/70aeb4f9a420cb62726d943b0d893c2bf9e9ab9c81a93f7542d3beb5d69c/cyclopts-4.23.0-py3-none-any.whl", hash = "sha256:1581758c5b9982c3b2ae7df6d87243e3a6fc3265ea621f96caeb349b6fa43ad2", size = 234671, upload-time = "2026-08-17T19:44:19.604Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -478,6 +490,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-rst"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/d6/d0b9fafc73b65767200da027acab1db1bdb1048f4fea5ebf659df01c700e/rich_rst-2.1.0.tar.gz", hash = "sha256:f4d117b49697f338769759fa5cacf5197da4888b347b9fda2e50aef5cd8d93bd", size = 302732, upload-time = "2026-07-05T02:59:44.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/68/1fc93dd759605b5d00fc98b50200739e41ed32bd22d6ba35ca6c3932371b/rich_rst-2.1.0-py3-none-any.whl", hash = "sha256:7ecd1343ee12c879d0e7ae74c3eb6d263b023d2929c6d114212eb1fd91057255", size = 272987, upload-time = "2026-07-05T02:59:42.792Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.5"
 source = { registry = "https://pypi.org/simple" }
@@ -504,15 +529,6 @@ wheels = [
 ]
 
 [[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -528,21 +544,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
-]
-
-[[package]]
-name = "typer"
-version = "0.25.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Migrates the `cheese` CLI from **typer 0.25.1** to **cyclopts 4.23.0**, and adopts cyclopts' native UX. Behavior — routing, exit codes, and the headless output contract — is preserved.

## Production changes

- **`cli.py`** — `App` + `@app.command` with `Parameter`-annotated, keyword-only options. `typer.Exit(code)` → `raise SystemExit(code)`, keeping the exit-code contract (`0` success, `1` failure, `2` manifest/option errors) and the discipline that headless stdout carries exactly one JSON document while every diagnostic goes to stderr.
- **`profiles/cli.py`** — same swap. `profile launch` passthrough now uses a `*arguments` variadic with `allow_leading_hyphen=True` in place of a typer `Context`, so forwarded harness args parse both with and without a `--` separator.
- **`pyproject.toml`** — `typer` dependency replaced by `cyclopts==4.23.0`. Entry point (`cheese_flow.cli:app`) unchanged.

## Native UX gained

- Rich, grouped help panels — `install` options split into **State source** and **Behavior**.
- `--version`, and `-h` alongside `--help`, for free.
- Action booleans and the comma/space-split list options drop cyclopts' auto `--no-*` / `--empty-*` negatives, keeping the help surface clean.

```
Usage: cheese COMMAND

╭─ Commands ───────────────────────────────────────────────────────────────────╮
│ doctor       Verify declared managed state without changing it.              │
│ install      Install the selected components ...                             │
│ profile      Inspect, compile, apply, launch, and render agent profiles.     │
│ --help (-h)  Display this message and exit.                                  │
│ --version    Display application version.                                    │
╰──────────────────────────────────────────────────────────────────────────────╯
```

## Tests

- New `tests/python/cyclopts_testing.py::CliRunner` — a typer-`CliRunner`-shaped wrapper that drives a cyclopts app, pins a wide non-tty console (so Rich never wraps an option name off the line an assertion scans), isolates `os.environ`/`stdin` per call, and exposes `exit_code`/`stdout`/`stderr`/`output`/`exception`. This keeps the existing test assertions intact behind the framework swap.
- The three CLI test modules point at it. The two typer-introspection assertions now iterate the cyclopts command tree. The dead `TYPER_USE_RICH` conftest shim is removed.

## Verification

`just build` is green — ruff format + lint clean, **930 passed**.

> Note: `tests/python/test_profiles_cli.py::test_launch_cli_redacts_build_environment_diagnostics` is sensitive to the developer shell's environment — it redacts every env value as a substring, so a short value like `SHLVL=3` or `CARGO_BUILD_JOBS=6` can fragment the assertion literal. This predates the migration (click's CliRunner also overlays onto the real `os.environ`) and does not occur in CI's clean environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)